### PR TITLE
feat(github_repositories): add GitHub repository handler and migrations

### DIFF
--- a/packages/openci-controller/.sqlx/query-6ee4ce9ae95556818ba6a02b21f19b317ba8b87160700c7d0cee9d137af7f047.json
+++ b/packages/openci-controller/.sqlx/query-6ee4ce9ae95556818ba6a02b21f19b317ba8b87160700c7d0cee9d137af7f047.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\nINSERT INTO github_repositories (external_id) VALUES ($1)\n",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int8"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "6ee4ce9ae95556818ba6a02b21f19b317ba8b87160700c7d0cee9d137af7f047"
+}

--- a/packages/openci-controller/migrations/20250820160000_create_github_repositories_table.down.sql
+++ b/packages/openci-controller/migrations/20250820160000_create_github_repositories_table.down.sql
@@ -1,2 +1,1 @@
 DROP TABLE IF EXISTS github_repositories;
-

--- a/packages/openci-controller/migrations/20250820160000_create_github_repositories_table.up.sql
+++ b/packages/openci-controller/migrations/20250820160000_create_github_repositories_table.up.sql
@@ -4,4 +4,3 @@ CREATE TABLE
     id          SERIAL PRIMARY KEY,
     external_id BIGINT NOT NULL UNIQUE
 );
-

--- a/packages/openci-controller/src/handlers/github_repository_handler.rs
+++ b/packages/openci-controller/src/handlers/github_repository_handler.rs
@@ -4,6 +4,9 @@ use sqlx::PgPool;
 use tracing::error;
 
 pub async fn post_github_repository(external_id: i64, pool: &PgPool) -> Result<StatusCode, (StatusCode, String)> {
+    if external_id < 0 {
+        return Err((StatusCode::BAD_REQUEST, "external_id must be positive".to_string()));
+    }
     sqlx::query!(r#"
 INSERT INTO github_repositories (external_id) VALUES ($1)
 "#, external_id).execute(pool).await.map_err(|e| {
@@ -14,10 +17,14 @@ INSERT INTO github_repositories (external_id) VALUES ($1)
         )
     })?;
 
-    Ok(StatusCode::OK)
+
+    Ok(StatusCode::CREATED)
 }
 
 pub async fn get_github_repository_by_external_id(external_id: i64, pool: &PgPool) -> Result<GitHubRepository, (StatusCode, String)> {
+    if external_id < 0 {
+        return Err((StatusCode::BAD_REQUEST, "external_id must be positive".to_string()));
+    }
     let result = sqlx::query_as!(
         GitHubRepository,
         r#"

--- a/packages/openci-controller/src/handlers/github_repository_handler.rs
+++ b/packages/openci-controller/src/handlers/github_repository_handler.rs
@@ -1,0 +1,56 @@
+use crate::models::github_repository::GitHubRepository;
+use axum::http::StatusCode;
+use sqlx::PgPool;
+use tracing::error;
+
+pub async fn post_github_repository(external_id: i64, pool: &PgPool) -> Result<StatusCode, (StatusCode, String)> {
+    sqlx::query!(r#"
+INSERT INTO github_repositories (external_id) VALUES ($1)
+"#, external_id).execute(pool).await.map_err(|e| {
+        error!("Failed to insert github repository: {}", e);
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Failed to insert github repository".to_string(),
+        )
+    })?;
+
+    Ok(StatusCode::OK)
+}
+
+pub async fn get_github_repository_by_external_id(external_id: i64, pool: &PgPool) -> Result<GitHubRepository, (StatusCode, String)> {
+    let result = sqlx::query_as!(
+        GitHubRepository,
+        r#"
+SELECT id, external_id FROM github_repositories WHERE external_id = $1
+"#,
+        external_id
+    ).fetch_one(pool).await.map_err(|e| {
+        error!("Failed to fetch github repository: {}", e);
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Failed to fetch github repository".to_string(),
+        )
+    })?;
+
+    Ok(result)
+}
+
+#[cfg(test)]
+mod github_repository_handler_tests {
+    use super::*;
+    use sqlx::PgPool;
+
+    #[sqlx::test]
+    async fn test_post_github_repository(pool: PgPool) {
+        let external_id = 1;
+        let result = post_github_repository(external_id, &pool).await;
+        assert!(result.is_ok());
+        let status_code = result.unwrap();
+        assert_eq!(status_code, StatusCode::OK);
+
+        let result = get_github_repository_by_external_id(external_id, &pool).await;
+        assert!(result.is_ok());
+        let repository = result.unwrap();
+        assert_eq!(repository.external_id, external_id);
+    }
+}

--- a/packages/openci-controller/src/handlers/mod.rs
+++ b/packages/openci-controller/src/handlers/mod.rs
@@ -2,3 +2,4 @@ pub mod api_key_handler;
 pub mod github_webhook_handler;
 pub mod user_handler;
 pub mod workflow_handler;
+pub mod github_repository_handler;

--- a/packages/openci-controller/src/models/api_key.rs
+++ b/packages/openci-controller/src/models/api_key.rs
@@ -3,7 +3,6 @@ use serde::{Deserialize, Serialize};
 use sqlx::FromRow;
 use utoipa::ToSchema;
 use validator::Validate;
-
 #[derive(Serialize, FromRow, ToSchema)]
 pub struct ApiKey {
     pub id: i32,

--- a/packages/openci-controller/src/models/api_key.rs
+++ b/packages/openci-controller/src/models/api_key.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 use sqlx::FromRow;
 use utoipa::ToSchema;
 use validator::Validate;
+
 #[derive(Serialize, FromRow, ToSchema)]
 pub struct ApiKey {
     pub id: i32,

--- a/packages/openci-controller/src/models/api_key.rs
+++ b/packages/openci-controller/src/models/api_key.rs
@@ -24,6 +24,9 @@ pub struct CreateApiKeyRequest {
 pub struct CreateApiKeyResponse {
     pub id: i32,
     pub name: String,
+    /// WARNING: Contains the actual API key in plain text.
+    /// This is only returned once during creation and should never be logged.
+    /// The client must store this securely as it cannot be retrieved again.
     pub api_key: String,
     pub prefix: String,
     pub created_at: DateTime<Utc>,

--- a/packages/openci-controller/src/models/api_key.rs
+++ b/packages/openci-controller/src/models/api_key.rs
@@ -24,9 +24,6 @@ pub struct CreateApiKeyRequest {
 pub struct CreateApiKeyResponse {
     pub id: i32,
     pub name: String,
-    /// WARNING: Contains the actual API key in plain text.
-    /// This is only returned once during creation and should never be logged.
-    /// The client must store this securely as it cannot be retrieved again.
     pub api_key: String,
     pub prefix: String,
     pub created_at: DateTime<Utc>,


### PR DESCRIPTION
Introduce `github_repository_handler` with CRUD operations and associated tests. Add migrations to create the `github_repositories` table to manage GitHub repository data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - サーバーで GitHub リポジトリの登録・取得をサポートし、適切なステータスを返却
- テスト
  - 登録から取得までのフローを検証するユニットテストを追加
- スタイル
  - マイグレーションファイルの余分な空行を削除し体裁を整備
- チョア
  - データ挿入用のクエリ定義を追加し一貫性を向上

<!-- end of auto-generated comment: release notes by coderabbit.ai -->