### PR TITLE
Add workflow steps to GET /workflows endpoint

### DIFF
--- a/packages/openci-controller/.gitignore
+++ b/packages/openci-controller/.gitignore
@@ -34,3 +34,6 @@ Thumbs.db
 *.zip
 
 .env
+
+# Claude Code configuration
+.claude/

--- a/packages/openci-controller/.sqlx/query-0d935b4693c67bc76dc256cc590d85b17d61b4068a47a60f37d3dd8c2ebe7ad2.json
+++ b/packages/openci-controller/.sqlx/query-0d935b4693c67bc76dc256cc590d85b17d61b4068a47a60f37d3dd8c2ebe7ad2.json
@@ -1,0 +1,58 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT id, workflow_id, step_order, name, command, created_at, updated_at\n            FROM workflow_steps\n            WHERE workflow_id = ANY($1)\n            ORDER BY step_order\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 1,
+        "name": "workflow_id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "step_order",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 3,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "command",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 6,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4Array"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "0d935b4693c67bc76dc256cc590d85b17d61b4068a47a60f37d3dd8c2ebe7ad2"
+}

--- a/packages/openci-controller/.sqlx/query-3256ee2ac48599f1f60ec707f1388f31021714b0f8cf2426d08355f92be903ee.json
+++ b/packages/openci-controller/.sqlx/query-3256ee2ac48599f1f60ec707f1388f31021714b0f8cf2426d08355f92be903ee.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n    SELECT id, name, created_at, updated_at, github_trigger_type\n    FROM workflows\n    WHERE id = $1\n    ORDER BY created_at DESC, id DESC\n    ",
+  "query": "\n        SELECT id, name, created_at, updated_at, github_trigger_type\n        FROM workflows\n        ORDER BY updated_at DESC, id DESC\n        ",
   "describe": {
     "columns": [
       {
@@ -30,9 +30,7 @@
       }
     ],
     "parameters": {
-      "Left": [
-        "Int4"
-      ]
+      "Left": []
     },
     "nullable": [
       false,
@@ -42,5 +40,5 @@
       false
     ]
   },
-  "hash": "6265bae42ca4268775eea31746bb49ff61ecbf398e58fc99316e87380d427026"
+  "hash": "3256ee2ac48599f1f60ec707f1388f31021714b0f8cf2426d08355f92be903ee"
 }

--- a/packages/openci-controller/.sqlx/query-e58a0e6cd898f3d99f390e88f010f4eb10c93b7bb4dbb2b2b65a1e10a7d58e37.json
+++ b/packages/openci-controller/.sqlx/query-e58a0e6cd898f3d99f390e88f010f4eb10c93b7bb4dbb2b2b65a1e10a7d58e37.json
@@ -1,0 +1,58 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT id, workflow_id, step_order, name, command, created_at, updated_at\n        FROM workflow_steps\n        WHERE workflow_id = $1\n        ORDER BY step_order\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 1,
+        "name": "workflow_id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "step_order",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 3,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "command",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 6,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "e58a0e6cd898f3d99f390e88f010f4eb10c93b7bb4dbb2b2b65a1e10a7d58e37"
+}

--- a/packages/openci-controller/.sqlx/query-ff93fee765eb5ae169502d7bbdd1f7500575f0ca436270bbb39de77b96c01bfe.json
+++ b/packages/openci-controller/.sqlx/query-ff93fee765eb5ae169502d7bbdd1f7500575f0ca436270bbb39de77b96c01bfe.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n        SELECT id, name, created_at, updated_at, github_trigger_type\n        FROM workflows\n        ORDER BY created_at DESC, id DESC\n        ",
+  "query": "\n    SELECT id, name, created_at, updated_at, github_trigger_type\n    FROM workflows\n    WHERE id = $1\n    ",
   "describe": {
     "columns": [
       {
@@ -30,7 +30,9 @@
       }
     ],
     "parameters": {
-      "Left": []
+      "Left": [
+        "Int4"
+      ]
     },
     "nullable": [
       false,
@@ -40,5 +42,5 @@
       false
     ]
   },
-  "hash": "bdde4a9887fadf4ffbb7eb47ea077860b42b2c1782118c0bb14bdeaead035904"
+  "hash": "ff93fee765eb5ae169502d7bbdd1f7500575f0ca436270bbb39de77b96c01bfe"
 }

--- a/packages/openci-controller/src/handlers/workflow_handler.rs
+++ b/packages/openci-controller/src/handlers/workflow_handler.rs
@@ -27,7 +27,7 @@ pub async fn get_workflows(
         r#"
         SELECT id, name, created_at, updated_at, github_trigger_type
         FROM workflows
-        ORDER BY updated_at DESC, id DESC
+        ORDER BY updated_at DESC
         "#,
     )
     .fetch_all(&pool)

--- a/packages/openci-controller/src/handlers/workflow_handler.rs
+++ b/packages/openci-controller/src/handlers/workflow_handler.rs
@@ -86,16 +86,6 @@ pub async fn get_workflows(
     Ok(Json(workflows_with_steps))
 }
 
-// pub struct WorkflowStep {
-//     pub id: i32,
-//     pub workflow_id: i32,
-//     pub step_order: i32,
-//     pub name: String,
-//     pub command: String,
-//     pub created_at: DateTime<Utc>,
-//     pub updated_at: DateTime<Utc>,
-// }
-
 #[utoipa::path(
     get,
     path = "/workflows/{workflow_id}",

--- a/packages/openci-controller/src/handlers/workflow_handler.rs
+++ b/packages/openci-controller/src/handlers/workflow_handler.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use crate::models::workflow::{
     CreateWorkflowRequest, GitHubTriggerType, UpdateWorkflowRequest, Workflow, WorkflowStep,
     WorkflowWithSteps,
@@ -12,14 +14,14 @@ use tracing::error;
     get,
     path = "/workflows",
     responses(
-        (status = 200, description = "Workflows retrieved successfully", body = Vec<Workflow>),
+        (status = 200, description = "Workflows retrieved successfully", body = Vec<WorkflowWithSteps>),
         (status = 500, description = "Internal server error")
     )
 )]
 #[tracing::instrument(skip(pool))]
 pub async fn get_workflows(
     State(pool): State<PgPool>,
-) -> Result<Json<Vec<Workflow>>, (StatusCode, String)> {
+) -> Result<Json<Vec<WorkflowWithSteps>>, (StatusCode, String)> {
     let workflows = sqlx::query_as!(
         Workflow,
         r#"
@@ -38,8 +40,61 @@ pub async fn get_workflows(
         )
     })?;
 
-    Ok(Json(workflows))
+    let workflow_ids: Vec<i32> = workflows.iter().map(|w| w.id).collect();
+
+    let steps = if !workflow_ids.is_empty() {
+        sqlx::query_as!(
+            WorkflowStep,
+            r#"
+            SELECT id, workflow_id, step_order, name, command, created_at, updated_at
+            FROM workflow_steps
+            WHERE workflow_id = ANY($1)
+            ORDER BY step_order
+            "#,
+            &workflow_ids[..]
+        )
+        .fetch_all(&pool)
+        .await
+        .map_err(|e| {
+            error!("Failed to fetch workflow steps: {}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed to fetch workflow details".to_string(),
+            )
+        })?
+    } else {
+        vec![]
+    };
+
+    let mut steps_map: HashMap<i32, Vec<WorkflowStep>> = HashMap::new();
+
+    for step in steps {
+        steps_map.entry(step.workflow_id).or_default().push(step);
+    }
+
+    let workflows_with_steps: Vec<WorkflowWithSteps> = workflows
+        .into_iter()
+        .map(|workflow| {
+            let workflow_id = workflow.id;
+            WorkflowWithSteps {
+                workflow,
+                steps: steps_map.remove(&workflow_id).unwrap_or_default(),
+            }
+        })
+        .collect();
+
+    Ok(Json(workflows_with_steps))
 }
+
+// pub struct WorkflowStep {
+//     pub id: i32,
+//     pub workflow_id: i32,
+//     pub step_order: i32,
+//     pub name: String,
+//     pub command: String,
+//     pub created_at: DateTime<Utc>,
+//     pub updated_at: DateTime<Utc>,
+// }
 
 #[utoipa::path(
     get,
@@ -382,23 +437,26 @@ mod tests {
         let get_result = get_workflows(State(pool)).await;
         assert!(get_result.is_ok());
 
-        let workflows = get_result.unwrap().0;
+        let workflows_with_steps_vec = get_result.unwrap().0;
 
-        assert_eq!(workflows.len(), 3);
+        assert_eq!(workflows_with_steps_vec.len(), 3);
 
-        assert_eq!(workflows[0].id, created_workflow3.workflow.id);
-        assert_eq!(workflows[0].name, "workflow-3");
-        assert_eq!(workflows[1].id, created_workflow2.workflow.id);
-        assert_eq!(workflows[1].name, "workflow-2");
-        assert_eq!(workflows[2].id, created_workflow1.workflow.id);
-        assert_eq!(workflows[2].name, "workflow-1");
+        let first_workflow = &workflows_with_steps_vec[0].workflow;
+        let second_workflow = &workflows_with_steps_vec[1].workflow;
+        let third_workflow = &workflows_with_steps_vec[2].workflow;
 
-        assert_eq!(workflows[0].github_trigger_type, GitHubTriggerType::Push);
+        assert_eq!(first_workflow.id, created_workflow3.workflow.id);
+        assert_eq!(first_workflow.name, "workflow-3");
+        assert_eq!(first_workflow.github_trigger_type, GitHubTriggerType::Push);
+        assert_eq!(second_workflow.id, created_workflow2.workflow.id);
+        assert_eq!(second_workflow.name, "workflow-2");
         assert_eq!(
-            workflows[1].github_trigger_type,
+            second_workflow.github_trigger_type,
             GitHubTriggerType::PullRequest
         );
-        assert_eq!(workflows[2].github_trigger_type, GitHubTriggerType::Push);
+        assert_eq!(third_workflow.id, created_workflow1.workflow.id);
+        assert_eq!(third_workflow.name, "workflow-1");
+        assert_eq!(third_workflow.github_trigger_type, GitHubTriggerType::Push);
     }
 
     #[sqlx::test]


### PR DESCRIPTION
Include workflow steps when retrieving all workflows, returning WorkflowWithSteps instead of plain Workflow objects to match the single workflow endpoint behavior.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新機能
  - ワークフロー一覧APIが各ワークフローに対応するステップ情報を含むようになり、一覧画面でステップを即時確認可能に。
- 改善
  - 一覧の並び順を「更新日時の新しい順」に変更。
  - 複数ワークフローのステップをまとめて取得することで表示がよりスムーズに。
  - ステップ取得失敗時のエラーメッセージを明確化。
- 雑務
  - リポジトリの無視設定にエントリを追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->