### PR TITLE
Refactor RunnerCommand and get_build_jobs

### DIFF
--- a/apps/openci_runner/lib/src/commands/runner_command.dart
+++ b/apps/openci_runner/lib/src/commands/runner_command.dart
@@ -23,13 +23,7 @@ import 'package:signals_core/signals_core.dart';
 
 final firestoreSignal = signal<Firestore?>(null);
 
-/// {@template sample_command}
-///
-/// `openci_runner sample`
-/// A [Command] to exemplify a sub command
-/// {@endtemplate}
 class RunnerCommand extends Command<int> {
-  /// {@macro sample_command}
   RunnerCommand({
     required Logger logger,
   }) : _logger = logger {
@@ -65,17 +59,6 @@ class RunnerCommand extends Command<int> {
     }
   }
 
-  Future<BuildJob?> _tryGetBuildJob(Firestore firestore) async {
-    final buildJob = await getBuildJob(firestore);
-    if (buildJob == null) {
-      _log(
-        'No build jobs found. Waiting 1 second before retrying.',
-      );
-      await Future<void>.delayed(const Duration(seconds: 1));
-    }
-    return buildJob;
-  }
-
   @override
   Future<int> run() async {
     final pemPath = argResults?['pem-path'] as String;
@@ -90,7 +73,11 @@ class RunnerCommand extends Command<int> {
     firestoreSignal.value = firestore;
 
     while (true) {
-      final buildJob = await _tryGetBuildJob(firestore);
+      final buildJob = await tryGetBuildJob(
+        firestore: firestore,
+        log: () =>
+            _log('No build jobs found. Waiting 1 second before retrying.'),
+      );
       if (buildJob == null) continue;
       _log('Found ${buildJob.toJson()} build jobs');
       final vmName = getVMName();

--- a/apps/openci_runner/lib/src/features/get_build_jobs.dart
+++ b/apps/openci_runner/lib/src/features/get_build_jobs.dart
@@ -29,3 +29,15 @@ Future<BuildJob?> getBuildJob(
   }
   return BuildJob.fromJson(qs.docs.first.data());
 }
+
+Future<BuildJob?> tryGetBuildJob({
+  required Firestore firestore,
+  required void Function() log,
+}) async {
+  final buildJob = await getBuildJob(firestore);
+  if (buildJob == null) {
+    log();
+    await Future<void>.delayed(const Duration(seconds: 1));
+  }
+  return buildJob;
+}


### PR DESCRIPTION
This commit refactors the RunnerCommand class in the openci_runner library. It removes the unused sample_command template and the _tryGetBuildJob method. Instead, it introduces a new tryGetBuildJob function in the get_build_jobs feature file. The tryGetBuildJob function takes a Firestore instance and a log function as parameters. It attempts to retrieve a BuildJob from the Firestore and logs a message if no build jobs are found. If no build jobs are found, it waits for 1 second before retrying. This refactoring improves code organization and separates concerns between the RunnerCommand and get_build_jobs files.