### PR TITLE
feat(ima): remove Imported chip IMA-155

### DIFF
--- a/apps/ima/lib/main.dart
+++ b/apps/ima/lib/main.dart
@@ -393,7 +393,6 @@ class _IssueBoardPageState extends State<IssueBoardPage> {
   String? _githubLogin;
   String? _loadError;
   int _enabledRepoCount = 0;
-  Timestamp? _lastImportedAt;
   Set<String> _enabledRepoFullNames = {};
   final Set<String> _closingIssueIds = {};
   final Set<String> _estimatingIssueIds = {};
@@ -585,15 +584,6 @@ class _IssueBoardPageState extends State<IssueBoardPage> {
     final enabledDocs = snapshot.docs
         .where((doc) => doc.data()['enabled'] == true)
         .toList();
-    final lastImportedAt = enabledDocs
-        .map((doc) => doc.data()['lastImportedAt'])
-        .whereType<Timestamp>()
-        .fold<Timestamp?>(null, (latest, current) {
-          if (latest == null || current.compareTo(latest) > 0) {
-            return current;
-          }
-          return latest;
-        });
 
     if (!mounted) {
       return;
@@ -604,7 +594,6 @@ class _IssueBoardPageState extends State<IssueBoardPage> {
       _enabledRepoFullNames = {
         for (final doc in enabledDocs) _asString(doc.data()['fullName']),
       }..remove('');
-      _lastImportedAt = lastImportedAt;
     });
   }
 
@@ -1178,7 +1167,6 @@ class _IssueBoardPageState extends State<IssueBoardPage> {
                     isConnected: isConnected,
                     isBusy: _isBusy,
                     repoCount: _enabledRepoCount,
-                    lastImportedAt: _lastImportedAt?.toDate(),
                     onConnectGitHub: _connectGitHub,
                     onSelectRepositories: _selectRepositories,
                     onImportIssues: _importGitHubIssues,
@@ -1211,7 +1199,6 @@ class _IssueBoardPageState extends State<IssueBoardPage> {
                 onSearchIssues: _openIssueSearchDialog,
                 githubLogin: _githubLogin,
                 repoCount: _enabledRepoCount,
-                lastImportedAt: _lastImportedAt?.toDate(),
                 isBusy: _isBusy,
               ),
               if (_loadError != null)
@@ -1442,7 +1429,6 @@ class BoardToolbar extends StatelessWidget {
     required this.onSearchIssues,
     required this.githubLogin,
     required this.repoCount,
-    required this.lastImportedAt,
     required this.isBusy,
   });
 
@@ -1453,7 +1439,6 @@ class BoardToolbar extends StatelessWidget {
   final VoidCallback onSearchIssues;
   final String? githubLogin;
   final int repoCount;
-  final DateTime? lastImportedAt;
   final bool isBusy;
 
   @override
@@ -1495,12 +1480,6 @@ class BoardToolbar extends StatelessWidget {
                 label: const Text('Sync pending'),
               ),
               ToolbarChip(
-                icon: Icons.history_rounded,
-                label: lastImportedAt == null
-                    ? 'Not imported'
-                    : 'Imported ${_formatDate(lastImportedAt!)}',
-              ),
-              ToolbarChip(
                 icon: Icons.search_outlined,
                 label: 'Search issues',
                 tooltip: 'Search issues (⌘K)',
@@ -1520,7 +1499,6 @@ class CompactBoardMenuButton extends StatelessWidget {
     required this.isConnected,
     required this.isBusy,
     required this.repoCount,
-    required this.lastImportedAt,
     required this.onConnectGitHub,
     required this.onSelectRepositories,
     required this.onImportIssues,
@@ -1532,7 +1510,6 @@ class CompactBoardMenuButton extends StatelessWidget {
   final bool isConnected;
   final bool isBusy;
   final int repoCount;
-  final DateTime? lastImportedAt;
   final VoidCallback onConnectGitHub;
   final VoidCallback onSelectRepositories;
   final VoidCallback onImportIssues;
@@ -1596,15 +1573,6 @@ class CompactBoardMenuButton extends StatelessWidget {
           ),
         ),
         const PopupMenuDivider(),
-        PopupMenuItem(
-          enabled: false,
-          child: _CompactMenuItem(
-            icon: Icons.history_rounded,
-            label: lastImportedAt == null
-                ? 'Not imported'
-                : 'Imported ${_formatDate(lastImportedAt!)}',
-          ),
-        ),
         const PopupMenuItem(
           value: 'search',
           child: _CompactMenuItem(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Remove the "Imported" chip from the IMA board toolbar.

The chip displayed either "Not imported" or "Imported {date}" showing the last import timestamp. Per issue request, this chip is no longer needed.

## Changes

- Removed the `ToolbarChip` showing import status from `BoardToolbar` (wide layout)
- Removed the corresponding disabled `PopupMenuItem` from `CompactBoardMenuButton` (compact layout)
- Removed the `lastImportedAt` parameter from both `BoardToolbar` and `CompactBoardMenuButton` widget classes
- Removed the `_lastImportedAt` state field and its computation logic in `_replaceRepositories`

## Related

Closes https://github.com/openci-org/openci/issues/1617
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6ad3b69f-c098-4523-b359-ac599e7b8aeb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6ad3b69f-c098-4523-b359-ac599e7b8aeb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * インポート日時の表示機能を削除しました。ボード画面のツールバーに表示されていた「未インポート/インポート日時」の表記とメニュー内のインポート履歴の表示が削除されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- ima-linked-issue:start -->
Fixes #1617
Ima: IMA-155
<!-- ima-linked-issue:end -->