### PR TITLE
Slack通知の内容をもう少しリッチに

### DIFF
--- a/openci-runner/src/services/slack.ts
+++ b/openci-runner/src/services/slack.ts
@@ -29,7 +29,7 @@ export async function notifyJobStarted(
 	payload: WorkflowJobPayload,
 ): Promise<void> {
 	await sendSlackMessage(webhookUrl, {
-		text: `🚀 ジョブ開始: ${payload}`,
+		text: `🚀 ジョブ開始: ${JSON.stringify(payload)}`,
 	});
 }
 

--- a/openci-runner/src/services/slack.ts
+++ b/openci-runner/src/services/slack.ts
@@ -28,10 +28,8 @@ export async function notifyJobStarted(
 	webhookUrl: string,
 	payload: WorkflowJobPayload,
 ): Promise<void> {
-	const jobName = payload.workflow_job?.name ?? "Unknown";
-
 	await sendSlackMessage(webhookUrl, {
-		text: `🚀 ジョブ開始: ${jobName}`,
+		text: `🚀 ジョブ開始: ${payload}`,
 	});
 }
 

--- a/openci-runner/test/services/slack.spec.ts
+++ b/openci-runner/test/services/slack.spec.ts
@@ -37,7 +37,7 @@ describe("notifyJobStarted", () => {
 		await notifyJobStarted(mockWebhookUrl, payload);
 
 		expect(mockFetch).toHaveBeenCalledWith(mockWebhookUrl, {
-			body: JSON.stringify({ text: "🚀 ジョブ開始: build" }),
+			body: JSON.stringify({ text: `🚀 ジョブ開始: ${payload}` }),
 			headers: { "Content-Type": "application/json" },
 			method: "POST",
 		});
@@ -50,7 +50,7 @@ describe("notifyJobStarted", () => {
 		await notifyJobStarted(mockWebhookUrl, payload);
 
 		expect(mockFetch).toHaveBeenCalledWith(mockWebhookUrl, {
-			body: JSON.stringify({ text: "🚀 ジョブ開始: Unknown" }),
+			body: JSON.stringify({ text: `🚀 ジョブ開始: ${payload}` }),
 			headers: { "Content-Type": "application/json" },
 			method: "POST",
 		});

--- a/openci-runner/test/services/slack.spec.ts
+++ b/openci-runner/test/services/slack.spec.ts
@@ -37,7 +37,9 @@ describe("notifyJobStarted", () => {
 		await notifyJobStarted(mockWebhookUrl, payload);
 
 		expect(mockFetch).toHaveBeenCalledWith(mockWebhookUrl, {
-			body: JSON.stringify({ text: `🚀 ジョブ開始: ${payload}` }),
+			body: JSON.stringify({
+				text: `🚀 ジョブ開始: ${JSON.stringify(payload)}`,
+			}),
 			headers: { "Content-Type": "application/json" },
 			method: "POST",
 		});
@@ -50,7 +52,9 @@ describe("notifyJobStarted", () => {
 		await notifyJobStarted(mockWebhookUrl, payload);
 
 		expect(mockFetch).toHaveBeenCalledWith(mockWebhookUrl, {
-			body: JSON.stringify({ text: `🚀 ジョブ開始: ${payload}` }),
+			body: JSON.stringify({
+				text: `🚀 ジョブ開始: ${JSON.stringify(payload)}`,
+			}),
 			headers: { "Content-Type": "application/json" },
 			method: "POST",
 		});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **変更**
  * Slackへのジョブ開始通知の文面を更新しました。従来のジョブ名ではなく、開始通知に関連するペイロード全体をJSON形式で埋め込んだ表示に変更されます。通知を受け取る際は、これまでより詳細な実行情報がメッセージ内に含まれるようになります。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->