### PR TITLE
ci: Add step to save `GoogleService-Info.plist` for iOS builds.

### DIFF
--- a/.openci/test-flutter-ios.yaml
+++ b/.openci/test-flutter-ios.yaml
@@ -23,6 +23,11 @@ jobs:
           secret: ${{ secrets.FIREBASE_OPTIONS }}
           path: "apps/dashboard/lib/firebase_options.dart"
 
+      - uses: open-ci-io/save-secret-file@v1
+        with:
+          secret: ${{ secrets.GOOGLE_SERVICE_INFO_PLIST_IOS }}
+          path: "apps/dashboard/ios/Runner/GoogleService-Info.plist"
+
       - uses: open-ci-io/flutter-ci@v1
         with:
           test: "false"

--- a/.openci/test-flutter-ios.yaml
+++ b/.openci/test-flutter-ios.yaml
@@ -38,6 +38,7 @@ jobs:
           platform: "ios"
           working-directory: "apps/dashboard"
           build-number: ${{ env.OPENCI_RUN_NUMBER }}
+          build-args: "--dart-define=REVENUE_CAT_API_KEY=${{ secrets.REVENUE_CAT_API_KEY }}"
           certificate-private-key: ${{ secrets.OPENCI_CERTIFICATE_PRIVATE_KEY }}
           asc-key-id: ${{ secrets.OPENCI_ASC_KEY_ID }}
           asc-issuer-id: ${{ secrets.OPENCI_ASC_ISSUER_ID }}

--- a/.openci/test-flutter-ios.yaml
+++ b/.openci/test-flutter-ios.yaml
@@ -37,6 +37,7 @@ jobs:
         with:
           platform: "ios"
           working-directory: "apps/dashboard"
+          build-number: ${{ env.OPENCI_RUN_NUMBER }}
           certificate-private-key: ${{ secrets.OPENCI_CERTIFICATE_PRIVATE_KEY }}
           asc-key-id: ${{ secrets.OPENCI_ASC_KEY_ID }}
           asc-issuer-id: ${{ secrets.OPENCI_ASC_ISSUER_ID }}

--- a/.openci/test-flutter-setup.yaml
+++ b/.openci/test-flutter-setup.yaml
@@ -1,37 +1,37 @@
-# name: Flutter Web CI/CD
+name: Flutter Web CI/CD
 
-# on:
-#   push:
-#     branches:
-#       - develop
-#   pull_request:
-#     branches:
-#       - develop
+on:
+  push:
+    branches:
+      - develop
+  pull_request:
+    branches:
+      - develop
 
-# jobs:
-#   test-setup:
-#     runs-on: macos-latest
-#     steps:
-#       - uses: actions/checkout@v4
+jobs:
+  test-setup:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
 
-#       - uses: open-ci-io/flutter-setup@v1
-#         with:
-#           flutter-version: "stable"
+      - uses: open-ci-io/flutter-setup@v1
+        with:
+          flutter-version: "stable"
 
-#       - uses: open-ci-io/save-secret-file@v1
-#         with:
-#           secret: ${{ secrets.FIREBASE_OPTIONS }}
-#           path: "apps/dashboard/lib/firebase_options.dart"
+      - uses: open-ci-io/save-secret-file@v1
+        with:
+          secret: ${{ secrets.FIREBASE_OPTIONS }}
+          path: "apps/dashboard/lib/firebase_options.dart"
 
-#       - uses: open-ci-io/flutter-ci@v1
-#         with:
-#           test: "false"
-#           working-directory: "apps/dashboard"
+      - uses: open-ci-io/flutter-ci@v1
+        with:
+          test: "false"
+          working-directory: "apps/dashboard"
 
-#       - uses: open-ci-io/flutter-cd@v1
-#         with:
-#           platform: "web"
-#           working-directory: "apps/dashboard"
-#           build-args: "--dart-define=REVENUE_CAT_WEB_API_KEY=${{ secrets.REVENUE_CAT_WEB_API_KEY }}"
-#           firebase-service-account: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
-#           preview: ${{ github.event_name == 'pull_request' }}
+      - uses: open-ci-io/flutter-cd@v1
+        with:
+          platform: "web"
+          working-directory: "apps/dashboard"
+          build-args: "--dart-define=REVENUE_CAT_WEB_API_KEY=${{ secrets.REVENUE_CAT_WEB_API_KEY }}"
+          firebase-service-account: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
+          preview: ${{ github.event_name == 'pull_request' }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflow for iOS testing updated to persist the required iOS configuration file securely before running tests, improving reliability and reducing configuration-related failures.
  * iOS test job now records the CI build number during execution to aid traceability and diagnostics of test runs.
  * CI test/setup workflow activated and configured to run automatically on relevant branches and run the macOS test job, improving automated test coverage and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->