### PR TITLE
chore: migrate organization to openci-org and update worker installation to pub global activate

### DIFF
--- a/.agents/workflows/release-worker-cli.md
+++ b/.agents/workflows/release-worker-cli.md
@@ -98,7 +98,7 @@ Workers are now installed and updated via `dart pub global activate`:
 dart pub global activate openci_worker_cli
 
 # Run
-openci-worker --project-id=<ID> --service-account=<path>
+openci_worker --project-id=<ID> --service-account=<path>
 ```
 
 ## Worker Locations

--- a/.agents/workflows/release-worker-cli.md
+++ b/.agents/workflows/release-worker-cli.md
@@ -8,7 +8,7 @@ This workflow covers the full release process for `openci_worker_cli` via pub.de
 
 ## Prerequisites
 
-- Push access to `open-ci-io/openci`
+- Push access to `openci-org/openci`
 - Dart SDK installed
 - `PUB_CREDENTIALS` secret registered in GCP Secret Manager (already done)
 
@@ -98,7 +98,7 @@ Workers are now installed and updated via `dart pub global activate`:
 dart pub global activate openci_worker_cli
 
 # Run
-openci_worker_cli --project-id=<ID> --service-account=<path>
+openci-worker --project-id=<ID> --service-account=<path>
 ```
 
 ## Worker Locations

--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,5 @@
 
 # Build artifacts
 *.tar.gz
-apps/openci_worker_cli/openci-worker
+apps/openci_worker_cli/openci_worker
 apps/openci_vm_cli/openci-vm

--- a/apps/landing_page/lib/components/studio_about_content.dart
+++ b/apps/landing_page/lib/components/studio_about_content.dart
@@ -46,7 +46,7 @@ class StudioAboutContent extends StatelessComponent {
               const br(),
               Component.text('ご興味のある方は、'),
               a([Component.text('OpenCIのGitHub')],
-                  href: 'https://github.com/open-ci-io/openci',
+                  href: 'https://github.com/openci-org/openci',
                   target: Target.blank,
                   attributes: {'rel': 'noopener noreferrer'}),
               Component.text('をご覧ください。'),

--- a/apps/landing_page/lib/components/studio_footer.dart
+++ b/apps/landing_page/lib/components/studio_footer.dart
@@ -59,7 +59,7 @@ class StudioFooter extends StatelessComponent {
                   children: [
                     a(
                       [Component.text('GitHub')],
-                      href: 'https://github.com/open-ci-io',
+                      href: 'https://github.com/openci-org',
                       target: Target.blank,
                       attributes: {'rel': 'noopener noreferrer'},
                     ),

--- a/apps/landing_page/lib/layouts/cicd_layout.dart
+++ b/apps/landing_page/lib/layouts/cicd_layout.dart
@@ -40,7 +40,7 @@ class CicdLayout extends PageLayoutBase {
             ], href: '#pricing'),
             a(
               [Component.text('GitHub')],
-              href: 'https://github.com/open-ci-io/openci',
+              href: 'https://github.com/openci-org/openci',
               target: Target.blank,
               attributes: {'rel': 'noopener noreferrer'},
             ),
@@ -200,7 +200,7 @@ class CicdLayout extends PageLayoutBase {
             div(classes: 'footer-links', [
               a(
                 [Component.text('GitHub')],
-                href: 'https://github.com/open-ci-io/openci',
+                href: 'https://github.com/openci-org/openci',
                 target: Target.blank,
                 attributes: {'rel': 'noopener noreferrer'},
               ),

--- a/apps/openci_vm_cli/README.md
+++ b/apps/openci_vm_cli/README.md
@@ -3,9 +3,9 @@
 [![pub package](https://img.shields.io/pub/v/openci_vm_cli.svg)](https://pub.dev/packages/openci_vm_cli)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
-CLI tool that runs inside [OpenCI](https://openci.io) VMs to handle iOS code signing, building, and exporting IPAs.
+CLI tool that runs inside [OpenCI](https://openci.org) VMs to handle iOS code signing, building, and exporting IPAs.
 
-Part of the [OpenCI](https://github.com/open-ci-io/openci) open-source CI/CD platform.
+Part of the [OpenCI](https://github.com/openci-org/openci) open-source CI/CD platform.
 
 ## Installation
 

--- a/apps/openci_vm_cli/pubspec.yaml
+++ b/apps/openci_vm_cli/pubspec.yaml
@@ -1,8 +1,8 @@
 name: openci_vm_cli
 description: OpenCI VM CLI
 version: 1.0.12
-repository: https://github.com/open-ci-io/openci
-homepage: https://openci.io
+repository: https://github.com/openci-org/openci
+homepage: https://openci.org
 
 environment:
   sdk: 3.11.5

--- a/apps/openci_worker_cli/.pubignore
+++ b/apps/openci_worker_cli/.pubignore
@@ -1,6 +1,5 @@
 # Compiled binaries
 openci_worker
-openci-worker
 
 # Dev scripts
 update_version.dart

--- a/apps/openci_worker_cli/lib/args.dart
+++ b/apps/openci_worker_cli/lib/args.dart
@@ -35,6 +35,6 @@ ArgParser get argParser {
 }
 
 void printArgsUsage() {
-  print('Usage: openci-worker <flags> [arguments]');
+  print('Usage: openci_worker <flags> [arguments]');
   print(argParser.usage);
 }

--- a/apps/openci_worker_cli/lib/worker_config.dart
+++ b/apps/openci_worker_cli/lib/worker_config.dart
@@ -31,8 +31,7 @@ Future<WorkerConfig?> parseWorkerConfig(List<String> arguments) async {
   if (results.flag('update')) {
     _log.info('Updating openci-worker...');
     final shell = Shell(verbose: true);
-    await shell.run('brew update');
-    await shell.run('brew upgrade openci-worker');
+    await shell.run('dart pub global activate openci_worker_cli');
     _log.info('Updated successfully!');
     return null;
   }

--- a/apps/openci_worker_cli/lib/worker_config.dart
+++ b/apps/openci_worker_cli/lib/worker_config.dart
@@ -24,12 +24,12 @@ Future<WorkerConfig?> parseWorkerConfig(List<String> arguments) async {
   }
 
   if (results.flag('version')) {
-    _log.info('openci-worker version: $version');
+    _log.info('openci_worker version: $version');
     return null;
   }
 
   if (results.flag('update')) {
-    _log.info('Updating openci-worker...');
+    _log.info('Updating openci_worker...');
     final shell = Shell(verbose: true);
     await shell.run('dart pub global activate openci_worker_cli');
     _log.info('Updated successfully!');

--- a/apps/openci_worker_cli/pubspec.yaml
+++ b/apps/openci_worker_cli/pubspec.yaml
@@ -25,4 +25,4 @@ dev_dependencies:
   test: ^1.25.6
 
 executables:
-  openci_worker: openci_worker_cli
+  openci-worker: openci_worker_cli

--- a/apps/openci_worker_cli/pubspec.yaml
+++ b/apps/openci_worker_cli/pubspec.yaml
@@ -25,4 +25,4 @@ dev_dependencies:
   test: ^1.25.6
 
 executables:
-  openci-worker: openci_worker_cli
+  openci_worker: openci_worker_cli

--- a/apps/openci_worker_cli/pubspec.yaml
+++ b/apps/openci_worker_cli/pubspec.yaml
@@ -1,7 +1,7 @@
 name: openci_worker_cli
 description: OpenCI Worker CLI - A CI/CD worker for OpenCI
 version: 0.9.16
-repository: https://github.com/open-ci-io/openci
+repository: https://github.com/openci-org/openci
 
 environment:
   sdk: ^3.11.0

--- a/packages/openci_shared/pubspec.yaml
+++ b/packages/openci_shared/pubspec.yaml
@@ -1,7 +1,7 @@
 name: openci_shared
 description: Shared models and constants for OpenCI
 version: 0.1.1
-repository: https://github.com/open-ci-io/openci
+repository: https://github.com/openci-org/openci
 
 environment:
   sdk: ^3.11.0

--- a/setup.sh
+++ b/setup.sh
@@ -83,6 +83,12 @@ else
 fi
 
 # 7. Worker CLI
+if ! command -v dart &> /dev/null; then
+  echo "📦 Installing Dart SDK..."
+  brew tap dart-lang/dart
+  brew install dart
+fi
+
 if command -v openci-worker &> /dev/null; then
   echo "✅ openci-worker already installed"
 else

--- a/setup.sh
+++ b/setup.sh
@@ -85,11 +85,11 @@ else
 fi
 
 # 6. VM image
-if lume ls 2>/dev/null | grep -q "tahoe-base"; then
+if lume ls 2>/dev/null | grep -q "tahoe-base_v1.1.1"; then
   echo "✅ VM image already pulled"
 else
   echo "📦 Pulling VM image (this may take a while)..."
-  lume pull tahoe-base:v1.0.0 --organization openci-org
+  lume pull tahoe-base:v1.1.1 --organization openci-org
 fi
 
 # 7. Worker CLI

--- a/setup.sh
+++ b/setup.sh
@@ -31,12 +31,21 @@ else
 fi
 
 # 2. PATH setup
-if echo "$PATH" | grep -q "$HOME/.local/bin"; then
-  echo "✅ PATH already configured"
-else
-  echo "🔧 Configuring PATH..."
+NEED_PATH_UPDATE=false
+if ! echo "$PATH" | grep -q "$HOME/.local/bin"; then
+  NEED_PATH_UPDATE=true
   echo 'export PATH="$PATH":"$HOME/.local/bin"' >> ~/.zshrc
   export PATH="$PATH":"$HOME/.local/bin"
+fi
+if ! echo "$PATH" | grep -q "$HOME/.pub-cache/bin"; then
+  NEED_PATH_UPDATE=true
+  echo 'export PATH="$PATH":"$HOME/.pub-cache/bin"' >> ~/.zshrc
+  export PATH="$PATH":"$HOME/.pub-cache/bin"
+fi
+if [ "$NEED_PATH_UPDATE" = true ]; then
+  echo "🔧 PATH configured"
+else
+  echo "✅ PATH already configured"
 fi
 
 # 3. tmux

--- a/setup.sh
+++ b/setup.sh
@@ -6,7 +6,7 @@ SCRIPT_VERSION="1.0.0"
 NUM_WORKERS=${1:-2}
 SA_PATH=${2:-~/service-account.json}
 SESSION_NAME="openci-setup"
-REPO_BASE="https://raw.githubusercontent.com/open-ci-io/openci/develop"
+REPO_BASE="https://raw.githubusercontent.com/openci-org/openci/develop"
 INSTALL_DIR="$HOME/.openci"
 
 # 0. Download scripts to ~/.openci (always fetch latest)
@@ -79,7 +79,7 @@ if lume ls 2>/dev/null | grep -q "tahoe-base"; then
   echo "✅ VM image already pulled"
 else
   echo "📦 Pulling VM image (this may take a while)..."
-  lume pull tahoe-base:v1.0.0 --organization open-ci-io
+  lume pull tahoe-base:v1.0.0 --organization openci-org
 fi
 
 # 7. Worker CLI
@@ -87,8 +87,7 @@ if command -v openci-worker &> /dev/null; then
   echo "✅ openci-worker already installed"
 else
   echo "📦 Installing Worker CLI..."
-  brew tap open-ci-io/tap
-  brew install openci-worker
+  dart pub global activate openci_worker_cli
 fi
 
 echo ""

--- a/setup.sh
+++ b/setup.sh
@@ -37,10 +37,11 @@ if ! echo "$PATH" | grep -q "$HOME/.local/bin"; then
   echo 'export PATH="$PATH":"$HOME/.local/bin"' >> ~/.zshrc
   export PATH="$PATH":"$HOME/.local/bin"
 fi
-if ! echo "$PATH" | grep -q "$HOME/.pub-cache/bin"; then
+DART_PUB_CACHE_BIN="${PUB_CACHE:-$HOME/.pub-cache}/bin"
+if ! echo ":$PATH:" | grep -q ":$DART_PUB_CACHE_BIN:"; then
   NEED_PATH_UPDATE=true
-  echo 'export PATH="$PATH":"$HOME/.pub-cache/bin"' >> ~/.zshrc
-  export PATH="$PATH":"$HOME/.pub-cache/bin"
+  echo 'export PATH="$PATH":"${PUB_CACHE:-$HOME/.pub-cache}/bin"' >> ~/.zshrc
+  export PATH="$PATH:$DART_PUB_CACHE_BIN"
 fi
 if [ "$NEED_PATH_UPDATE" = true ]; then
   echo "🔧 PATH configured"
@@ -98,8 +99,8 @@ if ! command -v dart &> /dev/null; then
   brew install dart
 fi
 
-if command -v openci-worker &> /dev/null; then
-  echo "✅ openci-worker already installed"
+if command -v openci_worker &> /dev/null; then
+  echo "✅ openci_worker already installed"
 else
   echo "📦 Installing Worker CLI..."
   dart pub global activate openci_worker_cli
@@ -119,7 +120,7 @@ if [ -f "$SA_PATH_EXPANDED" ]; then
 
   tmux rename-session -t "$SESSION_NAME" "openci-workers" 2>/dev/null || true
 
-  WORKER_CMD='while true; do openci-worker --service-account '"$SA_PATH"' --worker-id WORKER_ID; echo "🔄 Worker exited. Restarting in 3s..."; sleep 3; done'
+  WORKER_CMD='while true; do openci_worker --service-account '"$SA_PATH"' --worker-id WORKER_ID; echo "🔄 Worker exited. Restarting in 3s..."; sleep 3; done'
 
   for ((i = 2; i <= NUM_WORKERS; i++)); do
     tmux split-window "$(echo "$WORKER_CMD" | sed "s/WORKER_ID/worker-$i/")"
@@ -127,7 +128,7 @@ if [ -f "$SA_PATH_EXPANDED" ]; then
   done
 
   while true; do
-    openci-worker --service-account "$SA_PATH_EXPANDED" --worker-id worker-1
+    openci_worker --service-account "$SA_PATH_EXPANDED" --worker-id worker-1
     echo "🔄 Worker exited. Restarting in 3s..."
     sleep 3
   done

--- a/start-workers.sh
+++ b/start-workers.sh
@@ -7,8 +7,9 @@ SA_PATH=${2:-~/service-account.json}
 SESSION_NAME="openci-workers"
 
 # Ensure dart pub global executables are on PATH
-if ! echo "$PATH" | grep -q "$HOME/.pub-cache/bin"; then
-  export PATH="$PATH":"$HOME/.pub-cache/bin"
+DART_PUB_CACHE_BIN="${PUB_CACHE:-$HOME/.pub-cache}/bin"
+if ! echo ":$PATH:" | grep -q ":$DART_PUB_CACHE_BIN:"; then
+  export PATH="$PATH:$DART_PUB_CACHE_BIN"
 fi
 
 if ! command -v tmux &> /dev/null; then
@@ -16,8 +17,8 @@ if ! command -v tmux &> /dev/null; then
   exit 1
 fi
 
-if ! command -v openci-worker &> /dev/null; then
-  echo "Error: openci-worker is not installed. Install it with:"
+if ! command -v openci_worker &> /dev/null; then
+  echo "Error: openci_worker is not installed. Install it with:"
   echo "  dart pub global activate openci_worker_cli"
   exit 1
 fi
@@ -27,7 +28,7 @@ if [ ! -f "$SA_PATH" ]; then
   exit 1
 fi
 
-WORKER_CMD='while true; do openci-worker --service-account '"$SA_PATH"' --worker-id WORKER_ID; echo "🔄 Worker exited. Restarting in 3s..."; sleep 3; done'
+WORKER_CMD='while true; do openci_worker --service-account '"$SA_PATH"' --worker-id WORKER_ID; echo "🔄 Worker exited. Restarting in 3s..."; sleep 3; done'
 
 tmux kill-session -t "$SESSION_NAME" 2>/dev/null
 

--- a/start-workers.sh
+++ b/start-workers.sh
@@ -6,6 +6,11 @@ NUM_WORKERS=${1:-2}
 SA_PATH=${2:-~/service-account.json}
 SESSION_NAME="openci-workers"
 
+# Ensure dart pub global executables are on PATH
+if ! echo "$PATH" | grep -q "$HOME/.pub-cache/bin"; then
+  export PATH="$PATH":"$HOME/.pub-cache/bin"
+fi
+
 if ! command -v tmux &> /dev/null; then
   echo "Error: tmux is not installed. Install it with: brew install tmux"
   exit 1

--- a/start-workers.sh
+++ b/start-workers.sh
@@ -13,7 +13,7 @@ fi
 
 if ! command -v openci-worker &> /dev/null; then
   echo "Error: openci-worker is not installed. Install it with:"
-  echo "  brew tap open-ci-io/tap && brew install openci-worker"
+  echo "  dart pub global activate openci_worker_cli"
   exit 1
 fi
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Chores**
  * GitHubリポジトリURLを `open-ci-io` から `openci-org` へ更新
  * ドメイン参照を `openci.io` から `openci.org` へ更新
  * 複数パッケージのメタデータを更新（リポジトリ／ホームページURL）

* **Documentation**
  * READMEやワークフロー内のハイパーリンクを更新

* **Refactor**
  * Worker CLIのインストール方法をHomebrewからDartグローバル活性化へ変更
  * CLI実行名を一部でハイフン表記へ調整
<!-- end of auto-generated comment: release notes by coderabbit.ai -->