### PR TITLE
feat: improve issue display and sorting in the board column

### DIFF
--- a/apps/ima/lib/main.dart
+++ b/apps/ima/lib/main.dart
@@ -763,16 +763,12 @@ class _IssueBoardPageState extends State<IssueBoardPage> {
       return;
     }
 
-    final doneColumn = _columns.firstWhere(
-      (column) => column.id == _closedStatusId,
-    );
-
     setState(() => _closingIssueIds.add(issueId));
     try {
       await _moveIssue(
         issueId: issueId,
         targetColumnId: _closedStatusId,
-        targetIndex: doneColumn.issues.length,
+        targetIndex: 0,
       );
       _showSavedSnackBar('Closed');
     } catch (error) {
@@ -2411,6 +2407,8 @@ class BoardColumnView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final visibleIssues = _visibleIssuesForColumn(column);
+
     return DragTarget<IssueDragData>(
       onWillAcceptWithDetails: (details) =>
           details.data.sourceColumnId != column.id,
@@ -2451,7 +2449,7 @@ class BoardColumnView extends StatelessWidget {
                 child: ListView(
                   padding: EdgeInsets.zero,
                   children: [
-                    if (column.issues.isEmpty) ...[
+                    if (visibleIssues.isEmpty) ...[
                       EmptyColumnIssueCreator(
                         columnTitle: column.title,
                         onPressed: () => onAddIssue(column.id),
@@ -2460,20 +2458,26 @@ class BoardColumnView extends StatelessWidget {
                     ],
                     for (
                       var index = 0;
-                      index < column.issues.length;
+                      index < visibleIssues.length;
                       index++
                     ) ...[
-                      IssueCardDropTarget(
-                        issue: column.issues[index],
-                        sourceColumnId: column.id,
-                        index: index,
-                        isClosing: closingIssueIds.contains(
-                          column.issues[index].id,
-                        ),
-                        onTap: () => onIssueTapped(column.issues[index].id),
-                        onCloseIssue: () =>
-                            onIssueClosed(column.issues[index].id),
-                        onIssueDropped: onIssueDropped,
+                      Builder(
+                        builder: (context) {
+                          final issue = visibleIssues[index];
+                          final rankIndex = column.issues.indexWhere(
+                            (candidate) => candidate.id == issue.id,
+                          );
+
+                          return IssueCardDropTarget(
+                            issue: issue,
+                            sourceColumnId: column.id,
+                            index: rankIndex < 0 ? index : rankIndex,
+                            isClosing: closingIssueIds.contains(issue.id),
+                            onTap: () => onIssueTapped(issue.id),
+                            onCloseIssue: () => onIssueClosed(issue.id),
+                            onIssueDropped: onIssueDropped,
+                          );
+                        },
                       ),
                       const SizedBox(height: 8),
                     ],
@@ -2492,6 +2496,28 @@ class BoardColumnView extends StatelessWidget {
       },
     );
   }
+}
+
+List<Issue> _visibleIssuesForColumn(BoardColumn column) {
+  if (column.id != _closedStatusId) {
+    return column.issues;
+  }
+
+  return [...column.issues]..sort(_compareDoneIssues);
+}
+
+int _compareDoneIssues(Issue left, Issue right) {
+  final leftClosedAt = left.closedAt;
+  final rightClosedAt = right.closedAt;
+
+  if (leftClosedAt != null && rightClosedAt != null) {
+    final closedAtComparison = rightClosedAt.compareTo(leftClosedAt);
+    if (closedAtComparison != 0) {
+      return closedAtComparison;
+    }
+  }
+
+  return left.rank.compareTo(right.rank);
 }
 
 class ColumnHeader extends StatelessWidget {
@@ -3641,6 +3667,7 @@ class Issue {
     this.dueDate,
     this.statusId = 'triage',
     this.rank = 0,
+    this.closedAt,
     this.weightEstimate,
     this.pullRequests = const [],
   }) : displayId = displayId ?? issueKey ?? id;
@@ -3671,6 +3698,7 @@ class Issue {
       dueDate: _asDate(data['dueDate']),
       statusId: _asString(data['statusId'], 'triage'),
       rank: _asDouble(data['rank']),
+      closedAt: _asDate(data['closedAt']),
       weightEstimate: IssueWeightEstimate.fromMap(
         _asMap(data['weightEstimate']),
       ),
@@ -3695,6 +3723,7 @@ class Issue {
   final DateTime? dueDate;
   final String statusId;
   final double rank;
+  final DateTime? closedAt;
   final IssueWeightEstimate? weightEstimate;
   final List<IssuePullRequest> pullRequests;
 }

--- a/apps/ima/test/widget_test.dart
+++ b/apps/ima/test/widget_test.dart
@@ -212,6 +212,66 @@ void main() {
     expect(targetColumnId, 'review');
   });
 
+  testWidgets('Done board column shows latest closed issue first', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: BoardColumnView(
+            column: BoardColumn(
+              id: 'done',
+              title: 'Done',
+              description: '今週完了',
+              color: Colors.green,
+              issues: [
+                Issue(
+                  id: 'old',
+                  repo: 'openci/ima',
+                  title: 'Old closed issue',
+                  assignee: 'MF',
+                  labels: const ['done'],
+                  comments: 0,
+                  priority: Priority.low,
+                  statusId: 'done',
+                  rank: 1000,
+                  closedAt: DateTime(2026, 5, 1),
+                ),
+                Issue(
+                  id: 'new',
+                  repo: 'openci/ima',
+                  title: 'New closed issue',
+                  assignee: 'MF',
+                  labels: const ['done'],
+                  comments: 0,
+                  priority: Priority.low,
+                  statusId: 'done',
+                  rank: 2000,
+                  closedAt: DateTime(2026, 5, 2),
+                ),
+              ],
+            ),
+            closingIssueIds: const <String>{},
+            onIssueDropped:
+                ({
+                  required issueId,
+                  required targetColumnId,
+                  required targetIndex,
+                }) {},
+            onAddIssue: (_) {},
+            onIssueTapped: (_) {},
+            onIssueClosed: (_) {},
+          ),
+        ),
+      ),
+    );
+
+    expect(
+      tester.getTopLeft(find.text('New closed issue')).dy,
+      lessThan(tester.getTopLeft(find.text('Old closed issue')).dy),
+    );
+  });
+
   testWidgets('Edit issue dialog can return close action', (tester) async {
     Object? dialogResult;
     final columns = [


### PR DESCRIPTION
- Updated the issue closing functionality to move closed issues to the top of the 'Done' column, enhancing visibility of the latest closed issues.
- Refactored the issue rendering logic in the `BoardColumnView` to utilize a new method for filtering visible issues, ensuring that closed issues are sorted by their closure date.
- Added a new `closedAt` field to the `Issue` model to track the closure date of issues, facilitating the sorting mechanism.
- Enhanced widget tests to verify that the 'Done' column displays the latest closed issue first, improving the user experience in issue management.

These changes streamline the issue management process by providing clearer visibility of recently closed issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * Done列でクローズされたIssueが、クローズ日時の新しい順（降順）で表示されるようになりました。最近完了したIssueが列の上部に表示されます。

* **改善**
  * Issue完了時に、完了したIssueが完了列の最上位に配置されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- ima-linked-issue:start -->
Fixes #1590
Ima: IMA-138
<!-- ima-linked-issue:end -->