### PR TITLE
ci: add FAD release notes context IMA-296

### DIFF
--- a/.openci/flutter-ci-cd.yaml
+++ b/.openci/flutter-ci-cd.yaml
@@ -64,14 +64,41 @@ jobs:
           FIREBASE_SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
           FIREBASE_IOS_APP_ID: ${{ secrets.FIREBASE_IOS_APP_ID }}
           FIREBASE_APP_DISTRIBUTION_GROUPS: ${{ secrets.FIREBASE_APP_DISTRIBUTION_GROUPS }}
+          RELEASE_EVENT_NAME: ${{ github.event_name }}
+          RELEASE_PR_NUMBER: ${{ github.event.pull_request.number }}
+          RELEASE_HEAD_REF: ${{ github.head_ref }}
+          RELEASE_BASE_REF: ${{ github.base_ref }}
+          RELEASE_REF_NAME: ${{ github.ref_name }}
+          RELEASE_SHA: ${{ github.sha }}
         run: |
           printf '%s' "$FIREBASE_SERVICE_ACCOUNT" > /tmp/firebase-service-account.json
-          trap 'rm -f /tmp/firebase-service-account.json' EXIT
+          release_notes_file="$(mktemp)"
+          trap 'rm -f /tmp/firebase-service-account.json "$release_notes_file"' EXIT
           export GOOGLE_APPLICATION_CREDENTIALS=/tmp/firebase-service-account.json
+
+          {
+            echo "OpenCI build"
+            echo "Trigger: ${RELEASE_EVENT_NAME:-unknown}"
+
+            if [ "${RELEASE_EVENT_NAME:-}" = "pull_request" ]; then
+              echo "Pull Request: #${RELEASE_PR_NUMBER:-unknown}"
+              [ -n "${RELEASE_HEAD_REF:-}" ] && echo "Head branch: $RELEASE_HEAD_REF"
+              [ -n "${RELEASE_BASE_REF:-}" ] && echo "Base branch: $RELEASE_BASE_REF"
+            elif [ "${RELEASE_EVENT_NAME:-}" = "push" ]; then
+              branch="${RELEASE_REF_NAME:-}"
+              if [ -z "$branch" ] && [ -n "${GITHUB_REF:-}" ]; then
+                branch="${GITHUB_REF#refs/heads/}"
+              fi
+              [ -n "$branch" ] && echo "Branch: $branch"
+            fi
+
+            [ -n "${RELEASE_SHA:-}" ] && echo "Commit: $RELEASE_SHA"
+          } > "$release_notes_file"
 
           npx -y firebase-tools appdistribution:distribute "${{ steps.ios-build.outputs.ipa-path }}" \
             --app "$FIREBASE_IOS_APP_ID" \
-            --groups "$FIREBASE_APP_DISTRIBUTION_GROUPS"
+            --groups "$FIREBASE_APP_DISTRIBUTION_GROUPS" \
+            --release-notes-file "$release_notes_file"
 
   deploy-web:
     needs: [ci]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add Firebase App Distribution release notes for iOS dashboard builds.
- Include whether the build came from `pull_request` or `push`, plus PR/branch and commit context.

Closes https://github.com/openci-org/openci/issues/1804

## Testing
- `python3 -c "import pathlib, yaml; yaml.safe_load(pathlib.Path('.openci/flutter-ci-cd.yaml').read_text()); print('YAML syntax ok')"`
- `bash -n` on the extracted FAD upload shell block
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .openci/flutter-ci-cd.yaml`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-09975e04-ad3c-40d3-b82b-952b321aae1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-09975e04-ad3c-40d3-b82b-952b321aae1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * Firebase App Distributionのリリースに自動生成されるリリースノートが追加されました。ベータテスターはPR情報やコミット詳細などの詳細情報をリリースノートで確認できるようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- ima-linked-issue:start -->
Fixes #1804
Ima: IMA-296
<!-- ima-linked-issue:end -->