### PR TITLE
workflow_jobをキャンセルした場合、incusインスタンスが削除されない。

### DIFF
--- a/openci-runner/src/routes/webhook.ts
+++ b/openci-runner/src/routes/webhook.ts
@@ -1,5 +1,6 @@
 import { Hono } from "hono";
 import {
+	handleWorkflowJobCancelled,
 	handleWorkflowJobCompleted,
 	handleWorkflowJobQueued,
 } from "../handlers/workflow-job";
@@ -27,6 +28,10 @@ webhook.post("/", async (c) => {
 
 	if (payload.action === "completed") {
 		return handleWorkflowJobCompleted(c, payload);
+	}
+
+	if (payload.action === "cancelled") {
+		return handleWorkflowJobCancelled(c, payload);
 	}
 
 	return c.text("Workflow Job action not supported", 200);

--- a/openci-runner/src/services/slack.ts
+++ b/openci-runner/src/services/slack.ts
@@ -50,6 +50,17 @@ export async function notifyJobCompleted(
 	});
 }
 
+export async function notifyJobCancelled(
+	webhookUrl: string,
+	payload: WorkflowJobPayload,
+): Promise<void> {
+	const jobName = payload.workflow_job?.name ?? "Unknown";
+
+	await sendSlackMessage(webhookUrl, {
+		text: `🚫 ジョブキャンセル: ${jobName}`,
+	});
+}
+
 function isConclusion(value: string): value is Conclusion {
 	return value in ConclusionStatusMap;
 }

--- a/openci-runner/test/services/slack.spec.ts
+++ b/openci-runner/test/services/slack.spec.ts
@@ -1,5 +1,9 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { notifyJobCompleted, notifyJobStarted } from "../../src/services/slack";
+import {
+	notifyJobCancelled,
+	notifyJobCompleted,
+	notifyJobStarted,
+} from "../../src/services/slack";
 import type { WorkflowJobPayload } from "../../src/types/github.types";
 
 const mockFetch = vi.fn();
@@ -172,6 +176,44 @@ describe("notifyJobCompleted", () => {
 		const payload = createPayload({ conclusion: "success", name: "test" });
 
 		await expect(notifyJobCompleted(mockWebhookUrl, payload)).rejects.toThrow(
+			"Failed to send Slack message: 500",
+		);
+	});
+});
+
+describe("notifyJobCancelled", () => {
+	it("sends job cancelled notification", async () => {
+		mockFetch.mockResolvedValueOnce({ ok: true });
+
+		const payload = createPayload({ name: "build" });
+		await notifyJobCancelled(mockWebhookUrl, payload);
+
+		expect(mockFetch).toHaveBeenCalledWith(mockWebhookUrl, {
+			body: JSON.stringify({ text: "🚫 ジョブキャンセル: build" }),
+			headers: { "Content-Type": "application/json" },
+			method: "POST",
+		});
+	});
+
+	it("uses Unknown when job name is missing", async () => {
+		mockFetch.mockResolvedValueOnce({ ok: true });
+
+		const payload = createPayload({ name: undefined });
+		await notifyJobCancelled(mockWebhookUrl, payload);
+
+		expect(mockFetch).toHaveBeenCalledWith(mockWebhookUrl, {
+			body: JSON.stringify({ text: "🚫 ジョブキャンセル: Unknown" }),
+			headers: { "Content-Type": "application/json" },
+			method: "POST",
+		});
+	});
+
+	it("throws error when fetch fails", async () => {
+		mockFetch.mockResolvedValueOnce({ ok: false, status: 500 });
+
+		const payload = createPayload({ name: "test" });
+
+		await expect(notifyJobCancelled(mockWebhookUrl, payload)).rejects.toThrow(
 			"Failed to send Slack message: 500",
 		);
 	});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ジョブがキャンセルされたときの処理に対応しました。
  * キャンセル時にSlackで通知が送信されるようになりました。

* **テスト**
  * キャンセル処理とSlack通知のテストカバレッジを追加しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->