### PR TITLE
Remove 'Install Dependencies (Cocoapods)' step from React Native iOS …

### DIFF
--- a/cli/openci_worker_cli/bin/openci_worker_cli.dart
+++ b/cli/openci_worker_cli/bin/openci_worker_cli.dart
@@ -140,7 +140,8 @@ Future<bool> processJob(
     await updateCheckRun(owner, repo, checkRunId, token, status: 'in_progress');
   }
 
-  final currentVmName = '$baseVmName-$buildJobId';
+  // Clone destination must be a local name (not OCI URL)
+  final currentVmName = 'openci-vm-$buildJobId';
   print('Cloning VM $baseVmName to $currentVmName...');
   await Shell().run('tart clone $baseVmName $currentVmName');
 
@@ -227,7 +228,12 @@ Future<bool> processJob(
         command,
       ];
 
-      await execCommand('/bin/zsh -c "${commandParts.join(' && ')}"');
+      // Encode the command to avoid shell parsing issues with quotes
+      final fullCommand = commandParts.join(' && ');
+      final encodedCommand = base64Encode(utf8.encode(fullCommand));
+      await execCommand(
+        "/bin/zsh -c 'echo $encodedCommand | base64 -D | /bin/zsh'",
+      );
     }
 
     await Future.delayed(const Duration(seconds: 5));
@@ -281,7 +287,7 @@ Future<bool> processJob(
   return true;
 }
 
-const baseVmName = 'sequoia-base';
+const baseVmName = 'ghcr.io/cirruslabs/macos-sequoia-xcode:latest';
 
 Future<void> updateCheckRun(
   String owner,

--- a/frontend/dashboard/lib/workflow/editor/workflow_template/react_native_ios_cd_form.dart
+++ b/frontend/dashboard/lib/workflow/editor/workflow_template/react_native_ios_cd_form.dart
@@ -214,11 +214,6 @@ class ReactNativeIosCdForm extends HookWidget {
                                   isCompleted: true,
                                 ).toJson(),
                                 WorkflowStep(
-                                  name: 'Install Dependencies (Cocoapods)',
-                                  command: "cd ios && pod install",
-                                  isCompleted: true,
-                                ).toJson(),
-                                WorkflowStep(
                                   name: 'Create API Key File',
                                   command:
                                       "echo \"\$APP_STORE_CONNECT_PRIVATE_KEY_BASE64\" | base64 -D > ios/AuthKey_\$APP_STORE_CONNECT_KEY_ID.p8",

--- a/frontend/dashboard/lib/workflow/editor/workflow_template/react_native_ios_cd_form.dart
+++ b/frontend/dashboard/lib/workflow/editor/workflow_template/react_native_ios_cd_form.dart
@@ -29,6 +29,7 @@ class ReactNativeIosCdForm extends HookWidget {
     final privateKeyController = useTextEditingController();
     final teamIdController = useTextEditingController();
     final bundleIdController = useTextEditingController();
+    final schemeNameController = useTextEditingController();
 
     return SizedBox(
       height: MediaQuery.of(context).size.height * 0.8,
@@ -152,6 +153,14 @@ class ReactNativeIosCdForm extends HookWidget {
                         labelText: "Bundle id",
                       ),
                     ),
+                    const SizedBox(height: 16),
+                    TextFormField(
+                      controller: schemeNameController,
+                      decoration: InputDecoration(
+                        labelText: "Scheme Name",
+                        helperText: "e.g. YourAppName",
+                      ),
+                    ),
 
                     const SizedBox(height: 32),
                     Center(
@@ -216,7 +225,7 @@ class ReactNativeIosCdForm extends HookWidget {
                                 WorkflowStep(
                                   name: 'Create API Key File',
                                   command:
-                                      "echo \"\$APP_STORE_CONNECT_PRIVATE_KEY_BASE64\" | base64 -D > ios/AuthKey_\$APP_STORE_CONNECT_KEY_ID.p8",
+                                      "echo \$APP_STORE_CONNECT_PRIVATE_KEY_BASE64 | base64 -D > ios/AuthKey_\$APP_STORE_CONNECT_KEY_ID.p8",
                                   isCompleted: true,
                                   requiredSecrets: [
                                     WorkflowStepRequiredSecret(
@@ -234,18 +243,7 @@ class ReactNativeIosCdForm extends HookWidget {
                                 WorkflowStep(
                                   name: 'Create ExportOptions.plist',
                                   command:
-                                      '''cat <<EOF > ios/ExportOptions.plist
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-    <key>method</key>
-    <string>app-store</string>
-    <key>teamID</key>
-    <string>\$TEAM_ID</string>
-</dict>
-</plist>
-EOF''',
+                                      "printf '%s\\n' '<?xml version=\"1.0\" encoding=\"UTF-8\"?>' '<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">' '<plist version=\"1.0\">' '<dict>' '<key>method</key>' '<string>app-store-connect</string>' '<key>teamID</key>' '<string>'\"\$TEAM_ID\"'</string>' '</dict>' '</plist>' > ios/ExportOptions.plist",
                                   isCompleted: true,
                                   requiredSecrets: [
                                     WorkflowStepRequiredSecret(
@@ -257,7 +255,7 @@ EOF''',
                                 WorkflowStep(
                                   name: 'Archive Build',
                                   command:
-                                      "xcodebuild -workspace ios/*.xcworkspace -configuration Release -archivePath \$PWD/ios/build/App.xcarchive archive -allowProvisioningUpdates -authenticationKeyPath \$PWD/ios/AuthKey_\$APP_STORE_CONNECT_KEY_ID.p8 -authenticationKeyID \$APP_STORE_CONNECT_KEY_ID -authenticationKeyIssuerID \$APP_STORE_CONNECT_ISSUER_ID",
+                                      "xcodebuild -quiet -workspace ios/*.xcworkspace -scheme ${schemeNameController.text} -configuration Release -archivePath \$PWD/ios/build/App.xcarchive archive -allowProvisioningUpdates -authenticationKeyPath \$PWD/ios/AuthKey_\$APP_STORE_CONNECT_KEY_ID.p8 -authenticationKeyID \$APP_STORE_CONNECT_KEY_ID -authenticationKeyIssuerID \$APP_STORE_CONNECT_ISSUER_ID DEVELOPMENT_TEAM=\$TEAM_ID > /tmp/xcodebuild.log 2>&1 || (tail -n 200 /tmp/xcodebuild.log && exit 1)",
                                   isCompleted: true,
                                   requiredSecrets: [
                                     WorkflowStepRequiredSecret(
@@ -269,12 +267,16 @@ EOF''',
                                       secretDocumentId:
                                           issuerIdSecretDocumentId,
                                     ),
+                                    WorkflowStepRequiredSecret(
+                                      key: 'TEAM_ID',
+                                      secretDocumentId: teamIdSecretDocumentId,
+                                    ),
                                   ],
                                 ).toJson(),
                                 WorkflowStep(
                                   name: 'Export IPA',
                                   command:
-                                      "xcodebuild -exportArchive -archivePath \$PWD/ios/build/App.xcarchive -exportOptionsPlist ios/ExportOptions.plist -exportPath \$PWD/ios/build -allowProvisioningUpdates -authenticationKeyPath \$PWD/ios/AuthKey_\$APP_STORE_CONNECT_KEY_ID.p8 -authenticationKeyID \$APP_STORE_CONNECT_KEY_ID -authenticationKeyIssuerID \$APP_STORE_CONNECT_ISSUER_ID",
+                                      "xcodebuild -exportArchive -archivePath \$PWD/ios/build/App.xcarchive -exportOptionsPlist ios/ExportOptions.plist -exportPath \$PWD/ios/build -allowProvisioningUpdates -authenticationKeyPath \$PWD/ios/AuthKey_\$APP_STORE_CONNECT_KEY_ID.p8 -authenticationKeyID \$APP_STORE_CONNECT_KEY_ID -authenticationKeyIssuerID \$APP_STORE_CONNECT_ISSUER_ID > /tmp/export.log 2>&1 || (tail -n 200 /tmp/export.log && exit 1)",
                                   isCompleted: true,
                                   requiredSecrets: [
                                     WorkflowStepRequiredSecret(
@@ -291,7 +293,7 @@ EOF''',
                                 WorkflowStep(
                                   name: 'Upload to App Store Connect',
                                   command:
-                                      "xcrun altool --upload-app --type ios --file \$PWD/ios/build/*.ipa --apiKey \$APP_STORE_CONNECT_KEY_ID --apiIssuer \$APP_STORE_CONNECT_ISSUER_ID",
+                                      "xcrun altool --upload-app --type ios --file \$PWD/ios/build/*.ipa --apiKey \$APP_STORE_CONNECT_KEY_ID --apiIssuer \$APP_STORE_CONNECT_ISSUER_ID 2>&1 || exit 1",
                                   isCompleted: true,
                                   requiredSecrets: [
                                     WorkflowStepRequiredSecret(

--- a/frontend/react-native-sample/app.json
+++ b/frontend/react-native-sample/app.json
@@ -11,6 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.mafreud.reactnativesample",
+      "buildNumber": "2",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false
       }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Scheme Name field to the React Native iOS deployment form.

* **Bug Fixes**
  * Removed the automatic CocoaPods installation step from iOS CI/CD workflows.

* **Improvements**
  * Improved iOS build/export/upload logging and API key handling for more reliable runs.

* **Chores**
  * Added TEAM_ID as a required secret and bumped the sample app iOS build number; updated VM base image and remote command execution approach for build infrastructure.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->