### PR TITLE
fix: allow Cmd+T issue creation IMA-224

### DIFF
--- a/apps/ima/test/widget_test.dart
+++ b/apps/ima/test/widget_test.dart
@@ -189,6 +189,29 @@ void main() {
     expect(searchCount, 1);
   });
 
+  testWidgets('Issue board shortcuts trigger issue creation with Cmd+T', (
+    tester,
+  ) async {
+    var addIssueCount = 0;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: IssueBoardShortcuts(
+          onAddIssue: () => addIssueCount++,
+          onSearchIssues: () {},
+          child: const SizedBox.expand(),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.metaLeft);
+    await tester.sendKeyEvent(LogicalKeyboardKey.keyT);
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.metaLeft);
+
+    expect(addIssueCount, 1);
+  });
+
   testWidgets('Issue search dialog filters issues and returns selection', (
     tester,
   ) async {

--- a/apps/ima/web/index.html
+++ b/apps/ima/web/index.html
@@ -33,6 +33,19 @@
   <link rel="manifest" href="manifest.json">
 </head>
 <body>
+  <script>
+    window.addEventListener('keydown', function(event) {
+      if (
+        event.metaKey &&
+        !event.ctrlKey &&
+        !event.altKey &&
+        !event.shiftKey &&
+        event.key.toLowerCase() === 't'
+      ) {
+        event.preventDefault();
+      }
+    }, { capture: true });
+  </script>
   <!--
     You can customize the "flutter_bootstrap.js" script.
     This is useful to provide a custom configuration to the Flutter loader


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Prevent the browser default new-tab action from stealing plain Cmd+T in the IMA web app
- Add widget coverage that Cmd+T invokes the issue creation shortcut callback

Fixes https://github.com/openci-org/openci/issues/1713

## Testing
- `git diff --check`
- `flutter test test/widget_test.dart` (not run: `flutter` is not installed in this environment)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2bf953ef-b7ec-42e4-b38e-3c29c78e07e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2bf953ef-b7ec-42e4-b38e-3c29c78e07e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能
* Cmd+T キーボードショートカットを追加しました。課題ボードから素早く新規課題を作成できるようになりました。

## テスト
* キーボードショートカット機能の動作を検証するウィジェットテストを追加しました。既存の Cmd+K 検索ショートカット機能は継続して利用可能です。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- ima-linked-issue:start -->
Fixes #1713
Ima: IMA-224
<!-- ima-linked-issue:end -->