### PR TITLE
fix: Rename RN templates

### DIFF
--- a/frontend/dashboard/lib/workflow/editor/workflow_template/choose_workflow_template.dart
+++ b/frontend/dashboard/lib/workflow/editor/workflow_template/choose_workflow_template.dart
@@ -1,8 +1,8 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:dashboard/firebase/firestore_paths.dart';
 import 'package:dashboard/firebase/firestore_provider.dart';
-import 'package:dashboard/workflow/editor/workflow_template/react_native_android_cd_form.dart';
-import 'package:dashboard/workflow/editor/workflow_template/react_native_ios_cd_form.dart';
+import 'package:dashboard/workflow/editor/workflow_template/react_native_expo_android_cd_form.dart';
+import 'package:dashboard/workflow/editor/workflow_template/react_native_expo_ios_cd_form.dart';
 import 'package:dashboard/workflow/editor/workflow_template/workflow_template.dart';
 import 'package:dashboard/workflow/workflow.dart';
 import 'package:flutter/material.dart';
@@ -67,10 +67,11 @@ class ChooseWorkflowTemplate extends HookConsumerWidget {
                     padding: const EdgeInsets.all(20.0),
                     child: InkWell(
                       onTap: () {
-                        if (template.name == 'react_native_cd_ios') {
-                          _showReactNativeIosCdForm(context);
-                        } else if (template.name == 'react_native_cd_android') {
-                          _showReactNativeAndroidCdForm(context);
+                        if (template.name == 'react_native_expo_cd_ios') {
+                          _showReactNativeExpoIosCdForm(context);
+                        } else if (template.name ==
+                            'react_native_expo_cd_android') {
+                          _showReactNativeExpoAndroidCdForm(context);
                         } else {
                           var script = 'echo "Hello World"';
                           if (template.name == 'set_version_ios_with_tag') {
@@ -130,22 +131,22 @@ npx -y react-native-version --never-amend
     );
   }
 
-  void _showReactNativeIosCdForm(BuildContext context) {
+  void _showReactNativeExpoIosCdForm(BuildContext context) {
     showModalBottomSheet(
       isScrollControlled: true,
       context: context,
       builder: (context) {
-        return ReactNativeIosCdForm(documentId: documentId);
+        return ReactNativeExpoIosCdForm(documentId: documentId);
       },
     );
   }
 
-  void _showReactNativeAndroidCdForm(BuildContext context) {
+  void _showReactNativeExpoAndroidCdForm(BuildContext context) {
     showModalBottomSheet(
       isScrollControlled: true,
       context: context,
       builder: (context) {
-        return ReactNativeAndroidCdForm(documentId: documentId);
+        return ReactNativeExpoAndroidCdForm(documentId: documentId);
       },
     );
   }

--- a/frontend/dashboard/lib/workflow/editor/workflow_template/react_native_expo_android_cd_form.dart
+++ b/frontend/dashboard/lib/workflow/editor/workflow_template/react_native_expo_android_cd_form.dart
@@ -12,8 +12,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
-class ReactNativeAndroidCdForm extends HookConsumerWidget {
-  const ReactNativeAndroidCdForm({
+class ReactNativeExpoAndroidCdForm extends HookConsumerWidget {
+  const ReactNativeExpoAndroidCdForm({
     super.key,
     required this.documentId,
   });
@@ -47,7 +47,7 @@ class ReactNativeAndroidCdForm extends HookConsumerWidget {
                 const SizedBox(width: 48),
                 Expanded(
                   child: Text(
-                    "React Native CD (Android)",
+                    "React Native (Expo) CD (Android)",
                     style: Theme.of(context).textTheme.titleLarge?.copyWith(
                       fontWeight: FontWeight.bold,
                     ),
@@ -363,10 +363,10 @@ class ReactNativeAndroidCdForm extends HookConsumerWidget {
   if (/signingConfigs \\{/) {
     print \$0
     print "        release {"
-    print "            storeFile file(project.findProperty(\\\"MYAPP_UPLOAD_STORE_FILE\\\") ?: \\\"release.keystore\\\")"
-    print "            storePassword project.findProperty(\\\"MYAPP_UPLOAD_STORE_PASSWORD\\\") ?: \\\"\\\""
-    print "            keyAlias project.findProperty(\\\"MYAPP_UPLOAD_KEY_ALIAS\\\") ?: \\\"\\\""
-    print "            keyPassword project.findProperty(\\\"MYAPP_UPLOAD_KEY_PASSWORD\\\") ?: \\\"\\\""
+    print "            storeFile file(project.findProperty(\\"MYAPP_UPLOAD_STORE_FILE\\") ?: \\"release.keystore\\")"
+    print "            storePassword project.findProperty(\\"MYAPP_UPLOAD_STORE_PASSWORD\\") ?: \\"\\""
+    print "            keyAlias project.findProperty(\\"MYAPP_UPLOAD_KEY_ALIAS\\") ?: \\"\\""
+    print "            keyPassword project.findProperty(\\"MYAPP_UPLOAD_KEY_PASSWORD\\") ?: \\"\\""
     print "        }"
     next
   }

--- a/frontend/dashboard/lib/workflow/editor/workflow_template/react_native_expo_ios_cd_form.dart
+++ b/frontend/dashboard/lib/workflow/editor/workflow_template/react_native_expo_ios_cd_form.dart
@@ -12,8 +12,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
-class ReactNativeIosCdForm extends HookConsumerWidget {
-  const ReactNativeIosCdForm({
+class ReactNativeExpoIosCdForm extends HookConsumerWidget {
+  const ReactNativeExpoIosCdForm({
     super.key,
     required this.documentId,
   });
@@ -41,7 +41,7 @@ class ReactNativeIosCdForm extends HookConsumerWidget {
                 const SizedBox(width: 48),
                 Expanded(
                   child: Text(
-                    "React Native CD (iOS)",
+                    "React Native (Expo) CD (iOS)",
                     style: Theme.of(context).textTheme.titleLarge?.copyWith(
                       fontWeight: FontWeight.bold,
                     ),

--- a/frontend/dashboard/lib/workflow/editor/workflow_template/workflow_template.dart
+++ b/frontend/dashboard/lib/workflow/editor/workflow_template/workflow_template.dart
@@ -9,12 +9,12 @@ const workflowTemplateList = [
     title: 'Write your code',
   ),
   WorkflowTemplate(
-    name: 'react_native_cd_ios',
-    title: 'React Native CD (iOS)',
+    name: 'react_native_expo_cd_ios',
+    title: 'React Native (Expo) CD (iOS)',
   ),
   WorkflowTemplate(
-    name: 'react_native_cd_android',
-    title: 'React Native CD (Android)',
+    name: 'react_native_expo_cd_android',
+    title: 'React Native (Expo) CD (Android)',
   ),
   WorkflowTemplate(
     name: 'set_version_ios_with_tag',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * React Native continuous deployment workflow templates now utilise Expo-based variants for both iOS and Android platforms, replacing previous standard implementations.
  * Updated workflow template naming and interface labels to clearly indicate Expo-based configurations, enhancing clarity when selecting from available workflow templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->