### PR TITLE
Refactor Firebase and imports in openci_runner

### DIFF
--- a/apps/openci_runner/lib/src/commands/runner_command.dart
+++ b/apps/openci_runner/lib/src/commands/runner_command.dart
@@ -1,12 +1,8 @@
-import 'dart:async';
 import 'dart:io';
 
 import 'package:args/command_runner.dart';
-import 'package:dart_firebase_admin_plus/firestore.dart';
 import 'package:openci_runner/src/run_app.dart';
-import 'package:signals_core/signals_core.dart';
 
-final firestoreSignal = signal<Firestore?>(null);
 const pollingInterval = Duration(seconds: 5);
 
 class RunnerCommand extends Command<int> {

--- a/apps/openci_runner/lib/src/features/update_build_status.dart
+++ b/apps/openci_runner/lib/src/features/update_build_status.dart
@@ -1,6 +1,6 @@
 import 'package:mason_logger/mason_logger.dart';
 import 'package:openci_models/openci_models.dart';
-import 'package:openci_runner/src/commands/commands.dart';
+import 'package:openci_runner/src/firebase.dart';
 
 Future<void> updateBuildStatus({
   required String jobId,

--- a/apps/openci_runner/lib/src/firebase.dart
+++ b/apps/openci_runner/lib/src/firebase.dart
@@ -1,6 +1,10 @@
 import 'dart:io';
 
 import 'package:dart_firebase_admin_plus/dart_firebase_admin.dart';
+import 'package:dart_firebase_admin_plus/firestore.dart';
+import 'package:signals_core/signals_core.dart';
+
+final firestoreSignal = signal<Firestore?>(null);
 
 Future<FirebaseAdminApp> initializeFirebaseAdminApp(
   String projectId,

--- a/apps/openci_runner/lib/src/process_build_job.dart
+++ b/apps/openci_runner/lib/src/process_build_job.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:dart_firebase_admin_plus/firestore.dart';
 import 'package:openci_models/openci_models.dart';
 import 'package:openci_runner/src/initialize_vm.dart';

--- a/apps/openci_runner/lib/src/run_app.dart
+++ b/apps/openci_runner/lib/src/run_app.dart
@@ -1,8 +1,5 @@
-import 'dart:async';
-
 import 'package:dart_firebase_admin_plus/firestore.dart';
-import 'package:openci_runner/src/commands/runner_command.dart';
-import 'package:openci_runner/src/firebase/firebase_admin.dart';
+import 'package:openci_runner/src/firebase.dart';
 import 'package:openci_runner/src/main_loop.dart';
 import 'package:openci_runner/src/sentry.dart';
 

--- a/apps/openci_runner/lib/src/run_command.dart
+++ b/apps/openci_runner/lib/src/run_command.dart
@@ -1,8 +1,8 @@
 import 'package:dart_firebase_admin_plus/firestore.dart';
 import 'package:dartssh2/dartssh2.dart';
 import 'package:openci_models/openci_models.dart';
-import 'package:openci_runner/src/commands/runner_command.dart';
 import 'package:openci_runner/src/exceptions/command_execution_exception.dart';
+import 'package:openci_runner/src/firebase.dart';
 import 'package:openci_runner/src/service/dartssh2/dartssh2_service.dart';
 import 'package:openci_runner/src/service/logger_service.dart';
 


### PR DESCRIPTION
- Remove unused imports across multiple files
- Consolidate Firebase-related imports and functions
- Delete firebase_admin.dart and move its functionality
- Simplify import statements in run_app.dart, run_command.dart, and other files