### PR TITLE
Adds GitHub webhook signature verification

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -31,6 +31,7 @@
 		"dotenv",
 		"dotenvy",
 		"hexdigit",
+		"Hmac",
 		"jsonwebtoken",
 		"libpq",
 		"mockall",

--- a/packages/openci-controller/Cargo.lock
+++ b/packages/openci-controller/Cargo.lock
@@ -1206,6 +1206,8 @@ dependencies = [
  "bcrypt",
  "chrono",
  "dotenvy",
+ "hex",
+ "hmac",
  "mockall",
  "rand 0.9.1",
  "secrecy",

--- a/packages/openci-controller/Cargo.toml
+++ b/packages/openci-controller/Cargo.toml
@@ -28,3 +28,5 @@ mockall = "0.13.1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 validator = { version = "0.18.1", features = ["derive"] }
+hmac = "0.12.1"
+hex = "0.4.3"

--- a/packages/openci-controller/src/middleware/github.rs
+++ b/packages/openci-controller/src/middleware/github.rs
@@ -1,0 +1,43 @@
+use axum::{
+    body::to_bytes, extract::Request, http::StatusCode, middleware::Next, response::Response,
+};
+use hmac::{Hmac, Mac};
+use sha2::Sha256;
+use std::env;
+
+type HmacSha256 = Hmac<Sha256>;
+
+pub async fn verify_github_webhook(request: Request, next: Next) -> Result<Response, StatusCode> {
+    let (parts, body) = request.into_parts();
+    let headers = &parts.headers;
+
+    let signature = match headers.get("X-Hub-Signature-256") {
+        Some(s) => s.to_str().unwrap_or(""),
+        None => return Err(StatusCode::UNAUTHORIZED),
+    };
+
+    let body_bytes = to_bytes(body, usize::MAX)
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    if verify_signature(signature, &body_bytes).is_err() {
+        return Err(StatusCode::UNAUTHORIZED);
+    }
+
+    let request = Request::from_parts(parts, axum::body::Body::from(body_bytes));
+    Ok(next.run(request).await)
+}
+
+fn verify_signature(signature: &str, body: &[u8]) -> Result<(), ()> {
+    let secret = env::var("GITHUB_WEBHOOK_SECRET").map_err(|_| ())?;
+    let mut mac = HmacSha256::new_from_slice(secret.as_bytes()).map_err(|_| ())?;
+    mac.update(body);
+
+    let expected_signature = format!("sha256={}", hex::encode(mac.finalize().into_bytes()));
+
+    if signature != expected_signature {
+        return Err(());
+    }
+
+    Ok(())
+}

--- a/packages/openci-controller/src/middleware/mod.rs
+++ b/packages/openci-controller/src/middleware/mod.rs
@@ -1,1 +1,2 @@
 pub mod auth;
+pub mod github;


### PR DESCRIPTION
Implements HMAC-based signature verification for incoming GitHub webhooks to ensure request authenticity and prevent unauthorized access to build job endpoints.

Adds cryptographic dependencies for HMAC computation and hex encoding, introduces dedicated middleware for webhook verification, and applies the verification layer to the build jobs route.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added GitHub webhook signature verification for build job creation. Only requests with a valid X-Hub-Signature-256 are accepted; unauthorised requests are rejected.

- Chores
  - Expanded the spell-check dictionary to recognise “Hmac”.
  - Included new cryptography and encoding libraries to support request verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->