### PR TITLE
feat(ima): タイトル下のTextを削除

### DIFF
--- a/apps/ima/lib/main.dart
+++ b/apps/ima/lib/main.dart
@@ -1335,10 +1335,6 @@ class BoardHeader extends StatelessWidget {
               (isCompact ? textTheme.headlineSmall : textTheme.headlineMedium)
                   ?.copyWith(fontWeight: FontWeight.w700, letterSpacing: -0.8),
         );
-        final description = Text(
-          '複数repoのGitHub Issuesを同期して、macOSとiOSで軽く扱うためのKanbanプロトタイプ。',
-          style: textTheme.bodyMedium?.copyWith(color: const Color(0xFF64748B)),
-        );
 
         if (isCompact) {
           return Padding(
@@ -1352,12 +1348,7 @@ class BoardHeader extends StatelessWidget {
           child: Row(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [title, const SizedBox(height: 6), description],
-                ),
-              ),
+              Expanded(child: title),
               const SizedBox(width: 16),
               Column(
                 crossAxisAlignment: CrossAxisAlignment.end,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`BoardHeader` ウィジェットのタイトル「イマ」の下に表示されていた説明テキスト（`複数repoのGitHub Issuesを同期して、macOSとiOSで軽く扱うためのKanbanプロトタイプ。`）を削除しました。使われていないため不要です。

## Changes

- `apps/ima/lib/main.dart`: `BoardHeader.build()` から `description` Text ウィジェットおよび関連する `SizedBox` と `Column` ラッパーを削除し、タイトルのみを表示するようにシンプル化しました。

Closes https://github.com/openci-org/openci/issues/1600
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-361350d6-85e9-4654-9a6a-219c483e23ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-361350d6-85e9-4654-9a6a-219c483e23ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **UI改善**
  * ボードヘッダーの非コンパクトレイアウトが簡素化されました。左側のコンテンツがタイトルのみの表示に変更され、説明文が削除されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- ima-linked-issue:start -->
Fixes #1600
Ima: IMA-145
<!-- ima-linked-issue:end -->