### PR TITLE
fix: update Firebase service account secret in GitHub Actions workflow

### DIFF
--- a/.github/workflows/github-apps-cd.yml
+++ b/.github/workflows/github-apps-cd.yml
@@ -54,7 +54,7 @@ jobs:
 
       - uses: google-github-actions/auth@v2
         with:
-          credentials_json: ${{ secrets.FIREBASE_SA_KEY }}
+          credentials_json: ${{ secrets.GHA_SERVICE_ACCOUNT }}
 
       - name: Install dependencies
         working-directory: openci-runner/firebase/functions


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * CI/CD のデプロイ認証に使用するシークレットを更新（開発・本番ともに新しいサービスアカウントへ切り替え）。
  * デプロイパイプラインの安定性とセキュリティを向上。ユーザー向けの機能や挙動の変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->