### PR TITLE
feat: Add `tailscale-proxy` service to enable secure access to build machines and Lume instances via Tailscale.

### DIFF
--- a/services/tailscale-proxy/.dockerignore
+++ b/services/tailscale-proxy/.dockerignore
@@ -1,0 +1,6 @@
+.dart_tool/
+.git
+.gitignore
+pubspec.lock
+build/
+README.md

--- a/services/tailscale-proxy/.gitignore
+++ b/services/tailscale-proxy/.gitignore
@@ -1,0 +1,4 @@
+.dart_tool/
+pubspec.lock
+build/
+server

--- a/services/tailscale-proxy/Dockerfile
+++ b/services/tailscale-proxy/Dockerfile
@@ -1,0 +1,24 @@
+FROM dart:stable AS builder
+
+WORKDIR /app
+COPY pubspec.* ./
+RUN dart pub get
+COPY . .
+RUN dart compile exe bin/server.dart -o bin/server
+
+FROM alpine:latest
+
+RUN apk add --no-cache ca-certificates iptables gcompat
+
+COPY --from=docker.io/tailscale/tailscale:stable /usr/local/bin/tailscaled /app/tailscaled
+COPY --from=docker.io/tailscale/tailscale:stable /usr/local/bin/tailscale /app/tailscale
+RUN mkdir -p /var/run/tailscale /var/cache/tailscale /var/lib/tailscale
+
+COPY --from=builder /app/bin/server /app/server
+
+COPY start.sh /app/start.sh
+RUN chmod +x /app/start.sh
+
+ENV PORT=8080
+
+CMD ["/app/start.sh"]

--- a/services/tailscale-proxy/README.md
+++ b/services/tailscale-proxy/README.md
@@ -1,0 +1,54 @@
+# Tailscale Proxy (Cloud Run)
+
+Tailscale経由でビルドマシンのLume REST APIにアクセスするためのCloud Runプロキシサービス。
+Dart (Relic) + socks5_proxy で実装。
+
+## セットアップ
+
+### 1. Tailscale Auth Keyの生成
+
+[Tailscale Admin Console](https://login.tailscale.com/admin/settings/keys) で Ephemeral Auth Key を生成。
+
+### 2. GCP Secret Managerに保存
+
+```bash
+echo -n "tskey-auth-xxxxx" | gcloud secrets create tailscale-authkey --data-file=-
+```
+
+### 3. デプロイ
+
+```bash
+gcloud run deploy tailscale-proxy \
+  --source . \
+  --region us-central1 \
+  --project openci-dev-da298 \
+  --set-secrets=TAILSCALE_AUTHKEY=tailscale-authkey:latest \
+  --set-env-vars=PROXY_API_KEY=your-api-key \
+  --allow-unauthenticated=false \
+  --min-instances=0 \
+  --max-instances=3 \
+  --memory=512Mi \
+  --cpu=1
+```
+
+## 使い方
+
+```bash
+# ヘルスチェック
+curl https://<CLOUD_RUN_URL>/health
+
+# Lume APIにプロキシ（例: VMリスト取得）
+curl https://<CLOUD_RUN_URL>/proxy/vms \
+  -H "x-api-key: your-api-key" \
+  -H "x-target-url: http://<TAILSCALE_MACHINE_IP>:3000"
+```
+
+## 環境変数
+
+| 変数                | 説明                                              |
+| ------------------- | ------------------------------------------------- |
+| `TAILSCALE_AUTHKEY` | Tailscaleの認証キー（Secret Managerから注入）     |
+| `PROXY_API_KEY`     | プロキシへのアクセスを制限するAPIキー（任意）     |
+| `SOCKS_HOST`        | SOCKS5プロキシのホスト（デフォルト: `localhost`） |
+| `SOCKS_PORT`        | SOCKS5プロキシのポート（デフォルト: `1055`）      |
+| `PORT`              | サーバーポート（デフォルト: `8080`）              |

--- a/services/tailscale-proxy/bin/server.dart
+++ b/services/tailscale-proxy/bin/server.dart
@@ -1,0 +1,83 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:relic/relic.dart';
+import 'package:socks5_proxy/socks_client.dart';
+
+Future<void> main() async {
+  final port = int.tryParse(Platform.environment['PORT'] ?? '') ?? 8080;
+  final socksPort =
+      int.tryParse(Platform.environment['SOCKS_PORT'] ?? '') ?? 1055;
+
+  final httpClient = HttpClient();
+  SocksTCPClient.assignToHttpClient(httpClient, [
+    ProxySettings(InternetAddress.loopbackIPv4, socksPort),
+  ]);
+
+  final app =
+      RelicApp()
+        ..get('/health', (_) {
+          return Response.ok(
+            body: Body.fromString(jsonEncode({'status': 'ok'})),
+          );
+        })
+        ..get('/peers', (_) async {
+          final result = await Process.run('/app/tailscale', [
+            'status',
+            '--json',
+          ]);
+          if (result.exitCode != 0) {
+            return Response(500, body: Body.fromString('${result.stderr}'));
+          }
+
+          final status =
+              jsonDecode(result.stdout as String) as Map<String, dynamic>;
+          final peers = status['Peer'] as Map<String, dynamic>? ?? {};
+
+          final machines =
+              peers.values.map((peer) {
+                return {
+                  'hostname': peer['HostName'],
+                  'dns': peer['DNSName'],
+                  'ips': peer['TailscaleIPs'],
+                  'os': peer['OS'],
+                  'online': peer['Online'],
+                };
+              }).toList();
+
+          return Response.ok(body: Body.fromString(jsonEncode(machines)));
+        })
+        ..any('/lume/:ip/**', (Request req) async {
+          final ip = req.pathParameters.raw[#ip] ?? '';
+          final requestPath = req.url.path;
+          final match = RegExp(r'/lume/[^/]+/(.*)').firstMatch(requestPath);
+          final subpath = match?.group(1) ?? '';
+          final url = 'http://$ip:3000/$subpath';
+
+          try {
+            final proxyReq = await httpClient.openUrl(
+              req.method.name,
+              Uri.parse(url),
+            );
+
+            if (req.method != Method.get && req.method != Method.head) {
+              if (!req.isEmpty) {
+                proxyReq.add(utf8.encode(await req.readAsString()));
+              }
+            }
+
+            final proxyRes = await proxyReq.close();
+            final body = await proxyRes.transform(utf8.decoder).join();
+
+            return Response(proxyRes.statusCode, body: Body.fromString(body));
+          } catch (e) {
+            return Response(
+              502,
+              body: Body.fromString(jsonEncode({'error': '$e'})),
+            );
+          }
+        });
+
+  await app.serve(address: InternetAddress.anyIPv4, port: port);
+  stdout.writeln('Tailscale proxy listening on port $port');
+}

--- a/services/tailscale-proxy/pubspec.yaml
+++ b/services/tailscale-proxy/pubspec.yaml
@@ -1,0 +1,11 @@
+name: tailscale_proxy
+description: Cloud Run proxy service to access build machines via Tailscale.
+version: 1.0.0
+publish_to: none
+
+environment:
+  sdk: ^3.7.0
+
+dependencies:
+  relic: ^1.1.1
+  socks5_proxy: ^2.1.1

--- a/services/tailscale-proxy/start.sh
+++ b/services/tailscale-proxy/start.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+/app/tailscaled --tun=userspace-networking --socks5-server=localhost:1055 --port=41641 --statedir=/var/lib/tailscale &
+
+until /app/tailscale up --auth-key="${TAILSCALE_AUTHKEY}" --hostname=openci-proxy 2>&1; do
+  echo "Waiting for tailscale to come up..."
+  sleep 1
+done
+
+echo "Tailscale started"
+
+/app/server


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Tailscale Proxy service for Cloud Run deployment, enabling secure access to build machines via Tailscale integration.
  * Includes health check endpoint and peer status monitoring capabilities.
  * Supports HTTP request proxying to connected machines.

* **Documentation**
  * Added comprehensive setup and deployment guide covering authentication, GCP Secret Manager configuration, and usage examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->