### PR TITLE
feat: remove All priorities chip IMA-153

### DIFF
--- a/apps/ima/lib/main.dart
+++ b/apps/ima/lib/main.dart
@@ -1500,10 +1500,6 @@ class BoardToolbar extends StatelessWidget {
                     ? 'Not imported'
                     : 'Imported ${_formatDate(lastImportedAt!)}',
               ),
-              const ToolbarChip(
-                icon: Icons.filter_alt_outlined,
-                label: 'All priorities',
-              ),
               ToolbarChip(
                 icon: Icons.search_outlined,
                 label: 'Search issues',
@@ -1607,13 +1603,6 @@ class CompactBoardMenuButton extends StatelessWidget {
             label: lastImportedAt == null
                 ? 'Not imported'
                 : 'Imported ${_formatDate(lastImportedAt!)}',
-          ),
-        ),
-        const PopupMenuItem(
-          enabled: false,
-          child: _CompactMenuItem(
-            icon: Icons.filter_alt_outlined,
-            label: 'All priorities',
           ),
         ),
         const PopupMenuItem(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Remove the "All priorities" chip from the IMA mobile app UI.

Closes https://github.com/openci-org/openci/issues/1614

## Changes

- Removed the static `ToolbarChip` displaying "All priorities" from the wide `BoardToolbar` layout
- Removed the disabled `PopupMenuItem` displaying "All priorities" from the `CompactBoardMenuButton` menu

Both instances were non-interactive (no `onPressed` / `enabled: false`) placeholder elements. No functional logic is affected by this removal.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dbb4aa51-6a73-4f7a-8f7f-d3c8d44cb322"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dbb4aa51-6a73-4f7a-8f7f-d3c8d44cb322"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * インポートステータス表示を追加しました。ツールバーに最終インポート日時が表示されるようになり、未インポート時は「未インポート」、インポート済み時は「インポート済み＜日付＞」と表示されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- ima-linked-issue:start -->
Fixes #1614
Ima: IMA-153
<!-- ima-linked-issue:end -->