### PR TITLE
feat: Configure CI to pass `REVENUE_CAT_WEB_API_KEY` as a build argument for web builds.

### DIFF
--- a/.openci/test-flutter-setup.yaml
+++ b/.openci/test-flutter-setup.yaml
@@ -32,5 +32,6 @@ jobs:
         with:
           platform: "web"
           working-directory: "apps/dashboard"
+          build-args: "--dart-define=REVENUE_CAT_WEB_API_KEY=${{ secrets.REVENUE_CAT_WEB_API_KEY }}"
           firebase-service-account: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
           preview: ${{ github.event_name == 'pull_request' }}

--- a/apps/dashboard/lib/revenue_cat/revenue_cat.dart
+++ b/apps/dashboard/lib/revenue_cat/revenue_cat.dart
@@ -2,10 +2,9 @@ import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:purchases_flutter/purchases_flutter.dart';
 
 Future<void> initializeRevenueCat() async {
-  final apiKey =
-      kIsWeb
-          ? const String.fromEnvironment('REVENUE_CAT_WEB_API_KEY')
-          : const String.fromEnvironment('REVENUE_CAT_API_KEY');
+  final apiKey = kIsWeb
+      ? const String.fromEnvironment('REVENUE_CAT_WEB_API_KEY')
+      : const String.fromEnvironment('REVENUE_CAT_API_KEY');
   if (apiKey.isEmpty) {
     throw StateError(
       'RevenueCat API key is not set. '


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded continuous integration configuration to securely handle and inject API credentials for web platform builds using environment secrets, strengthening deployment security.
* **Refactor**
  * Simplified API key initialisation logic to improve code clarity and maintainability without altering existing functionality or error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->