### PR TITLE
refactor: update WorkflowStep to use a single `command` string instead of a list of `commands`.

### DIFF
--- a/cli/openci_worker_cli/CHANGELOG.md
+++ b/cli/openci_worker_cli/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.4.5
+
+- Support dynamic VM cloning and cleanup per job.
+- Support custom working directories.
+
 ## 0.4.4
 
 - Support multiple commands in a step.

--- a/cli/openci_worker_cli/bin/openci_worker_cli.dart
+++ b/cli/openci_worker_cli/bin/openci_worker_cli.dart
@@ -5,6 +5,8 @@ import 'dart:io';
 import 'package:args/args.dart';
 import 'package:dart_firebase_admin/dart_firebase_admin.dart';
 import 'package:dart_firebase_admin/firestore.dart';
+import 'package:googleapis/secretmanager/v1.dart';
+import 'package:googleapis_auth/auth_io.dart';
 import 'package:http/http.dart' as http;
 import 'package:process_run/process_run.dart';
 
@@ -68,7 +70,7 @@ Future<void> main(List<String> arguments) async {
     while (true) {
       bool jobFound = false;
       try {
-        jobFound = await processJob(firestore);
+        jobFound = await processJob(firestore, projectId, serviceAccountPath);
       } catch (e) {
         print('Error processing job: $e');
       }
@@ -88,7 +90,11 @@ Future<void> main(List<String> arguments) async {
   }
 }
 
-Future<bool> processJob(Firestore firestore) async {
+Future<bool> processJob(
+  Firestore firestore,
+  String projectId,
+  String serviceAccountPath,
+) async {
   final doc = await firestore
       .collection('build_jobs_v0')
       .where('status', WhereFilter.equal, 'queued')
@@ -135,7 +141,6 @@ Future<bool> processJob(Firestore firestore) async {
   }
 
   try {
-    // get steps
     final workflowQs = await firestore
         .collection('workflows_v1')
         .where(
@@ -153,6 +158,7 @@ Future<bool> processJob(Firestore firestore) async {
     final workflowDoc = workflowQs.docs.first;
     final workflowData = workflowDoc.data();
     final steps = workflowData['workflowSteps'] as List;
+    print('steps: $steps');
 
     unawaited(runTart());
 
@@ -170,10 +176,35 @@ Future<bool> processJob(Firestore firestore) async {
     print('finish cloning');
 
     for (final step in steps) {
-      final commands = step['commands'] as List;
-      for (final command in commands) {
+      final command = step['command'] as String;
+      final secrets = step['requiredSecrets'] as List;
+      if (secrets.isEmpty) {
         await execCommand('/bin/zsh -c "cd $repo && $command"');
+        continue;
       }
+      final exportCommands = <String>[];
+      for (final secret in secrets) {
+        final secretDocumentId = secret['secretDocumentId'] as String;
+        final key = secret['key'] as String;
+        final secretDoc = await firestore
+            .collection('secrets_v0')
+            .doc(secretDocumentId)
+            .get();
+
+        final secretData = secretDoc.data()!;
+        final pathToSecret = secretData['pathToSecret'] as String;
+        final secretValue = await fetchSecretValue(
+          projectId,
+          pathToSecret,
+          serviceAccountPath,
+        );
+
+        final escapedValue = secretValue.replaceAll("'", "'\\''");
+        exportCommands.add("export $key='$escapedValue'");
+      }
+
+      final envVars = exportCommands.join(' && ');
+      await execCommand('/bin/zsh -c "cd $repo && $envVars && $command"');
     }
 
     await Future.delayed(const Duration(seconds: 5));
@@ -193,8 +224,9 @@ Future<bool> processJob(Firestore firestore) async {
     await firestore.collection('build_jobs_v0').doc(buildJobId).update({
       'status': 'success',
     });
-  } catch (e) {
+  } catch (e, s) {
     print('Job failed: $e');
+    print('Stack trace: $s');
     if (checkRunId != null) {
       await updateCheckRun(
         owner,
@@ -283,4 +315,35 @@ Future<void> waitForVmReady(String name) async {
   }
 
   throw Exception('VM boot timeout: Guest Agent did not respond.');
+}
+
+Future<String> fetchSecretValue(
+  String projectId,
+  String pathToSecret,
+  String serviceAccountPath,
+) async {
+  final credentials = ServiceAccountCredentials.fromJson(
+    File(serviceAccountPath).readAsStringSync(),
+  );
+
+  final client = await clientViaServiceAccount(credentials, [
+    SecretManagerApi.cloudPlatformScope,
+  ]);
+
+  try {
+    final api = SecretManagerApi(client);
+    final response = await api.projects.secrets.versions.access(
+      '$pathToSecret/versions/latest',
+    );
+    final payload = response.payload?.data;
+
+    if (payload == null) {
+      throw Exception('Secret payload is empty');
+    }
+
+    // Secret payload is base64 encoded
+    return utf8.decode(base64.decode(payload));
+  } finally {
+    client.close();
+  }
 }

--- a/cli/openci_worker_cli/bin/openci_worker_cli.dart
+++ b/cli/openci_worker_cli/bin/openci_worker_cli.dart
@@ -10,7 +10,7 @@ import 'package:googleapis_auth/auth_io.dart';
 import 'package:http/http.dart' as http;
 import 'package:process_run/process_run.dart';
 
-const String version = '0.4.4';
+const String version = '0.4.5';
 
 ArgParser buildParser() {
   return ArgParser()

--- a/cli/openci_worker_cli/bin/openci_worker_cli.dart
+++ b/cli/openci_worker_cli/bin/openci_worker_cli.dart
@@ -140,6 +140,16 @@ Future<bool> processJob(
     await updateCheckRun(owner, repo, checkRunId, token, status: 'in_progress');
   }
 
+  final currentVmName = '$baseVmName-$buildJobId';
+  print('Cloning VM $baseVmName to $currentVmName...');
+  await Shell().run('tart clone $baseVmName $currentVmName');
+
+  // Local helper to execute commands on the specific VM
+  Future<void> execCommand(String command) async {
+    var shell = Shell(verbose: true);
+    await shell.run("tart exec $currentVmName $command");
+  }
+
   try {
     final workflowQs = await firestore
         .collection('workflows_v1')
@@ -158,12 +168,17 @@ Future<bool> processJob(
     final workflowDoc = workflowQs.docs.first;
     final workflowData = workflowDoc.data();
     final steps = workflowData['workflowSteps'] as List;
-    print('steps: $steps');
+    final workflowConfig =
+        workflowData['workflowConfig'] as Map<String, dynamic>?;
+    final cwd = workflowConfig?['selectedWorkingDirectory'] as String?;
 
-    unawaited(runTart());
+    print('steps: $steps');
+    print('cwd: $cwd');
+
+    unawaited(runTart(currentVmName));
 
     print('Waiting for VM to be ready...');
-    await waitForVmReady(vmName);
+    await waitForVmReady(currentVmName);
     print('VM is ready!');
 
     final cloneUrl =
@@ -175,11 +190,16 @@ Future<bool> processJob(
 
     print('finish cloning');
 
+    String workingDirectory = repo;
+    if (cwd != null && cwd.isNotEmpty) {
+      workingDirectory = '$repo/$cwd';
+    }
+
     for (final step in steps) {
       final command = step['command'] as String;
       final secrets = step['requiredSecrets'] as List;
       if (secrets.isEmpty) {
-        await execCommand('/bin/zsh -c "cd $repo && $command"');
+        await execCommand('/bin/zsh -c "cd $workingDirectory && $command"');
         continue;
       }
       final exportCommands = <String>[];
@@ -204,7 +224,9 @@ Future<bool> processJob(
       }
 
       final envVars = exportCommands.join(' && ');
-      await execCommand('/bin/zsh -c "cd $repo && $envVars && $command"');
+      await execCommand(
+        '/bin/zsh -c "cd $workingDirectory && $envVars && $command"',
+      );
     }
 
     await Future.delayed(const Duration(seconds: 5));
@@ -243,13 +265,22 @@ Future<bool> processJob(
     });
     rethrow;
   } finally {
-    await stopTart();
+    try {
+      await stopTart(currentVmName);
+    } catch (e) {
+      print('Error stopping VM: $e');
+    }
+    try {
+      await deleteTart(currentVmName);
+    } catch (e) {
+      print('Error deleting VM: $e');
+    }
   }
 
   return true;
 }
 
-const vmName = 'sequoia-base';
+const baseVmName = 'sequoia-base';
 
 Future<void> updateCheckRun(
   String owner,
@@ -285,19 +316,19 @@ Future<void> updateCheckRun(
   }
 }
 
-Future<void> execCommand(String command) async {
-  var shell = Shell(verbose: true);
-  await shell.run("tart exec $vmName $command");
-}
-
-Future<void> runTart() async {
+Future<void> runTart(String vmName) async {
   var shell = Shell();
   await shell.run('tart run $vmName');
 }
 
-Future<void> stopTart() async {
+Future<void> stopTart(String vmName) async {
   var shell = Shell();
   await shell.run('tart stop $vmName');
+}
+
+Future<void> deleteTart(String vmName) async {
+  var shell = Shell(throwOnError: false);
+  await shell.run('tart delete $vmName');
 }
 
 Future<void> waitForVmReady(String name) async {

--- a/cli/openci_worker_cli/pubspec.lock
+++ b/cli/openci_worker_cli/pubspec.lock
@@ -210,7 +210,7 @@ packages:
     source: hosted
     version: "0.3.3+1"
   googleapis:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: googleapis
       sha256: "864f222aed3f2ff00b816c675edf00a39e2aaf373d728d8abec30b37bee1a81c"
@@ -218,7 +218,7 @@ packages:
     source: hosted
     version: "13.2.0"
   googleapis_auth:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: googleapis_auth
       sha256: befd71383a955535060acde8792e7efc11d2fccd03dd1d3ec434e85b68775938

--- a/cli/openci_worker_cli/pubspec.yaml
+++ b/cli/openci_worker_cli/pubspec.yaml
@@ -1,6 +1,6 @@
 name: openci_worker_cli
 description: OpenCI Worker CLI
-version: 0.4.4
+version: 0.4.5
 repository: https://github.com/open-ci-io/openci
 
 environment:

--- a/cli/openci_worker_cli/pubspec.yaml
+++ b/cli/openci_worker_cli/pubspec.yaml
@@ -9,6 +9,8 @@ environment:
 dependencies:
   args: ^2.7.0
   dart_firebase_admin: ^0.4.1
+  googleapis: ^13.2.0
+  googleapis_auth: ^1.6.0
   http: ^1.6.0
   process_run: ^1.2.4
     

--- a/firebase/functions/src/index.ts
+++ b/firebase/functions/src/index.ts
@@ -206,7 +206,7 @@ export const createSecretV1 = onCall(
 
       logger.info(`Secret created: ${secretId}`, { userId, name });
 
-      return { success: true, secretId: documentId };
+      return { success: true, documentId };
     } catch (error: any) {
       if (error.code === 6) {
         await secretManagerClient.addSecretVersion({
@@ -216,8 +216,21 @@ export const createSecretV1 = onCall(
           },
         });
 
+        const existingDocs = await db
+          .collection(secretsCollectionPath)
+          .where("userId", "==", userId)
+          .where("name", "==", name)
+          .limit(1)
+          .get();
+
+        if (existingDocs.empty) {
+          throw new Error("Secret not found");
+        }
+
+        const documentId = existingDocs.docs[0].id;
+
         logger.info(`Secret updated: ${secretId}`, { userId, name });
-        return { success: true, message: "Secret updated" };
+        return { success: true, documentId };
       }
 
       logger.error("Failed to create secret", error);

--- a/frontend/dashboard/lib/workflow/editor/workflow_template/choose_workflow_template.dart
+++ b/frontend/dashboard/lib/workflow/editor/workflow_template/choose_workflow_template.dart
@@ -174,7 +174,7 @@ class ChooseWorkflowTemplate extends HookConsumerWidget {
                         'workflowSteps': FieldValue.arrayUnion([
                           WorkflowStep(
                             name: template.title,
-                            commands: [codeController.value.text],
+                            command: codeController.value.text,
                             isCompleted: true,
                           ).toJson(),
                         ]),

--- a/frontend/dashboard/lib/workflow/editor/workflow_template/react_native_ios_cd_form.dart
+++ b/frontend/dashboard/lib/workflow/editor/workflow_template/react_native_ios_cd_form.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:cloud_functions/cloud_functions.dart';
 import 'package:dashboard/firebase/firestore_paths.dart';
 import 'package:dashboard/workflow/workflow.dart';
 import 'package:file_picker/file_picker.dart';
@@ -155,49 +156,134 @@ class ReactNativeIosCdForm extends HookWidget {
                     Center(
                       child: ElevatedButton(
                         onPressed: () async {
-                          // final functions = FirebaseFunctions.instanceFor(
-                          //   region: 'asia-northeast1',
-                          // );
-                          // final createSecret = functions.httpsCallable(
-                          //   'createSecretV1',
-                          // );
+                          try {
+                            final functions = FirebaseFunctions.instanceFor(
+                              region: 'asia-northeast1',
+                            );
+                            final createSecret = functions.httpsCallable(
+                              'createSecretV1',
+                            );
 
-                          // await Future.wait([
-                          //   createSecret.call({
-                          //     'name': 'APP_STORE_CONNECT_ISSUER_ID',
-                          //     'value': issuerIdController.text,
-                          //   }),
-                          //   createSecret.call({
-                          //     'name': 'APP_STORE_CONNECT_KEY_ID',
-                          //     'value': keyIdController.text,
-                          //   }),
-                          //   createSecret.call({
-                          //     'name': 'APP_STORE_CONNECT_PRIVATE_KEY_BASE64',
-                          //     'value': privateKeyController.text,
-                          //   }),
-                          // ]);
+                            final issuerIdSecretDocumentId =
+                                (await createSecret.call({
+                                  'name': 'APP_STORE_CONNECT_ISSUER_ID',
+                                  'value': issuerIdController.text,
+                                })).data['documentId'];
 
-                          await FirebaseFirestore.instance
-                              .collection(workflowsCollection)
-                              .doc(documentId)
-                              .update({
-                                'workflowSteps': FieldValue.arrayUnion([
-                                  WorkflowStep(
-                                    name: 'Start React Native iOS CD',
-                                    commands: [
-                                      "echo 'Start React Native iOS CD'",
-                                    ],
-                                    isCompleted: true,
-                                  ).toJson(),
-                                  WorkflowStep(
-                                    name: 'Start React Native iOS CD',
-                                    commands: [
-                                      "echo 'Start React Native iOS CD'",
-                                    ],
-                                    isCompleted: true,
-                                  ).toJson(),
-                                ]),
-                              });
+                            final keyIdSecretDocumentId =
+                                (await createSecret.call({
+                                  'name': 'APP_STORE_CONNECT_KEY_ID',
+                                  'value': keyIdController.text,
+                                })).data['documentId'];
+
+                            final privateKeySecretDocumentId =
+                                (await createSecret.call({
+                                  'name':
+                                      'APP_STORE_CONNECT_PRIVATE_KEY_BASE64',
+                                  'value': privateKeyController.text,
+                                })).data['documentId'];
+
+                            final teamIdSecretDocumentId =
+                                (await createSecret.call({
+                                  'name': 'TEAM_ID',
+                                  'value': teamIdController.text,
+                                })).data['documentId'];
+
+                            final bundleIdSecretDocumentId =
+                                (await createSecret.call({
+                                  'name': 'BUNDLE_ID',
+                                  'value': bundleIdController.text,
+                                })).data['documentId'];
+
+                            await FirebaseFirestore.instance.collection(workflowsCollection).doc(documentId).update({
+                              'workflowSteps': FieldValue.arrayUnion([
+                                WorkflowStep(
+                                  name: 'Install Dependencies (npm)',
+                                  command: "npm install",
+                                  isCompleted: true,
+                                ).toJson(),
+                                WorkflowStep(
+                                  name: 'Install Dependencies (Cocoapods)',
+                                  command: "cd ios && pod install",
+                                  isCompleted: true,
+                                ).toJson(),
+                                // WorkflowStep(
+                                //   name: 'Create API Key File',
+                                //   command:
+                                //       "echo \"\$APP_STORE_CONNECT_PRIVATE_KEY_BASE64\" | base64 --decode > ios/AuthKey_\$APP_STORE_CONNECT_KEY_ID.p8",
+                                //   isCompleted: true,
+                                //   requiredSecrets: [
+                                //     WorkflowStepRequiredSecret(
+                                //       key: 'APP_STORE_CONNECT_PRIVATE_KEY_BASE64',
+                                //       secretDocumentId:
+                                //           privateKeySecretDocumentId,
+                                //     ),
+                                //     WorkflowStepRequiredSecret(
+                                //       key: 'APP_STORE_CONNECT_KEY_ID',
+                                //       secretDocumentId: keyIdSecretDocumentId,
+                                //     ),
+                                //   ],
+                                // ).toJson(),
+                                //                                   WorkflowStep(
+                                //                                     name: 'Create ExportOptions.plist',
+                                //                                     command:
+                                //                                         '''cat <<EOF > ios/ExportOptions.plist
+                                // <?xml version="1.0" encoding="UTF-8"?>
+                                // <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+                                // <plist version="1.0">
+                                // <dict>
+                                //     <key>method</key>
+                                //     <string>app-store</string>
+                                //     <key>teamID</key>
+                                //     <string>\$TEAM_ID</string>
+                                // </dict>
+                                // </plist>
+                                // EOF''',
+                                //                                     isCompleted: true,
+                                //                                     requiredSecrets: [
+                                //                                       WorkflowStepRequiredSecret(
+                                //                                         key: 'TEAM_ID',
+                                //                                         secretDocumentId:
+                                //                                             teamIdSecretDocumentId,
+                                //                                       ),
+                                //                                     ],
+                                //                                   ).toJson(),
+                                // WorkflowStep(
+                                //   name: 'Archive Build',
+                                //   command:
+                                //       "xcodebuild -workspace ios/*.xcworkspace -scheme \$IOS_SCHEME_NAME -configuration Release -archivePath \$PWD/ios/build/App.xcarchive archive -allowProvisioningUpdates -authenticationKeyPath \$PWD/ios/AuthKey_\$APP_STORE_CONNECT_KEY_ID.p8 -authenticationKeyID \$APP_STORE_CONNECT_KEY_ID -authenticationKeyIssuerID \$APP_STORE_CONNECT_ISSUER_ID",
+                                //   isCompleted: true,
+                                // ).toJson(),
+                                // WorkflowStep(
+                                //   name: 'Export IPA',
+                                //   command:
+                                //       "xcodebuild -exportArchive -archivePath \$PWD/ios/build/App.xcarchive -exportOptionsPlist ios/ExportOptions.plist -exportPath \$PWD/ios/build -allowProvisioningUpdates -authenticationKeyPath \$PWD/ios/AuthKey_\$APP_STORE_CONNECT_KEY_ID.p8 -authenticationKeyID \$APP_STORE_CONNECT_KEY_ID -authenticationKeyIssuerID \$APP_STORE_CONNECT_ISSUER_ID",
+                                //   isCompleted: true,
+                                // ).toJson(),
+                                // WorkflowStep(
+                                //   name: 'Upload to App Store Connect',
+                                //   command:
+                                //       "xcrun altool --upload-app --type ios --file \$PWD/ios/build/*.ipa --apiKey \$APP_STORE_CONNECT_KEY_ID --apiIssuer \$APP_STORE_CONNECT_ISSUER_ID",
+                                //   isCompleted: true,
+                                // ).toJson(),
+                              ]),
+                            });
+                          } catch (e) {
+                            print(e);
+                            if (context.mounted) {
+                              ScaffoldMessenger.of(context).showSnackBar(
+                                SnackBar(
+                                  content: Text('Failed to add workflow: $e'),
+                                  behavior: SnackBarBehavior.floating,
+                                ),
+                              );
+                            }
+                          } finally {
+                            if (context.mounted) {
+                              Navigator.pop(context);
+                              Navigator.pop(context);
+                            }
+                          }
                         },
                         child: const Text("Add Workflow"),
                       ),

--- a/frontend/dashboard/lib/workflow/editor/workflow_template/react_native_ios_cd_form.dart
+++ b/frontend/dashboard/lib/workflow/editor/workflow_template/react_native_ios_cd_form.dart
@@ -152,6 +152,7 @@ class ReactNativeIosCdForm extends HookWidget {
                         labelText: "Bundle id",
                       ),
                     ),
+
                     const SizedBox(height: 32),
                     Center(
                       child: ElevatedButton(
@@ -198,8 +199,18 @@ class ReactNativeIosCdForm extends HookWidget {
                             await FirebaseFirestore.instance.collection(workflowsCollection).doc(documentId).update({
                               'workflowSteps': FieldValue.arrayUnion([
                                 WorkflowStep(
+                                  name: 'Install Node.js',
+                                  command: "brew install node",
+                                  isCompleted: true,
+                                ).toJson(),
+                                WorkflowStep(
                                   name: 'Install Dependencies (npm)',
                                   command: "npm install",
+                                  isCompleted: true,
+                                ).toJson(),
+                                WorkflowStep(
+                                  name: 'Prebuild (Expo)',
+                                  command: "npx expo prebuild --platform ios",
                                   isCompleted: true,
                                 ).toJson(),
                                 WorkflowStep(
@@ -207,66 +218,157 @@ class ReactNativeIosCdForm extends HookWidget {
                                   command: "cd ios && pod install",
                                   isCompleted: true,
                                 ).toJson(),
-                                // WorkflowStep(
-                                //   name: 'Create API Key File',
-                                //   command:
-                                //       "echo \"\$APP_STORE_CONNECT_PRIVATE_KEY_BASE64\" | base64 --decode > ios/AuthKey_\$APP_STORE_CONNECT_KEY_ID.p8",
-                                //   isCompleted: true,
-                                //   requiredSecrets: [
-                                //     WorkflowStepRequiredSecret(
-                                //       key: 'APP_STORE_CONNECT_PRIVATE_KEY_BASE64',
-                                //       secretDocumentId:
-                                //           privateKeySecretDocumentId,
-                                //     ),
-                                //     WorkflowStepRequiredSecret(
-                                //       key: 'APP_STORE_CONNECT_KEY_ID',
-                                //       secretDocumentId: keyIdSecretDocumentId,
-                                //     ),
-                                //   ],
-                                // ).toJson(),
-                                //                                   WorkflowStep(
-                                //                                     name: 'Create ExportOptions.plist',
-                                //                                     command:
-                                //                                         '''cat <<EOF > ios/ExportOptions.plist
-                                // <?xml version="1.0" encoding="UTF-8"?>
-                                // <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-                                // <plist version="1.0">
-                                // <dict>
-                                //     <key>method</key>
-                                //     <string>app-store</string>
-                                //     <key>teamID</key>
-                                //     <string>\$TEAM_ID</string>
-                                // </dict>
-                                // </plist>
-                                // EOF''',
-                                //                                     isCompleted: true,
-                                //                                     requiredSecrets: [
-                                //                                       WorkflowStepRequiredSecret(
-                                //                                         key: 'TEAM_ID',
-                                //                                         secretDocumentId:
-                                //                                             teamIdSecretDocumentId,
-                                //                                       ),
-                                //                                     ],
-                                //                                   ).toJson(),
-                                // WorkflowStep(
-                                //   name: 'Archive Build',
-                                //   command:
-                                //       "xcodebuild -workspace ios/*.xcworkspace -scheme \$IOS_SCHEME_NAME -configuration Release -archivePath \$PWD/ios/build/App.xcarchive archive -allowProvisioningUpdates -authenticationKeyPath \$PWD/ios/AuthKey_\$APP_STORE_CONNECT_KEY_ID.p8 -authenticationKeyID \$APP_STORE_CONNECT_KEY_ID -authenticationKeyIssuerID \$APP_STORE_CONNECT_ISSUER_ID",
-                                //   isCompleted: true,
-                                // ).toJson(),
-                                // WorkflowStep(
-                                //   name: 'Export IPA',
-                                //   command:
-                                //       "xcodebuild -exportArchive -archivePath \$PWD/ios/build/App.xcarchive -exportOptionsPlist ios/ExportOptions.plist -exportPath \$PWD/ios/build -allowProvisioningUpdates -authenticationKeyPath \$PWD/ios/AuthKey_\$APP_STORE_CONNECT_KEY_ID.p8 -authenticationKeyID \$APP_STORE_CONNECT_KEY_ID -authenticationKeyIssuerID \$APP_STORE_CONNECT_ISSUER_ID",
-                                //   isCompleted: true,
-                                // ).toJson(),
-                                // WorkflowStep(
-                                //   name: 'Upload to App Store Connect',
-                                //   command:
-                                //       "xcrun altool --upload-app --type ios --file \$PWD/ios/build/*.ipa --apiKey \$APP_STORE_CONNECT_KEY_ID --apiIssuer \$APP_STORE_CONNECT_ISSUER_ID",
-                                //   isCompleted: true,
-                                // ).toJson(),
+                                WorkflowStep(
+                                  name: 'Create API Key File',
+                                  command:
+                                      "echo \"\$APP_STORE_CONNECT_PRIVATE_KEY_BASE64\" | base64 -D > ios/AuthKey_\$APP_STORE_CONNECT_KEY_ID.p8",
+                                  isCompleted: true,
+                                  requiredSecrets: [
+                                    WorkflowStepRequiredSecret(
+                                      key:
+                                          'APP_STORE_CONNECT_PRIVATE_KEY_BASE64',
+                                      secretDocumentId:
+                                          privateKeySecretDocumentId,
+                                    ),
+                                    WorkflowStepRequiredSecret(
+                                      key: 'APP_STORE_CONNECT_KEY_ID',
+                                      secretDocumentId: keyIdSecretDocumentId,
+                                    ),
+                                  ],
+                                ).toJson(),
+                                WorkflowStep(
+                                  name: 'Create ExportOptions.plist',
+                                  command:
+                                      '''cat <<EOF > ios/ExportOptions.plist
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>method</key>
+    <string>app-store</string>
+    <key>teamID</key>
+    <string>\$TEAM_ID</string>
+</dict>
+</plist>
+EOF''',
+                                  isCompleted: true,
+                                  requiredSecrets: [
+                                    WorkflowStepRequiredSecret(
+                                      key: 'TEAM_ID',
+                                      secretDocumentId: teamIdSecretDocumentId,
+                                    ),
+                                  ],
+                                ).toJson(),
+                                WorkflowStep(
+                                  name: 'Archive Build',
+                                  command:
+                                      "xcodebuild -workspace ios/*.xcworkspace -configuration Release -archivePath \$PWD/ios/build/App.xcarchive archive -allowProvisioningUpdates -authenticationKeyPath \$PWD/ios/AuthKey_\$APP_STORE_CONNECT_KEY_ID.p8 -authenticationKeyID \$APP_STORE_CONNECT_KEY_ID -authenticationKeyIssuerID \$APP_STORE_CONNECT_ISSUER_ID",
+                                  isCompleted: true,
+                                  requiredSecrets: [
+                                    WorkflowStepRequiredSecret(
+                                      key: 'APP_STORE_CONNECT_KEY_ID',
+                                      secretDocumentId: keyIdSecretDocumentId,
+                                    ),
+                                    WorkflowStepRequiredSecret(
+                                      key: 'APP_STORE_CONNECT_ISSUER_ID',
+                                      secretDocumentId:
+                                          issuerIdSecretDocumentId,
+                                    ),
+                                  ],
+                                ).toJson(),
+                                WorkflowStep(
+                                  name: 'Export IPA',
+                                  command:
+                                      "xcodebuild -exportArchive -archivePath \$PWD/ios/build/App.xcarchive -exportOptionsPlist ios/ExportOptions.plist -exportPath \$PWD/ios/build -allowProvisioningUpdates -authenticationKeyPath \$PWD/ios/AuthKey_\$APP_STORE_CONNECT_KEY_ID.p8 -authenticationKeyID \$APP_STORE_CONNECT_KEY_ID -authenticationKeyIssuerID \$APP_STORE_CONNECT_ISSUER_ID",
+                                  isCompleted: true,
+                                  requiredSecrets: [
+                                    WorkflowStepRequiredSecret(
+                                      key: 'APP_STORE_CONNECT_KEY_ID',
+                                      secretDocumentId: keyIdSecretDocumentId,
+                                    ),
+                                    WorkflowStepRequiredSecret(
+                                      key: 'APP_STORE_CONNECT_ISSUER_ID',
+                                      secretDocumentId:
+                                          issuerIdSecretDocumentId,
+                                    ),
+                                  ],
+                                ).toJson(),
+                                WorkflowStep(
+                                  name: 'Upload to App Store Connect',
+                                  command:
+                                      "xcrun altool --upload-app --type ios --file \$PWD/ios/build/*.ipa --apiKey \$APP_STORE_CONNECT_KEY_ID --apiIssuer \$APP_STORE_CONNECT_ISSUER_ID",
+                                  isCompleted: true,
+                                  requiredSecrets: [
+                                    WorkflowStepRequiredSecret(
+                                      key: 'APP_STORE_CONNECT_KEY_ID',
+                                      secretDocumentId: keyIdSecretDocumentId,
+                                    ),
+                                    WorkflowStepRequiredSecret(
+                                      key: 'APP_STORE_CONNECT_ISSUER_ID',
+                                      secretDocumentId:
+                                          issuerIdSecretDocumentId,
+                                    ),
+                                  ],
+                                ).toJson(),
                               ]),
+
+                              //   command:
+                              //       "echo \"\$APP_STORE_CONNECT_PRIVATE_KEY_BASE64\" | base64 --decode > ios/AuthKey_\$APP_STORE_CONNECT_KEY_ID.p8",
+                              //   isCompleted: true,
+                              //   requiredSecrets: [
+                              //     WorkflowStepRequiredSecret(
+                              //       key: 'APP_STORE_CONNECT_PRIVATE_KEY_BASE64',
+                              //       secretDocumentId:
+                              //           privateKeySecretDocumentId,
+                              //     ),
+                              //     WorkflowStepRequiredSecret(
+                              //       key: 'APP_STORE_CONNECT_KEY_ID',
+                              //       secretDocumentId: keyIdSecretDocumentId,
+                              //     ),
+                              //   ],
+                              // ).toJson(),
+                              //                                   WorkflowStep(
+                              //                                     name: 'Create ExportOptions.plist',
+                              //                                     command:
+                              //                                         '''cat <<EOF > ios/ExportOptions.plist
+                              // <?xml version="1.0" encoding="UTF-8"?>
+                              // <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+                              // <plist version="1.0">
+                              // <dict>
+                              //     <key>method</key>
+                              //     <string>app-store</string>
+                              //     <key>teamID</key>
+                              //     <string>\$TEAM_ID</string>
+                              // </dict>
+                              // </plist>
+                              // EOF''',
+                              //                                     isCompleted: true,
+                              //                                     requiredSecrets: [
+                              //                                       WorkflowStepRequiredSecret(
+                              //                                         key: 'TEAM_ID',
+                              //                                         secretDocumentId:
+                              //                                             teamIdSecretDocumentId,
+                              //                                       ),
+                              //                                     ],
+                              //                                   ).toJson(),
+                              // WorkflowStep(
+                              //   name: 'Archive Build',
+                              //   command:
+                              //       "xcodebuild -workspace ios/*.xcworkspace -scheme \$IOS_SCHEME_NAME -configuration Release -archivePath \$PWD/ios/build/App.xcarchive archive -allowProvisioningUpdates -authenticationKeyPath \$PWD/ios/AuthKey_\$APP_STORE_CONNECT_KEY_ID.p8 -authenticationKeyID \$APP_STORE_CONNECT_KEY_ID -authenticationKeyIssuerID \$APP_STORE_CONNECT_ISSUER_ID",
+                              //   isCompleted: true,
+                              // ).toJson(),
+                              // WorkflowStep(
+                              //   name: 'Export IPA',
+                              //   command:
+                              //       "xcodebuild -exportArchive -archivePath \$PWD/ios/build/App.xcarchive -exportOptionsPlist ios/ExportOptions.plist -exportPath \$PWD/ios/build -allowProvisioningUpdates -authenticationKeyPath \$PWD/ios/AuthKey_\$APP_STORE_CONNECT_KEY_ID.p8 -authenticationKeyID \$APP_STORE_CONNECT_KEY_ID -authenticationKeyIssuerID \$APP_STORE_CONNECT_ISSUER_ID",
+                              //   isCompleted: true,
+                              // ).toJson(),
+                              // WorkflowStep(
+                              //   name: 'Upload to App Store Connect',
+                              //   command:
+                              //       "xcrun altool --upload-app --type ios --file \$PWD/ios/build/*.ipa --apiKey \$APP_STORE_CONNECT_KEY_ID --apiIssuer \$APP_STORE_CONNECT_ISSUER_ID",
+                              //   isCompleted: true,
+                              // ).toJson(),
                             });
                           } catch (e) {
                             print(e);

--- a/frontend/dashboard/lib/workflow/workflow.dart
+++ b/frontend/dashboard/lib/workflow/workflow.dart
@@ -35,7 +35,7 @@ abstract class WorkflowConfig with _$WorkflowConfig {
 abstract class WorkflowStep with _$WorkflowStep {
   const factory WorkflowStep({
     required String name,
-    required List<String> commands,
+    required String command,
     required bool isCompleted,
     @Default([]) List<WorkflowStepRequiredSecret> requiredSecrets,
   }) = _WorkflowStep;

--- a/frontend/dashboard/lib/workflow/workflow.freezed.dart
+++ b/frontend/dashboard/lib/workflow/workflow.freezed.dart
@@ -586,7 +586,7 @@ as String,
 /// @nodoc
 mixin _$WorkflowStep {
 
- String get name; List<String> get commands; bool get isCompleted; List<WorkflowStepRequiredSecret> get requiredSecrets;
+ String get name; String get command; bool get isCompleted; List<WorkflowStepRequiredSecret> get requiredSecrets;
 /// Create a copy of WorkflowStep
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -599,16 +599,16 @@ $WorkflowStepCopyWith<WorkflowStep> get copyWith => _$WorkflowStepCopyWithImpl<W
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is WorkflowStep&&(identical(other.name, name) || other.name == name)&&const DeepCollectionEquality().equals(other.commands, commands)&&(identical(other.isCompleted, isCompleted) || other.isCompleted == isCompleted)&&const DeepCollectionEquality().equals(other.requiredSecrets, requiredSecrets));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is WorkflowStep&&(identical(other.name, name) || other.name == name)&&(identical(other.command, command) || other.command == command)&&(identical(other.isCompleted, isCompleted) || other.isCompleted == isCompleted)&&const DeepCollectionEquality().equals(other.requiredSecrets, requiredSecrets));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,name,const DeepCollectionEquality().hash(commands),isCompleted,const DeepCollectionEquality().hash(requiredSecrets));
+int get hashCode => Object.hash(runtimeType,name,command,isCompleted,const DeepCollectionEquality().hash(requiredSecrets));
 
 @override
 String toString() {
-  return 'WorkflowStep(name: $name, commands: $commands, isCompleted: $isCompleted, requiredSecrets: $requiredSecrets)';
+  return 'WorkflowStep(name: $name, command: $command, isCompleted: $isCompleted, requiredSecrets: $requiredSecrets)';
 }
 
 
@@ -619,7 +619,7 @@ abstract mixin class $WorkflowStepCopyWith<$Res>  {
   factory $WorkflowStepCopyWith(WorkflowStep value, $Res Function(WorkflowStep) _then) = _$WorkflowStepCopyWithImpl;
 @useResult
 $Res call({
- String name, List<String> commands, bool isCompleted, List<WorkflowStepRequiredSecret> requiredSecrets
+ String name, String command, bool isCompleted, List<WorkflowStepRequiredSecret> requiredSecrets
 });
 
 
@@ -636,11 +636,11 @@ class _$WorkflowStepCopyWithImpl<$Res>
 
 /// Create a copy of WorkflowStep
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? name = null,Object? commands = null,Object? isCompleted = null,Object? requiredSecrets = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? name = null,Object? command = null,Object? isCompleted = null,Object? requiredSecrets = null,}) {
   return _then(_self.copyWith(
 name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
-as String,commands: null == commands ? _self.commands : commands // ignore: cast_nullable_to_non_nullable
-as List<String>,isCompleted: null == isCompleted ? _self.isCompleted : isCompleted // ignore: cast_nullable_to_non_nullable
+as String,command: null == command ? _self.command : command // ignore: cast_nullable_to_non_nullable
+as String,isCompleted: null == isCompleted ? _self.isCompleted : isCompleted // ignore: cast_nullable_to_non_nullable
 as bool,requiredSecrets: null == requiredSecrets ? _self.requiredSecrets : requiredSecrets // ignore: cast_nullable_to_non_nullable
 as List<WorkflowStepRequiredSecret>,
   ));
@@ -727,10 +727,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String name,  List<String> commands,  bool isCompleted,  List<WorkflowStepRequiredSecret> requiredSecrets)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String name,  String command,  bool isCompleted,  List<WorkflowStepRequiredSecret> requiredSecrets)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _WorkflowStep() when $default != null:
-return $default(_that.name,_that.commands,_that.isCompleted,_that.requiredSecrets);case _:
+return $default(_that.name,_that.command,_that.isCompleted,_that.requiredSecrets);case _:
   return orElse();
 
 }
@@ -748,10 +748,10 @@ return $default(_that.name,_that.commands,_that.isCompleted,_that.requiredSecret
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String name,  List<String> commands,  bool isCompleted,  List<WorkflowStepRequiredSecret> requiredSecrets)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String name,  String command,  bool isCompleted,  List<WorkflowStepRequiredSecret> requiredSecrets)  $default,) {final _that = this;
 switch (_that) {
 case _WorkflowStep():
-return $default(_that.name,_that.commands,_that.isCompleted,_that.requiredSecrets);case _:
+return $default(_that.name,_that.command,_that.isCompleted,_that.requiredSecrets);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -768,10 +768,10 @@ return $default(_that.name,_that.commands,_that.isCompleted,_that.requiredSecret
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String name,  List<String> commands,  bool isCompleted,  List<WorkflowStepRequiredSecret> requiredSecrets)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String name,  String command,  bool isCompleted,  List<WorkflowStepRequiredSecret> requiredSecrets)?  $default,) {final _that = this;
 switch (_that) {
 case _WorkflowStep() when $default != null:
-return $default(_that.name,_that.commands,_that.isCompleted,_that.requiredSecrets);case _:
+return $default(_that.name,_that.command,_that.isCompleted,_that.requiredSecrets);case _:
   return null;
 
 }
@@ -783,11 +783,11 @@ return $default(_that.name,_that.commands,_that.isCompleted,_that.requiredSecret
 @JsonSerializable()
 
 class _WorkflowStep implements WorkflowStep {
-  const _WorkflowStep({required this.name, required this.commands, required this.isCompleted, this.requiredSecrets = const []});
+  const _WorkflowStep({required this.name, required this.command, required this.isCompleted, this.requiredSecrets = const []});
   factory _WorkflowStep.fromJson(Map<String, dynamic> json) => _$WorkflowStepFromJson(json);
 
 @override final  String name;
-@override final  List<String> commands;
+@override final  String command;
 @override final  bool isCompleted;
 @override@JsonKey() final  List<WorkflowStepRequiredSecret> requiredSecrets;
 
@@ -804,16 +804,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _WorkflowStep&&(identical(other.name, name) || other.name == name)&&const DeepCollectionEquality().equals(other.commands, commands)&&(identical(other.isCompleted, isCompleted) || other.isCompleted == isCompleted)&&const DeepCollectionEquality().equals(other.requiredSecrets, requiredSecrets));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _WorkflowStep&&(identical(other.name, name) || other.name == name)&&(identical(other.command, command) || other.command == command)&&(identical(other.isCompleted, isCompleted) || other.isCompleted == isCompleted)&&const DeepCollectionEquality().equals(other.requiredSecrets, requiredSecrets));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,name,const DeepCollectionEquality().hash(commands),isCompleted,const DeepCollectionEquality().hash(requiredSecrets));
+int get hashCode => Object.hash(runtimeType,name,command,isCompleted,const DeepCollectionEquality().hash(requiredSecrets));
 
 @override
 String toString() {
-  return 'WorkflowStep(name: $name, commands: $commands, isCompleted: $isCompleted, requiredSecrets: $requiredSecrets)';
+  return 'WorkflowStep(name: $name, command: $command, isCompleted: $isCompleted, requiredSecrets: $requiredSecrets)';
 }
 
 
@@ -824,7 +824,7 @@ abstract mixin class _$WorkflowStepCopyWith<$Res> implements $WorkflowStepCopyWi
   factory _$WorkflowStepCopyWith(_WorkflowStep value, $Res Function(_WorkflowStep) _then) = __$WorkflowStepCopyWithImpl;
 @override @useResult
 $Res call({
- String name, List<String> commands, bool isCompleted, List<WorkflowStepRequiredSecret> requiredSecrets
+ String name, String command, bool isCompleted, List<WorkflowStepRequiredSecret> requiredSecrets
 });
 
 
@@ -841,11 +841,11 @@ class __$WorkflowStepCopyWithImpl<$Res>
 
 /// Create a copy of WorkflowStep
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? name = null,Object? commands = null,Object? isCompleted = null,Object? requiredSecrets = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? name = null,Object? command = null,Object? isCompleted = null,Object? requiredSecrets = null,}) {
   return _then(_WorkflowStep(
 name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
-as String,commands: null == commands ? _self.commands : commands // ignore: cast_nullable_to_non_nullable
-as List<String>,isCompleted: null == isCompleted ? _self.isCompleted : isCompleted // ignore: cast_nullable_to_non_nullable
+as String,command: null == command ? _self.command : command // ignore: cast_nullable_to_non_nullable
+as String,isCompleted: null == isCompleted ? _self.isCompleted : isCompleted // ignore: cast_nullable_to_non_nullable
 as bool,requiredSecrets: null == requiredSecrets ? _self.requiredSecrets : requiredSecrets // ignore: cast_nullable_to_non_nullable
 as List<WorkflowStepRequiredSecret>,
   ));

--- a/frontend/dashboard/lib/workflow/workflow.g.dart
+++ b/frontend/dashboard/lib/workflow/workflow.g.dart
@@ -58,9 +58,7 @@ const _$TriggerTypeEnumMap = {
 _WorkflowStep _$WorkflowStepFromJson(Map<String, dynamic> json) =>
     _WorkflowStep(
       name: json['name'] as String,
-      commands: (json['commands'] as List<dynamic>)
-          .map((e) => e as String)
-          .toList(),
+      command: json['command'] as String,
       isCompleted: json['isCompleted'] as bool,
       requiredSecrets:
           (json['requiredSecrets'] as List<dynamic>?)
@@ -77,7 +75,7 @@ Map<String, dynamic> _$WorkflowStepToJson(
   _WorkflowStep instance,
 ) => <String, dynamic>{
   'name': instance.name,
-  'commands': instance.commands,
+  'command': instance.command,
   'isCompleted': instance.isCompleted,
   'requiredSecrets': instance.requiredSecrets.map((e) => e.toJson()).toList(),
 };

--- a/openci.code-workspace
+++ b/openci.code-workspace
@@ -159,6 +159,23 @@
           "cwd": "${workspaceFolder:openci_worker_cli}",
         },
       },
+      {
+        "label": "(debug) Run OpenCI Worker CLI",
+        "type": "shell",
+        "command": "dart",
+        "args": [
+          "run",
+          "bin/openci_worker_cli.dart",
+          "--project-id",
+          "openci-b1b91",
+          "--service-account",
+          "firebase_service_account.json",
+        ],
+        "options": {
+          "cwd": "${workspaceFolder:openci_worker_cli}",
+        },
+        "problemMatcher": [],
+      },
     ],
   },
 }

--- a/openci.code-workspace
+++ b/openci.code-workspace
@@ -158,6 +158,7 @@
         "options": {
           "cwd": "${workspaceFolder:openci_worker_cli}",
         },
+        "problemMatcher": [],
       },
       {
         "label": "(debug) Run OpenCI Worker CLI",


### PR DESCRIPTION
…

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Per-job isolated VM provisioning and cleanup for safer, parallel job runs
  - Workflow steps can include required secrets fetched securely and injected at runtime
  - Custom working directory support for repository checkouts and step execution

* **Bug Fixes**
  - Improved error reporting with stack traces and more explicit step/VM lifecycle logs
  - Safer cleanup on failures to ensure VMs are stopped and deleted

* **Documentation**
  - Changelog updated for v0.4.5 (VM cloning, working directory)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->