### PR TITLE
feat: チケット詳細画面からGitHubをブラウザで開く IMA-164

### DIFF
--- a/apps/ima/lib/main.dart
+++ b/apps/ima/lib/main.dart
@@ -7,6 +7,7 @@ import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 import 'firebase_options.dart';
 
@@ -139,6 +140,16 @@ Future<void> _copyTextToClipboard(
   }
 
   _showFloatingSnackBar(context, successMessage);
+}
+
+Future<void> _launchUrlExternal(String url) async {
+  final uri = Uri.tryParse(url.trim());
+  if (uri == null) {
+    return;
+  }
+  if (await canLaunchUrl(uri)) {
+    await launchUrl(uri, mode: LaunchMode.externalApplication);
+  }
 }
 
 class AuthGate extends StatelessWidget {
@@ -2390,6 +2401,13 @@ class _AddIssueDialogState extends State<AddIssueDialog> {
     );
   }
 
+  void _openGitHubUrl() {
+    final url = _githubUrlController.text.trim();
+    if (url.isNotEmpty) {
+      unawaited(_launchUrlExternal(url));
+    }
+  }
+
   Future<void> _pasteGitHubUrl() async {
     final data = await Clipboard.getData(Clipboard.kTextPlain);
     final text = data?.text?.trim();
@@ -2483,6 +2501,7 @@ class _AddIssueDialogState extends State<AddIssueDialog> {
                 label: 'GitHub link',
                 hint: 'https://github.com/openci/ima/issues/123',
               ),
+              onOpen: _openGitHubUrl,
               onCopy: _copyGitHubUrl,
               onPaste: _pasteGitHubUrl,
             ),
@@ -2894,12 +2913,14 @@ class _GitHubLinkField extends StatelessWidget {
   const _GitHubLinkField({
     required this.controller,
     required this.decoration,
+    required this.onOpen,
     required this.onCopy,
     required this.onPaste,
   });
 
   final TextEditingController controller;
   final InputDecoration decoration;
+  final VoidCallback onOpen;
   final VoidCallback onCopy;
   final Future<void> Function() onPaste;
 
@@ -2917,13 +2938,18 @@ class _GitHubLinkField extends StatelessWidget {
         final actions = ValueListenableBuilder<TextEditingValue>(
           valueListenable: controller,
           builder: (context, value, _) {
-            final canCopy = value.text.trim().isNotEmpty;
+            final hasUrl = value.text.trim().isNotEmpty;
             return Wrap(
               spacing: 8,
               runSpacing: 8,
               children: [
                 OutlinedButton.icon(
-                  onPressed: canCopy ? onCopy : null,
+                  onPressed: hasUrl ? onOpen : null,
+                  icon: const Icon(Icons.open_in_new_rounded, size: 18),
+                  label: const Text('Open'),
+                ),
+                OutlinedButton.icon(
+                  onPressed: hasUrl ? onCopy : null,
                   icon: const Icon(Icons.copy_rounded, size: 18),
                   label: const Text('Copy'),
                 ),
@@ -4108,7 +4134,7 @@ class IssueCard extends StatelessWidget {
               PriorityDot(priority: issue.priority),
               if (githubUrl != null) ...[
                 const SizedBox(width: 6),
-                GitHubLinkCopyButton(url: githubUrl),
+                GitHubLinkOpenButton(url: githubUrl),
                 const SizedBox(width: 6),
                 CursorAgentCardButton(
                   issue: issue,
@@ -4260,32 +4286,36 @@ class PullRequestBadge extends StatelessWidget {
     final label = pullRequests.length == 1
         ? 'PR #${latest.number}'
         : '${pullRequests.length} PRs';
+    final prUrl = latest.url;
     return Tooltip(
-      message: latest.url ?? 'Linked pull request',
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          const Icon(
-            Icons.alt_route_rounded,
-            size: 15,
-            color: Color(0xFF0EA5E9),
-          ),
-          const SizedBox(width: 3),
-          Text(
-            label,
-            style: const TextStyle(
-              color: Color(0xFF0369A1),
-              fontWeight: FontWeight.w800,
+      message: prUrl ?? 'Linked pull request',
+      child: GestureDetector(
+        onTap: prUrl != null ? () => unawaited(_launchUrlExternal(prUrl)) : null,
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(
+              Icons.alt_route_rounded,
+              size: 15,
+              color: Color(0xFF0EA5E9),
             ),
-          ),
-        ],
+            const SizedBox(width: 3),
+            Text(
+              label,
+              style: const TextStyle(
+                color: Color(0xFF0369A1),
+                fontWeight: FontWeight.w800,
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }
 }
 
-class GitHubLinkCopyButton extends StatelessWidget {
-  const GitHubLinkCopyButton({super.key, required this.url});
+class GitHubLinkOpenButton extends StatelessWidget {
+  const GitHubLinkOpenButton({super.key, required this.url});
 
   final String url;
 
@@ -4294,17 +4324,11 @@ class GitHubLinkCopyButton extends StatelessWidget {
     return SizedBox.square(
       dimension: 26,
       child: IconButton(
-        tooltip: 'Copy GitHub link',
+        tooltip: 'Open in GitHub',
         padding: EdgeInsets.zero,
         visualDensity: VisualDensity.compact,
-        onPressed: () => unawaited(
-          _copyTextToClipboard(
-            context,
-            text: url,
-            successMessage: 'GitHub link copied',
-          ),
-        ),
-        icon: const Icon(Icons.link_rounded, size: 16),
+        onPressed: () => unawaited(_launchUrlExternal(url)),
+        icon: const Icon(Icons.open_in_new_rounded, size: 16),
       ),
     );
   }

--- a/apps/ima/pubspec.yaml
+++ b/apps/ima/pubspec.yaml
@@ -20,6 +20,7 @@ dependencies:
   firebase_auth: ^6.4.0
   cloud_firestore: ^6.3.0
   cloud_functions: ^6.2.0
+  url_launcher: ^6.3.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

チケット詳細画面からGitHubのURLをブラウザ（モバイルではGitHubアプリ）で直接開けるようにしました。

Closes https://github.com/openci-org/openci/issues/1633

## 変更内容

### `apps/ima/pubspec.yaml`
- `url_launcher` パッケージを依存関係に追加

### `apps/ima/lib/main.dart`
- `url_launcher` パッケージをインポート
- `_launchUrlExternal` ヘルパー関数を追加（`LaunchMode.externalApplication` を使用してブラウザまたはGitHubアプリで開く）
- **カード上のGitHubリンクボタン**: `GitHubLinkCopyButton`（コピーのみ）を `GitHubLinkOpenButton` に変更。アイコンを `open_in_new_rounded` に変更し、タップでURLをブラウザで開くように
- **Issue編集ダイアログのGitHubリンクフィールド**: 既存の「Copy」「Paste」ボタンに加え、「Open」ボタンを追加。URLが入力されている場合にブラウザで開ける
- **PRバッジ**: `PullRequestBadge` を `GestureDetector` でラップし、タップでPRのURLをブラウザで開けるように

## 動作

- モバイル端末: GitHubアプリがインストールされていればGitHubアプリで開き、なければブラウザで開く
- デスクトップ: デフォルトブラウザで開く
- URLが空または無効な場合は何も起こらない（安全にフェイル）
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-189bcf7f-5278-4faf-9dae-d8be1b01df05"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-189bcf7f-5278-4faf-9dae-d8be1b01df05"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * GitHubリンクを外部アプリケーションで直接開く機能を追加
    * Issue詳細画面に「Open」ボタンを追加し、GitHubリンクをブラウザで開けるように
    * Pull Request Badgeをタップすると該当ページを外部で開けるように改善

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- ima-linked-issue:start -->
Fixes #1633
Ima: IMA-164
<!-- ima-linked-issue:end -->