### PR TITLE
feat(migrations): add default value for build job status column

### DIFF
--- a/packages/openci-controller/migrations/20250904132000_create_build_jobs_table.up.sql
+++ b/packages/openci-controller/migrations/20250904132000_create_build_jobs_table.up.sql
@@ -3,9 +3,10 @@ CREATE TABLE build_jobs
     id                 SERIAL PRIMARY KEY,
     workflow_id        INTEGER     NOT NULL REFERENCES workflows (id) ON DELETE CASCADE,
     repository_id      INTEGER     NOT NULL REFERENCES github_repositories (id) ON DELETE CASCADE,
-    status             VARCHAR(32) NOT NULL CHECK (status IN (
-                                                              'queued', 'running', 'success', 'failed', 'cancelled',
-                                                              'timed_out', 'skipped'
+    status             VARCHAR(32) NOT NULL DEFAULT 'queued' CHECK (status IN (
+                                                                               'queued', 'running', 'success', 'failed',
+                                                                               'cancelled',
+                                                                               'timed_out', 'skipped'
         )),
     commit_sha         VARCHAR(64) NOT NULL,
     github_delivery_id VARCHAR(64) NOT NULL,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - 新規ビルドジョブの初期ステータスが自動で「queued」になります。明示的に指定しなくてもキューから処理が開始されます。
- バグ修正
  - ステータス未指定時の挙動の不一致を低減し、ジョブ作成フローの信頼性と一貫性を向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->