### PR TITLE
fix(worker): add exponential backoff to poll loop to prevent port exhaustion

### DIFF
--- a/.openci/worker-cli-ci-cd.yaml
+++ b/.openci/worker-cli-ci-cd.yaml
@@ -27,8 +27,12 @@ jobs:
 
       - name: Install dependencies
         run: |
-          vp install
+          vp i
           git restore package.json package-lock.json
+
+      - name: Install build_job_services dependencies
+        working-directory: packages/build_job_services
+        run: vp i
 
       - name: Check
         run: vp check

--- a/.openci/worker-cli-ci-cd.yaml
+++ b/.openci/worker-cli-ci-cd.yaml
@@ -1,0 +1,46 @@
+name: Worker CLI CI
+
+on:
+  push:
+    branches:
+      - develop
+
+  pull_request:
+    branches:
+      - develop
+
+defaults:
+  run:
+    working-directory: apps/worker_cli_node
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: voidzero-dev/setup-vp@v1
+        with:
+          node-version: "22"
+          working-directory: apps/worker_cli_node
+          run-install: false
+
+      - name: Install dependencies
+        run: |
+          vp install
+          git restore package.json package-lock.json
+
+      - name: Check
+        run: vp check
+
+      - name: Lint
+        run: vp lint
+
+      - name: Format check
+        run: vp fmt --check
+
+      - name: Test
+        run: vp test
+
+      - name: Build
+        run: npm run build

--- a/apps/worker_cli_node/package-lock.json
+++ b/apps/worker_cli_node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openci-worker-cli",
-  "version": "0.1.22",
+  "version": "0.1.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openci-worker-cli",
-      "version": "0.1.22",
+      "version": "0.1.24",
       "license": "Apache-2.0",
       "dependencies": {
         "@google-cloud/secret-manager": "^6.1.1",

--- a/apps/worker_cli_node/package.json
+++ b/apps/worker_cli_node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openci-worker-cli",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "description": "OpenCI Worker CLI",
   "license": "Apache-2.0",
   "repository": {

--- a/apps/worker_cli_node/package.json
+++ b/apps/worker_cli_node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openci-worker-cli",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "description": "OpenCI Worker CLI",
   "license": "Apache-2.0",
   "repository": {

--- a/apps/worker_cli_node/src/index.ts
+++ b/apps/worker_cli_node/src/index.ts
@@ -2,7 +2,7 @@
 
 import { parseConfig } from "./config.js";
 import { initFirebase } from "./dataconnect.js";
-import { pollForJobs } from "./worker.js";
+import { pollForJobs } from "./worker/worker.js";
 
 async function main(): Promise<void> {
   const config = parseConfig(process.argv.slice(2));

--- a/apps/worker_cli_node/src/worker.ts
+++ b/apps/worker_cli_node/src/worker.ts
@@ -91,6 +91,13 @@ export async function processOneJob(config: WorkerConfig): Promise<boolean> {
   return true;
 }
 
+const maxBackoffMs = 5 * 60_000;
+
+function backoffMs(base: number, consecutiveFailures: number): number {
+  const delay = base * 2 ** Math.min(consecutiveFailures, 10);
+  return Math.min(delay, maxBackoffMs);
+}
+
 export async function pollForJobs(config: WorkerConfig): Promise<void> {
   console.log(`Worker started. Worker ID: ${config.workerId}`);
   console.log(`Worker version: ${version}`);
@@ -99,6 +106,7 @@ export async function pollForJobs(config: WorkerConfig): Promise<void> {
   );
 
   let lastUpdateCheckAt = 0;
+  let consecutiveFailures = 0;
   while (true) {
     try {
       if (!config.once && Date.now() - lastUpdateCheckAt > 60_000) {
@@ -106,20 +114,26 @@ export async function pollForJobs(config: WorkerConfig): Promise<void> {
         const updateResult = await checkAndUpdate();
         if (updateResult === "updated") exitForUpdate();
         if (updateResult === "failed") {
-          await new Promise((resolve) => setTimeout(resolve, config.pollIntervalMs));
+          consecutiveFailures += 1;
+          const delay = backoffMs(config.pollIntervalMs, consecutiveFailures);
+          console.warn(`Backing off for ${(delay / 1000).toFixed(0)}s (${consecutiveFailures} consecutive failures)`);
+          await new Promise((resolve) => setTimeout(resolve, delay));
           continue;
         }
       }
 
       const found = await processOneJob(config);
+      consecutiveFailures = 0;
       if (config.once) return;
       if (!found) {
         await new Promise((resolve) => setTimeout(resolve, config.pollIntervalMs));
       }
     } catch (error) {
-      console.error(`Error in poll loop: ${String(error)}`);
+      consecutiveFailures += 1;
+      const delay = backoffMs(config.pollIntervalMs, consecutiveFailures);
+      console.error(`Error in poll loop (${consecutiveFailures} consecutive failures, next retry in ${(delay / 1000).toFixed(0)}s): ${String(error)}`);
       if (config.once) throw error;
-      await new Promise((resolve) => setTimeout(resolve, config.pollIntervalMs));
+      await new Promise((resolve) => setTimeout(resolve, delay));
     }
   }
 }

--- a/apps/worker_cli_node/src/worker/backoff.test.ts
+++ b/apps/worker_cli_node/src/worker/backoff.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { backoffMilliSeconds } from "./backoff.js";
+
+describe("backoffMilliSeconds", () => {
+  it("returns 10s when consecutiveFailures is 0", () => {
+    expect(backoffMilliSeconds(0)).toBe(10_000);
+  });
+
+  it("doubles on each consecutive failure", () => {
+    expect(backoffMilliSeconds(1)).toBe(20_000);
+    expect(backoffMilliSeconds(2)).toBe(40_000);
+    expect(backoffMilliSeconds(3)).toBe(80_000);
+    expect(backoffMilliSeconds(4)).toBe(160_000);
+  });
+
+  it("caps at 5 minutes", () => {
+    const fiveMinutes = 5 * 60_000;
+    expect(backoffMilliSeconds(5)).toBe(fiveMinutes);
+    expect(backoffMilliSeconds(6)).toBe(fiveMinutes);
+    expect(backoffMilliSeconds(100)).toBe(fiveMinutes);
+  });
+});

--- a/apps/worker_cli_node/src/worker/backoff.ts
+++ b/apps/worker_cli_node/src/worker/backoff.ts
@@ -1,0 +1,7 @@
+const baseMilliSeconds = 10_000;
+const maxBackoffMilliSeconds = 5 * 60_000;
+
+export function backoffMilliSeconds(consecutiveFailures: number): number {
+  const delay = baseMilliSeconds * 2 ** Math.min(consecutiveFailures, 10);
+  return Math.min(delay, maxBackoffMilliSeconds);
+}

--- a/apps/worker_cli_node/src/worker/worker.ts
+++ b/apps/worker_cli_node/src/worker/worker.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { setTimeout } from "node:timers/promises";
 
 import {
   generateFailureSummary,
@@ -6,14 +7,15 @@ import {
   updateCheckRun,
 } from "@openci/build-job-services";
 import { BuildJobStatus } from "@openci/dataconnect-admin";
-import { claimNextJob, completeJob, createRun, updateRunStatus } from "./dataconnect.js";
-import { checkAndUpdate, exitForUpdate } from "./auto_updater.js";
-import { buildEnvVars, buildSecretVars } from "./env.js";
-import { withInstallationToken } from "./github.js";
-import { flushLogs, logError, logInfo } from "./logger.js";
-import { runBuildJob } from "./runner.js";
-import type { WorkerConfig } from "./types.js";
-import { version } from "./version.js";
+import { checkAndUpdate, exitForUpdate } from "../auto_updater.js";
+import { claimNextJob, completeJob, createRun, updateRunStatus } from "../dataconnect.js";
+import { buildEnvVars, buildSecretVars } from "../env.js";
+import { withInstallationToken } from "../github.js";
+import { flushLogs, logError, logInfo } from "../logger.js";
+import { runBuildJob } from "../runner.js";
+import type { WorkerConfig } from "../types.js";
+import { version } from "../version.js";
+import { backoffMilliSeconds } from "./backoff.js";
 
 export async function processOneJob(config: WorkerConfig): Promise<boolean> {
   const claimedJob = await claimNextJob();
@@ -91,13 +93,6 @@ export async function processOneJob(config: WorkerConfig): Promise<boolean> {
   return true;
 }
 
-const maxBackoffMs = 5 * 60_000;
-
-function backoffMs(base: number, consecutiveFailures: number): number {
-  const delay = base * 2 ** Math.min(consecutiveFailures, 10);
-  return Math.min(delay, maxBackoffMs);
-}
-
 export async function pollForJobs(config: WorkerConfig): Promise<void> {
   console.log(`Worker started. Worker ID: ${config.workerId}`);
   console.log(`Worker version: ${version}`);
@@ -114,10 +109,12 @@ export async function pollForJobs(config: WorkerConfig): Promise<void> {
         const updateResult = await checkAndUpdate();
         if (updateResult === "updated") exitForUpdate();
         if (updateResult === "failed") {
+          const delay = backoffMilliSeconds(consecutiveFailures);
           consecutiveFailures += 1;
-          const delay = backoffMs(config.pollIntervalMs, consecutiveFailures);
-          console.warn(`Backing off for ${(delay / 1000).toFixed(0)}s (${consecutiveFailures} consecutive failures)`);
-          await new Promise((resolve) => setTimeout(resolve, delay));
+          console.warn(
+            `Backing off for ${(delay / 1000).toFixed(0)}s (${consecutiveFailures} consecutive failures)`,
+          );
+          await setTimeout(delay);
           continue;
         }
       }
@@ -126,14 +123,16 @@ export async function pollForJobs(config: WorkerConfig): Promise<void> {
       consecutiveFailures = 0;
       if (config.once) return;
       if (!found) {
-        await new Promise((resolve) => setTimeout(resolve, config.pollIntervalMs));
+        await setTimeout(config.pollIntervalMs);
       }
     } catch (error) {
+      const delay = backoffMilliSeconds(consecutiveFailures);
       consecutiveFailures += 1;
-      const delay = backoffMs(config.pollIntervalMs, consecutiveFailures);
-      console.error(`Error in poll loop (${consecutiveFailures} consecutive failures, next retry in ${(delay / 1000).toFixed(0)}s): ${String(error)}`);
+      console.error(
+        `Error in poll loop (${consecutiveFailures} consecutive failures, next retry in ${(delay / 1000).toFixed(0)}s): ${String(error)}`,
+      );
       if (config.once) throw error;
-      await new Promise((resolve) => setTimeout(resolve, delay));
+      await setTimeout(delay);
     }
   }
 }


### PR DESCRIPTION
Fixed-interval retries during sustained network failures caused TCP ephemeral port exhaustion on macOS workers. Retry delay now doubles on each consecutive failure (10s → 20s → 40s → … → max 5min) and resets on success.

Bump worker version to 0.1.23.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * ジョブポーリング時の再試行に指数バックオフを導入し、連続失敗時の待機時間が段階的に増加・上限で制限されます。成功時に失敗カウントはリセットされます。
  * 失敗時のログに再試行回数と次回遅延の情報を出力するよう改善しました。

* **Tests**
  * バックオフ挙動を検証するテストスイートを追加しました。

* **Chores**
  * パッケージ公開バージョンを更新しました。
  * CIワークフローを追加し、チェック・テスト・ビルドを自動実行します。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- ima-linked-issue:start -->
Fixes #1625
Ima: IMA-158
<!-- ima-linked-issue:end -->