### PR TITLE
Ci push and pull triggers

### DIFF
--- a/.github/workflows/ci_lp.yml
+++ b/.github/workflows/ci_lp.yml
@@ -2,7 +2,11 @@ name: CI for LP
 
 on:
   push:
+    branches:
+      - develop
   pull_request:
+    branches:
+      - develop
 
 jobs:
   ci_lp:

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -1,6 +1,10 @@
 on:
   push:
+    branches:
+      - develop
   pull_request:
+    branches:
+      - develop
 
 name: Clippy check
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,7 +2,11 @@ name: Coverage
 
 on:
   push:
+    branches:
+      - develop
   pull_request:
+    branches:
+      - develop
 
 jobs:
   coverage:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,11 @@ name: Cargo Build & Test
 
 on:
   push:
+    branches:
+      - develop
   pull_request:
+    branches:
+      - develop
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
Limit GitHub Actions CI triggers to the `develop` branch for push and pull requests.

Previously, CI workflows were triggered on push and pull requests to all branches. This change restricts CI runs to only occur when changes are pushed to or pull requests are opened against the `develop` branch.

---
Linear Issue: [OP-443](https://linear.app/openci/issue/OP-443/cursor-set-develop-for-push-and-pull-trigger-for-all-cigithub-actions)

<a href="https://cursor.com/background-agent?bcId=bc-27d1a282-b271-4cb0-87c9-a7872b33498d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-27d1a282-b271-4cb0-87c9-a7872b33498d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated GitHub Actions workflows to run continuous integration checks exclusively on the develop branch for push and pull request events, streamlining the CI pipeline.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->