### PR TITLE
fix: Weightをissue編集画面で更新しても反映されない問題を修正 IMA-189

### DIFF
--- a/apps/ima/lib/main.dart
+++ b/apps/ima/lib/main.dart
@@ -732,6 +732,7 @@ class _IssueBoardPageState extends State<IssueBoardPage> {
         isStartingCursorAgent: _startingCursorAgentIssueIds.contains(issueId),
         onStartCursorAgent: _startCursorAgent,
         isBottomSheet: useBottomSheet,
+        workspaceId: _workspaceId,
       ),
     );
 
@@ -2329,6 +2330,7 @@ class AddIssueDialog extends StatefulWidget {
     this.isStartingCursorAgent = false,
     this.onStartCursorAgent,
     this.isBottomSheet = false,
+    this.workspaceId,
   });
 
   final List<BoardColumn> columns;
@@ -2340,6 +2342,7 @@ class AddIssueDialog extends StatefulWidget {
   final bool isStartingCursorAgent;
   final Future<void> Function(String issueId)? onStartCursorAgent;
   final bool isBottomSheet;
+  final String? workspaceId;
 
   @override
   State<AddIssueDialog> createState() => _AddIssueDialogState();
@@ -2358,6 +2361,9 @@ class _AddIssueDialogState extends State<AddIssueDialog> {
   DateTime? _dueDate;
   var _isEstimatingWeight = false;
   var _isStartingCursorAgent = false;
+  Issue? _liveIssue;
+  StreamSubscription<DocumentSnapshot<Map<String, dynamic>>>?
+      _issueSubscription;
 
   @override
   void initState() {
@@ -2370,6 +2376,8 @@ class _AddIssueDialogState extends State<AddIssueDialog> {
         : widget.repositoryOptions.first;
 
     if (issue != null) {
+      _liveIssue = issue;
+      _listenToIssue(issue.id);
       _titleController.text = issue.title;
       _bodyController.text = issue.body;
       _githubUrlController.text = issue.githubUrl ?? '';
@@ -2383,8 +2391,25 @@ class _AddIssueDialogState extends State<AddIssueDialog> {
     }
   }
 
+  void _listenToIssue(String issueId) {
+    final workspaceId = widget.workspaceId;
+    if (workspaceId == null || workspaceId.isEmpty) {
+      return;
+    }
+    _issueSubscription = FirebaseFirestore.instance
+        .doc('workspaces/$workspaceId/issues/$issueId')
+        .snapshots()
+        .listen((snapshot) {
+      if (!mounted || !snapshot.exists) return;
+      setState(() {
+        _liveIssue = Issue.fromDocument(snapshot);
+      });
+    });
+  }
+
   @override
   void dispose() {
+    _issueSubscription?.cancel();
     _titleController.dispose();
     _bodyController.dispose();
     _githubUrlController.dispose();
@@ -2597,7 +2622,7 @@ class _AddIssueDialogState extends State<AddIssueDialog> {
           if (isEditing) ...[
             const SizedBox(height: 14),
             IssueWeightPanel(
-              issue: widget.initialIssue!,
+              issue: _liveIssue ?? widget.initialIssue!,
               isEstimating: widget.isEstimatingWeight || _isEstimatingWeight,
               onEstimate: widget.onEstimateIssueWeight == null
                   ? null
@@ -2605,7 +2630,7 @@ class _AddIssueDialogState extends State<AddIssueDialog> {
             ),
             const SizedBox(height: 14),
             CursorAgentPanel(
-              issue: widget.initialIssue!,
+              issue: _liveIssue ?? widget.initialIssue!,
               isStarting:
                   widget.isStartingCursorAgent || _isStartingCursorAgent,
               onStart: widget.onStartCursorAgent == null


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

Issue編集画面でWeightを推定（Estimate / Re-estimate）しても、ダイアログ上のWeight表示が更新されない問題を修正しました。

## 原因

`AddIssueDialog` はオープン時に `initialIssue` を一度だけ受け取り、以降はFirestoreの更新を反映していませんでした。Weight推定はCloud Functionで実行されFirestoreに書き込まれますが、ダイアログは初期値のままだったため表示が更新されませんでした。

## 修正内容

- `AddIssueDialog` に `workspaceId` パラメータを追加
- `_AddIssueDialogState` でFirestoreのissueドキュメントをリアルタイムにlistenする `StreamSubscription` を追加
- Weight推定が完了してFirestoreが更新されると、`_liveIssue` が更新され `IssueWeightPanel` と `CursorAgentPanel` にリアルタイムで反映される
- ダイアログのdispose時にSubscriptionをキャンセル

## 影響範囲

- `apps/ima/lib/main.dart` のみ変更
- 既存テストへの影響なし（`workspaceId` はオプショナルパラメータ）

Closes https://github.com/openci-org/openci/issues/1662
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1f82f2e2-8e30-4ad8-b46b-48584e435e1a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1f82f2e2-8e30-4ad8-b46b-48584e435e1a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 問題編集時のリアルタイムデータ同期が改善されました。編集ダイアログで最新の問題情報が常に表示されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- ima-linked-issue:start -->
Fixes #1662
Ima: IMA-189
<!-- ima-linked-issue:end -->