### PR TITLE
Adds GitHub webhook signature verification

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -31,6 +31,7 @@
 		"dotenv",
 		"dotenvy",
 		"hexdigit",
+		"Hmac",
 		"jsonwebtoken",
 		"libpq",
 		"mockall",

--- a/README.md
+++ b/README.md
@@ -19,9 +19,18 @@ The best CI/CD service for people who love peace, who are making world a better 
 
 Go to [OpenCI Docs](https://docs.open-ci.io) to get started.
 
-## Contribute to OpenCI Docs
+## We are looking for contributors
 
-If you want to contribute to our docs, please fork apps/docs and make a PR.
+- Improve documentation
+- Fix bugs
+- Propose new features
+- Add test code
+- Update packages
+- Translate documentation
+- Review and proofread documentation
+- Become a GitHub Sponsor
+
+If you share OpenCI’s vision, we’d love your help.
 
 ## Discord Channel
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-# Welcome to OpenCI.
+# Welcome to OpenCI
 
-# Goals of OpenCI
+## Goals of OpenCI
 
-The best CI/CD service.
+The best CI/CD service for people who love peace, who are making world a better place. Hence, no crime that violates human rights can be committed using this service.
 
 1. Super fast loading of dashboards
 2. Extremely easy setup
 3. No charges for builds during setup
-4. Free or very low-cost usage for small-scale development
+4. Free or very low-cost usage for basic usage
 5. Ability to self-host
 6. Open-source
 7. Accessible to everyone
@@ -15,7 +15,7 @@ The best CI/CD service.
 9. Positive impact of OpenCI on Flutter and the entire software community
 10. Contribute to the success of the business and make a big contribution to humanity
 
-# Get started
+## Get started
 
 Go to [OpenCI Docs](https://docs.open-ci.io) to get started.
 
@@ -27,11 +27,11 @@ If you want to contribute to our docs, please fork apps/docs and make a PR.
 
 Join our [Discord channel](https://discord.gg/gwbnwWtefk) to get help from the community.
 
-# Pricing
+## Pricing
+
 Free
 
-# branch strategy
+## Branch strategy
 
 - `main` is the default branch.
 - `develop` is the branch for the next release. It uses develop env CI.
-

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Goals of OpenCI
 
-The best CI/CD service for people who love peace, who are making world a better place. Hence, no crime that violates human rights can be committed using this service.
+The best CI/CD service for people who love peace, who are making world a better place. Hence, OpenCI cannot be used for services that violate human rights.
 
 1. Super fast loading of dashboards
 2. Extremely easy setup

--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 ## Goals of OpenCI
 
-The best CI/CD service for people who love peace, who are making world a better place. Hence, OpenCI cannot be used for services that violate human rights.
+The best CI/CD service for people who love peace, who are making the world a better place. Hence, OpenCI cannot be used for services that violate human rights.
 
 1. Super fast loading of dashboards
 2. Extremely easy setup
 3. No charges for builds during setup
-4. Free or very low-cost usage for basic usage
+4. Free or very low-cost for basic usage
 5. Ability to self-host
 6. Open-source
 7. Accessible to everyone
@@ -40,7 +40,7 @@ Join our [Discord channel](https://discord.gg/gwbnwWtefk) to get help from the c
 
 Free
 
-## Branch strategy
+## Branch Strategy
 
 - `main` is the default branch.
 - `develop` is the branch for the next release. It uses develop env CI.

--- a/packages/openci-controller/Cargo.lock
+++ b/packages/openci-controller/Cargo.lock
@@ -1216,6 +1216,7 @@ dependencies = [
  "sha2",
  "sqlx",
  "tokio",
+ "tower-http",
  "tracing",
  "tracing-subscriber",
  "utoipa",
@@ -2147,6 +2148,22 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "http",
+ "http-body",
+ "http-body-util",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]

--- a/packages/openci-controller/Cargo.lock
+++ b/packages/openci-controller/Cargo.lock
@@ -1206,6 +1206,8 @@ dependencies = [
  "bcrypt",
  "chrono",
  "dotenvy",
+ "hex",
+ "hmac",
  "mockall",
  "rand 0.9.1",
  "secrecy",

--- a/packages/openci-controller/Cargo.toml
+++ b/packages/openci-controller/Cargo.toml
@@ -30,3 +30,4 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 validator = { version = "0.18.1", features = ["derive"] }
 hmac = "0.12.1"
 hex = "0.4.3"
+tower-http = { version = "0.6.6", features = ["limit"] }

--- a/packages/openci-controller/Cargo.toml
+++ b/packages/openci-controller/Cargo.toml
@@ -28,3 +28,5 @@ mockall = "0.13.1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 validator = { version = "0.18.1", features = ["derive"] }
+hmac = "0.12.1"
+hex = "0.4.3"

--- a/packages/openci-controller/src/api/routes.rs
+++ b/packages/openci-controller/src/api/routes.rs
@@ -35,8 +35,8 @@ pub fn create_routes(pool: PgPool) -> Router {
         .route(
             "/build-jobs",
             post(handlers::build_job_handler::post_build_job)
-                .route_layer(middleware::from_fn(verify_github_webhook))
-                .route_layer(RequestBodyLimitLayer::new(1_048_576)),
+                .route_layer(RequestBodyLimitLayer::new(1_048_576))
+                .route_layer(middleware::from_fn(verify_github_webhook)),
         )
         .merge(authenticated_routes)
         .merge(SwaggerUi::new("/docs").url("/api-docs/openapi.json", ApiDoc::openapi()))

--- a/packages/openci-controller/src/api/routes.rs
+++ b/packages/openci-controller/src/api/routes.rs
@@ -7,6 +7,8 @@ use sqlx::PgPool;
 use utoipa::OpenApi;
 use utoipa_swagger_ui::SwaggerUi;
 
+use tower_http::limit::RequestBodyLimitLayer;
+
 use super::doc::ApiDoc;
 use crate::{
     handlers,
@@ -33,7 +35,8 @@ pub fn create_routes(pool: PgPool) -> Router {
         .route(
             "/build-jobs",
             post(handlers::build_job_handler::post_build_job)
-                .route_layer(middleware::from_fn(verify_github_webhook)),
+                .route_layer(middleware::from_fn(verify_github_webhook))
+                .route_layer(RequestBodyLimitLayer::new(1_048_576)),
         )
         .merge(authenticated_routes)
         .merge(SwaggerUi::new("/docs").url("/api-docs/openapi.json", ApiDoc::openapi()))

--- a/packages/openci-controller/src/middleware/github.rs
+++ b/packages/openci-controller/src/middleware/github.rs
@@ -26,6 +26,7 @@ pub async fn verify_github_webhook(request: Request, next: Next) -> Result<Respo
         .map_err(|_| StatusCode::PAYLOAD_TOO_LARGE)?;
 
     if verify_signature(signature, &body_bytes).is_err() {
+        tracing::warn!("GitHub webhook HMAC verification failed");
         return Err(StatusCode::UNAUTHORIZED);
     }
 

--- a/packages/openci-controller/src/middleware/github.rs
+++ b/packages/openci-controller/src/middleware/github.rs
@@ -11,8 +11,11 @@ pub async fn verify_github_webhook(request: Request, next: Next) -> Result<Respo
     let (parts, body) = request.into_parts();
     let headers = &parts.headers;
 
-    let signature = match headers.get("X-Hub-Signature-256") {
-        Some(s) => s.to_str().unwrap_or(""),
+    let signature = match headers
+        .get("X-Hub-Signature-256")
+        .and_then(|s| s.to_str().ok())
+    {
+        Some(s) => s,
         None => return Err(StatusCode::UNAUTHORIZED),
     };
 

--- a/packages/openci-controller/src/middleware/github.rs
+++ b/packages/openci-controller/src/middleware/github.rs
@@ -1,0 +1,43 @@
+use axum::{
+    body::to_bytes, extract::Request, http::StatusCode, middleware::Next, response::Response,
+};
+use hmac::{Hmac, Mac};
+use sha2::Sha256;
+use std::env;
+
+type HmacSha256 = Hmac<Sha256>;
+
+pub async fn verify_github_webhook(request: Request, next: Next) -> Result<Response, StatusCode> {
+    let (parts, body) = request.into_parts();
+    let headers = &parts.headers;
+
+    let signature = match headers.get("X-Hub-Signature-256") {
+        Some(s) => s.to_str().unwrap_or(""),
+        None => return Err(StatusCode::UNAUTHORIZED),
+    };
+
+    let body_bytes = to_bytes(body, usize::MAX)
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    if verify_signature(signature, &body_bytes).is_err() {
+        return Err(StatusCode::UNAUTHORIZED);
+    }
+
+    let request = Request::from_parts(parts, axum::body::Body::from(body_bytes));
+    Ok(next.run(request).await)
+}
+
+fn verify_signature(signature: &str, body: &[u8]) -> Result<(), ()> {
+    let secret = env::var("GITHUB_WEBHOOK_SECRET").map_err(|_| ())?;
+    let mut mac = HmacSha256::new_from_slice(secret.as_bytes()).map_err(|_| ())?;
+    mac.update(body);
+
+    let expected_signature = format!("sha256={}", hex::encode(mac.finalize().into_bytes()));
+
+    if signature != expected_signature {
+        return Err(());
+    }
+
+    Ok(())
+}

--- a/packages/openci-controller/src/middleware/mod.rs
+++ b/packages/openci-controller/src/middleware/mod.rs
@@ -1,1 +1,2 @@
 pub mod auth;
+pub mod github;


### PR DESCRIPTION
Implements HMAC-based signature verification for incoming GitHub webhooks to ensure request authenticity and prevent unauthorized access to build job endpoints.

Adds cryptographic dependencies for HMAC computation and hex encoding, introduces dedicated middleware for webhook verification, and applies the verification layer to the build jobs route.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新機能
  - GitHub Webhook の署名検証を導入し、不正な送信を拒否します。
  - 受信リクエストのサイズ上限（1 MiB）を導入し、大きすぎるペイロードを拒否します。

- ドキュメント
  - README を再構成し、見出し整理、利用開始案内、寄稿案内、Discord 情報を整理しました。

- 雑務
  - エディタのスペルチェック辞書に「Hmac」を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->