### PR TITLE
Biome config cleanup

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -10,9 +10,6 @@
 	"files": {
 		"includes": [
 			"**",
-			"!**/node_modules",
-			"!openci-runner/worker-configuration.d.ts",
-			"!**/.wrangler",
 			"!**/coverage"
 		]
 	},


### PR DESCRIPTION
Remove `openci-runner`, Cloudflare, and `node_modules` exclusion patterns from `biome.jsonc` because the associated code and configurations have been removed from the project.

---
Linear Issue: [OP-432](https://linear.app/openci/issue/OP-432/modify-biomejsonc-to-remove-openci-runner-related-codes-including)

<a href="https://cursor.com/background-agent?bcId=bc-2835f3bf-799c-4351-9d5d-e2574ae74ac4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2835f3bf-799c-4351-9d5d-e2574ae74ac4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Streamlines Biome configuration to reflect current codebase.
> 
> - Updates `files.includes` in `biome.jsonc` by removing exclusions for `node_modules`, `openci-runner/worker-configuration.d.ts`, and `.wrangler`; retains `coverage` exclusion
> - No other linter or assist settings changed
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b9ffaec13f71c73e21c8dd2ccd3060a86f892b17. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build tool configuration to adjust file matching behavior for internal project paths.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->