### PR TITLE
Remove `payload` field from job data stored in Firestore.

### DIFF
--- a/firebase/functions/src/index.ts
+++ b/firebase/functions/src/index.ts
@@ -176,11 +176,14 @@ async function createBuildJobs(
     }
 
     const documentId = uuidv4();
+    const jobData = { ...params };
+    delete jobData.payload;
+
     await db
       .collection(buildJobCollectionPath)
       .doc(documentId)
       .set({
-        ...params,
+        ...jobData,
         updatedAt: FieldValue.serverTimestamp(),
         createdAt: FieldValue.serverTimestamp(),
         status: "queued",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed job record storage to prevent redundant payload data from being persisted to the database. This optimisation improves storage efficiency whilst maintaining all essential job information integrity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->