### PR TITLE
Fix: Tag push events incorrectly trigger push workflows (OP-740)

### DIFF
--- a/firebase/functions/src/github-app.ts
+++ b/firebase/functions/src/github-app.ts
@@ -58,8 +58,12 @@ export const githubApp = onRequest(
           await createBuildJobs(app, eventData);
         }
       } else if (event === "push") {
-        logger.info(`Push to ${body.ref}`, { structuredData: true });
-        await createBuildJobs(app, eventData);
+        if (body.ref.startsWith("refs/tags/")) {
+          logger.info(`Skipping push event for tag ${body.ref}`, { structuredData: true });
+        } else {
+          logger.info(`Push to ${body.ref}`, { structuredData: true });
+          await createBuildJobs(app, eventData);
+        }
       } else if (event === "create") {
         if (body.ref_type === "tag") {
           logger.info(`Tag created: ${body.ref}`, { structuredData: true });


### PR DESCRIPTION
## Summary

When a tag is pushed, GitHub sends both a `push` event and a `create` event. The previous code processed tag pushes as `push` events, causing:

1. `branch = payload.ref.replace("refs/heads/", "")` leaves `refs/tags/v1.0.0` as-is (invalid branch name)
2. Firestore query fails silently since no workflow matches `selectedTriggerBranch == "refs/tags/v1.0.0"`
3. If accidentally matched, push-trigger workflows would misfire on tag creation

## Fix

Skip push events where `ref` starts with `refs/tags/`. Tags are already handled by the `create` event handler.

Closes OP-740