### PR TITLE
fix: resolve Row overflow in build logs detail and workflow list pages

### DIFF
--- a/apps/dashboard/lib/build_logs/build_logs_detail_page.dart
+++ b/apps/dashboard/lib/build_logs/build_logs_detail_page.dart
@@ -344,12 +344,16 @@ class _DetailGitChip extends StatelessWidget {
         children: [
           FaIcon(icon, size: 11, color: color),
           const SizedBox(width: 4),
-          Text(
-            label,
-            style: TextStyle(
-              fontSize: 12,
-              color: color,
-              fontWeight: FontWeight.w500,
+          Flexible(
+            child: Text(
+              label,
+              overflow: TextOverflow.ellipsis,
+              maxLines: 1,
+              style: TextStyle(
+                fontSize: 12,
+                color: color,
+                fontWeight: FontWeight.w500,
+              ),
             ),
           ),
         ],

--- a/apps/dashboard/lib/workflow/list/workflow_list_page.dart
+++ b/apps/dashboard/lib/workflow/list/workflow_list_page.dart
@@ -390,12 +390,16 @@ class _WorkflowBody extends ConsumerWidget {
                       padding: const EdgeInsets.only(top: 4),
                       child: Row(
                         children: [
-                          Text(
-                            file.name,
-                            style: TextStyle(
-                              color: Theme.of(
-                                context,
-                              ).colorScheme.onSurfaceVariant,
+                          Flexible(
+                            child: Text(
+                              file.name,
+                              overflow: TextOverflow.ellipsis,
+                              maxLines: 1,
+                              style: TextStyle(
+                                color: Theme.of(
+                                  context,
+                                ).colorScheme.onSurfaceVariant,
+                              ),
                             ),
                           ),
                           const SizedBox(width: 8),


### PR DESCRIPTION
## Summary
- `_DetailGitChip` (build_logs_detail_page.dart): 長いブランチ名がRowの幅を超えてオーバーフローしていた問題を修正。`Text` を `Flexible` でラップし `TextOverflow.ellipsis` を適用。
- Workflow list (workflow_list_page.dart): ファイル名テキストが長い場合にRowがオーバーフローしていた問題を修正。同様に `Flexible` + `TextOverflow.ellipsis` を適用。

## Test plan
- [ ] build_logs_detail_page で長いブランチ名（例: `openci/add-workflow-1775430383782`）が省略表示されることを確認
- [ ] workflow_list_page で長いファイル名が省略表示され、FilterChipが正常に表示されることを確認
- [ ] 短いブランチ名・ファイル名の場合に表示が変わらないことを確認


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正
* ビルドログ詳細ページのチップコンポーネントで、長いラベルテキストが表示領域を超える問題を修正しました。
* ワークフロー一覧ページのファイル名表示で、テキストのオーバーフローを防ぎ、省略記号で切り詰めるようにしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->