### PR TITLE
fix: remove IMA GitHub link paste action IMA-221

### DIFF
--- a/apps/ima/lib/main.dart
+++ b/apps/ima/lib/main.dart
@@ -4118,23 +4118,6 @@ class _AddIssueDialogState extends State<AddIssueDialog> {
     }
   }
 
-  Future<void> _pasteGitHubUrl() async {
-    final data = await Clipboard.getData(Clipboard.kTextPlain);
-    final text = data?.text?.trim();
-    if (text == null || text.isEmpty) {
-      if (!mounted) {
-        return;
-      }
-      _showFloatingSnackBar(context, 'Clipboard is empty');
-      return;
-    }
-
-    _githubUrlController.text = text;
-    _githubUrlController.selection = TextSelection.collapsed(
-      offset: text.length,
-    );
-  }
-
   Future<void> _pickDueDate() async {
     final now = DateTime.now();
     final initialDate = _dueDate ?? now;
@@ -4226,7 +4209,6 @@ class _AddIssueDialogState extends State<AddIssueDialog> {
               ),
               onOpen: _openGitHubUrl,
               onCopy: _copyGitHubUrl,
-              onPaste: _pasteGitHubUrl,
             ),
             const SizedBox(height: 14),
             CreateSubIssuePanel(
@@ -4917,14 +4899,12 @@ class _GitHubLinkField extends StatelessWidget {
     required this.decoration,
     required this.onCopy,
     required this.onOpen,
-    required this.onPaste,
   });
 
   final TextEditingController controller;
   final InputDecoration decoration;
   final VoidCallback onCopy;
   final VoidCallback onOpen;
-  final Future<void> Function() onPaste;
 
   @override
   Widget build(BuildContext context) {
@@ -4954,11 +4934,6 @@ class _GitHubLinkField extends StatelessWidget {
                   onPressed: hasUrl ? onOpen : null,
                   icon: const Icon(Icons.open_in_new_rounded, size: 18),
                   label: const Text('Open'),
-                ),
-                OutlinedButton.icon(
-                  onPressed: () => unawaited(onPaste()),
-                  icon: const Icon(Icons.content_paste_rounded, size: 18),
-                  label: const Text('Paste'),
                 ),
               ],
             );

--- a/apps/ima/test/widget_test.dart
+++ b/apps/ima/test/widget_test.dart
@@ -502,7 +502,8 @@ void main() {
       findsOneWidget,
     );
     expect(find.text('Copy'), findsOneWidget);
-    expect(find.text('Paste'), findsOneWidget);
+    expect(find.text('Open'), findsOneWidget);
+    expect(find.text('Paste'), findsNothing);
   });
 
   testWidgets('Edit issue dialog shows copyable issue ID chip', (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Remove the Paste button from the IMA edit dialog GitHub link controls.
- Delete the now-unused GitHub link clipboard paste handler.
- Update the widget test to expect Copy/Open controls and no Paste action.

Fixes https://github.com/openci-org/openci/issues/1708

## Testing
- Not run: `dart format apps/ima/lib/main.dart apps/ima/test/widget_test.dart` (`dart` not found in PATH)
- Not run: Flutter widget tests (`flutter` not found in PATH)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-18feac2a-fabb-4f40-9b76-eea564e18fcc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-18feac2a-fabb-4f40-9b76-eea564e18fcc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * GitHub リンクフィールドから「貼り付け」アクションを削除しました。現在は「開く」と「コピー」アクションのみがサポートされています。

* **Tests**
  * GitHub リンク コントロール テストを更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- ima-linked-issue:start -->
Fixes #1708
Ima: IMA-221
<!-- ima-linked-issue:end -->