### PR TITLE
Change workflow retrieval order to sort by updated_at instead of created_at

### DIFF
--- a/packages/openci-controller/src/handlers/workflow_handler.rs
+++ b/packages/openci-controller/src/handlers/workflow_handler.rs
@@ -25,7 +25,7 @@ pub async fn get_workflows(
         r#"
         SELECT id, name, created_at, updated_at, github_trigger_type
         FROM workflows
-        ORDER BY created_at DESC, id DESC
+        ORDER BY updated_at DESC, id DESC
         "#,
     )
     .fetch_all(&pool)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * ワークフロー一覧の並び順を「作成日時」優先から「最終更新日時」優先（降順）に変更。
  * これにより、最近更新されたワークフローがリストの先頭に表示され、進行中の変更を見つけやすくなります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->