### PR TITLE
feat: add localized sign-in subtitle for authentication page

### DIFF
--- a/apps/dashboard/lib/auth/auth_page.dart
+++ b/apps/dashboard/lib/auth/auth_page.dart
@@ -125,7 +125,7 @@ class AuthPage extends HookConsumerWidget {
                           ),
                           const SizedBox(height: 6),
                           Text(
-                            'Sign in to your account',
+                            authT.signInSubtitle,
                             style: Theme.of(context).textTheme.bodyMedium
                                 ?.copyWith(
                                   color: AppColors.of(context).textSecondary,

--- a/apps/dashboard/lib/i18n/en.i18n.json
+++ b/apps/dashboard/lib/i18n/en.i18n.json
@@ -41,6 +41,7 @@
     "settings": "Settings"
   },
   "auth": {
+    "signInSubtitle": "Sign in to your account",
     "email": "Email",
     "password": "Password",
     "login": "Log in",

--- a/apps/dashboard/lib/i18n/es.i18n.json
+++ b/apps/dashboard/lib/i18n/es.i18n.json
@@ -41,6 +41,7 @@
     "settings": "Configuración"
   },
   "auth": {
+    "signInSubtitle": "Inicia sesión en tu cuenta",
     "email": "Correo electrónico",
     "password": "Contraseña",
     "login": "Iniciar sesión",

--- a/apps/dashboard/lib/i18n/ja.i18n.json
+++ b/apps/dashboard/lib/i18n/ja.i18n.json
@@ -41,6 +41,7 @@
     "settings": "設定"
   },
   "auth": {
+    "signInSubtitle": "アカウントにサインイン",
     "email": "メールアドレス",
     "password": "パスワード",
     "login": "ログイン",

--- a/apps/dashboard/lib/i18n/strings.g.dart
+++ b/apps/dashboard/lib/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 3
-/// Strings: 1341 (447 per locale)
+/// Strings: 1344 (448 per locale)
 ///
-/// Built on 2026-04-29 at 07:03 UTC
+/// Built on 2026-04-30 at 05:40 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/apps/dashboard/lib/i18n/strings_en.g.dart
+++ b/apps/dashboard/lib/i18n/strings_en.g.dart
@@ -155,6 +155,9 @@ class TranslationsAuthEn {
 
 	// Translations
 
+	/// en: 'Sign in to your account'
+	String get signInSubtitle => 'Sign in to your account';
+
 	/// en: 'Email'
 	String get email => 'Email';
 
@@ -1720,6 +1723,7 @@ extension on Translations {
 			'nav.logs' => 'Logs',
 			'nav.release' => 'Release',
 			'nav.settings' => 'Settings',
+			'auth.signInSubtitle' => 'Sign in to your account',
 			'auth.email' => 'Email',
 			'auth.password' => 'Password',
 			'auth.login' => 'Log in',

--- a/apps/dashboard/lib/i18n/strings_es.g.dart
+++ b/apps/dashboard/lib/i18n/strings_es.g.dart
@@ -110,6 +110,7 @@ class _TranslationsAuthEs implements TranslationsAuthEn {
 	final TranslationsEs _root; // ignore: unused_field
 
 	// Translations
+	@override String get signInSubtitle => 'Inicia sesión en tu cuenta';
 	@override String get email => 'Correo electrónico';
 	@override String get password => 'Contraseña';
 	@override String get login => 'Iniciar sesión';
@@ -817,6 +818,7 @@ extension on TranslationsEs {
 			'nav.logs' => 'Registros',
 			'nav.release' => 'Lanzamiento',
 			'nav.settings' => 'Configuración',
+			'auth.signInSubtitle' => 'Inicia sesión en tu cuenta',
 			'auth.email' => 'Correo electrónico',
 			'auth.password' => 'Contraseña',
 			'auth.login' => 'Iniciar sesión',

--- a/apps/dashboard/lib/i18n/strings_ja.g.dart
+++ b/apps/dashboard/lib/i18n/strings_ja.g.dart
@@ -110,6 +110,7 @@ class _TranslationsAuthJa implements TranslationsAuthEn {
 	final TranslationsJa _root; // ignore: unused_field
 
 	// Translations
+	@override String get signInSubtitle => 'アカウントにサインイン';
 	@override String get email => 'メールアドレス';
 	@override String get password => 'パスワード';
 	@override String get login => 'ログイン';
@@ -817,6 +818,7 @@ extension on TranslationsJa {
 			'nav.logs' => 'ログ',
 			'nav.release' => 'リリース',
 			'nav.settings' => '設定',
+			'auth.signInSubtitle' => 'アカウントにサインイン',
 			'auth.email' => 'メールアドレス',
 			'auth.password' => 'パスワード',
 			'auth.login' => 'ログイン',


### PR DESCRIPTION
- Introduced a new translation key `signInSubtitle` for the sign-in prompt in English, Spanish, and Japanese.
- Updated the `AuthPage` to utilize the localized subtitle, enhancing the user experience across different languages.
- Adjusted related internationalization files to include the new subtitle, ensuring consistency in the UI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ダッシュボードのサインインページの字幕が複数言語に対応しました。英語、スペイン語、日本語での表示が可能になりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->