### PR TITLE
feat: add mobile drawer navigation IMA-282

### DIFF
--- a/apps/landing_page/components/mobile-drawer-nav.tsx
+++ b/apps/landing_page/components/mobile-drawer-nav.tsx
@@ -34,6 +34,7 @@ export function MobileDrawerNav({ title, homeHref, links, ariaLabel, menuLabel, 
     }
 
     const previousBodyOverflow = document.body.style.overflow;
+    const triggerElement = triggerRef.current;
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
         setOpen(false);
@@ -47,7 +48,7 @@ export function MobileDrawerNav({ title, homeHref, links, ariaLabel, menuLabel, 
     return () => {
       document.body.style.overflow = previousBodyOverflow;
       document.removeEventListener('keydown', onKeyDown);
-      triggerRef.current?.focus();
+      triggerElement?.focus();
     };
   }, [open]);
 

--- a/apps/landing_page/components/mobile-drawer-nav.tsx
+++ b/apps/landing_page/components/mobile-drawer-nav.tsx
@@ -1,0 +1,121 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+export type MobileDrawerLink = {
+  href: string;
+  label: string;
+  external?: boolean;
+  variant?: 'link' | 'button';
+};
+
+type MobileDrawerNavProps = {
+  title: string;
+  homeHref: string;
+  links: MobileDrawerLink[];
+  ariaLabel: string;
+  menuLabel: string;
+  closeLabel: string;
+};
+
+const drawerLinkClass =
+  'block rounded-lg px-3 py-2 text-sm font-normal text-neutral-700 transition-colors hover:bg-neutral-100 hover:text-neutral-950 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500';
+const drawerButtonLinkClass =
+  'mt-2 inline-flex w-full items-center justify-center rounded-lg bg-neutral-950 px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-neutral-800 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500';
+
+export function MobileDrawerNav({ title, homeHref, links, ariaLabel, menuLabel, closeLabel }: MobileDrawerNavProps) {
+  const [open, setOpen] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    const previousBodyOverflow = document.body.style.overflow;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setOpen(false);
+      }
+    };
+
+    document.body.style.overflow = 'hidden';
+    document.addEventListener('keydown', onKeyDown);
+    closeButtonRef.current?.focus();
+
+    return () => {
+      document.body.style.overflow = previousBodyOverflow;
+      document.removeEventListener('keydown', onKeyDown);
+      triggerRef.current?.focus();
+    };
+  }, [open]);
+
+  return (
+    <div className="sm:hidden">
+      <button
+        ref={triggerRef}
+        type="button"
+        className="inline-flex h-10 w-10 items-center justify-center rounded-lg text-neutral-700 transition-colors hover:bg-neutral-100 hover:text-neutral-950 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
+        aria-label={menuLabel}
+        aria-expanded={open}
+        onClick={() => setOpen(true)}
+      >
+        <MenuIcon />
+      </button>
+
+      {open ? (
+        <div className="fixed inset-0 z-[60]" role="presentation">
+          <button type="button" className="absolute inset-0 h-full w-full cursor-default bg-neutral-950/35" aria-label={closeLabel} onClick={() => setOpen(false)} />
+          <aside className="relative flex h-dvh w-72 max-w-[calc(100vw-3rem)] flex-col border-r border-neutral-950/10 bg-white p-6 shadow-2xl" role="dialog" aria-modal="true" aria-label={ariaLabel}>
+            <div className="flex items-center justify-between gap-4">
+              <a href={homeHref} className="text-[1.0625rem] font-semibold tracking-tight text-neutral-950 transition-opacity hover:opacity-70" onClick={() => setOpen(false)}>
+                {title}
+              </a>
+              <button
+                ref={closeButtonRef}
+                type="button"
+                className="inline-flex h-9 w-9 items-center justify-center rounded-lg text-neutral-600 transition-colors hover:bg-neutral-100 hover:text-neutral-950 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
+                aria-label={closeLabel}
+                onClick={() => setOpen(false)}
+              >
+                <CloseIcon />
+              </button>
+            </div>
+
+            <nav className="mt-8 space-y-1" aria-label={ariaLabel}>
+              {links.map((link) => (
+                <a
+                  key={`${link.href}-${link.label}`}
+                  href={link.href}
+                  target={link.external ? '_blank' : undefined}
+                  rel={link.external ? 'noopener noreferrer' : undefined}
+                  className={link.variant === 'button' ? drawerButtonLinkClass : drawerLinkClass}
+                  onClick={() => setOpen(false)}
+                >
+                  {link.label}
+                </a>
+              ))}
+            </nav>
+          </aside>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function MenuIcon() {
+  return (
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" strokeWidth="1.8" stroke="currentColor" aria-hidden="true">
+      <path strokeLinecap="round" d="M4 7h16M4 12h16M4 17h16" />
+    </svg>
+  );
+}
+
+function CloseIcon() {
+  return (
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" strokeWidth="1.8" stroke="currentColor" aria-hidden="true">
+      <path strokeLinecap="round" strokeLinejoin="round" d="M6 6l12 12M18 6 6 18" />
+    </svg>
+  );
+}

--- a/apps/landing_page/components/site.tsx
+++ b/apps/landing_page/components/site.tsx
@@ -1,5 +1,6 @@
 import Image from 'next/image';
 import type { ReactNode } from 'react';
+import { MobileDrawerNav, type MobileDrawerLink } from './mobile-drawer-nav';
 
 const formUrl = 'https://form.typeform.com/to/XIdO4iES';
 const dashboardUrl = 'https://dashboard.openci.org/';
@@ -135,6 +136,11 @@ const cicdPricing = {
 
 export function CicdPage({ lang }: { lang: 'en' | 'ja' }) {
   const copy = cicdCopy[lang];
+  const navLinks: MobileDrawerLink[] = [
+    { href: '#pricing', label: copy.navPricing },
+    { href: githubUrl, label: 'GitHub', external: true },
+    { href: dashboardUrl, label: copy.navDashboard, external: true, variant: 'button' },
+  ];
 
   return (
     <div className="flex min-h-dvh flex-col bg-white text-neutral-950">
@@ -143,17 +149,14 @@ export function CicdPage({ lang }: { lang: 'en' | 'ja' }) {
           <a href={copy.homeHref} className="text-[1.0625rem] font-semibold tracking-tight text-neutral-950 transition-opacity hover:opacity-70" aria-label={lang === 'ja' ? 'ホームページ' : 'Homepage'}>
             OpenCI
           </a>
-          <nav className="flex items-center gap-4 sm:gap-7" aria-label="Main navigation">
-            <a href="#pricing" className="text-sm font-normal text-neutral-600 transition-colors hover:text-neutral-950">
-              {copy.navPricing}
-            </a>
-            <a href={githubUrl} target="_blank" rel="noopener noreferrer" className="text-sm font-normal text-neutral-600 transition-colors hover:text-neutral-950">
-              GitHub
-            </a>
-            <a href={dashboardUrl} target="_blank" rel="noopener noreferrer" className={secondaryButtonClass}>
-              {copy.navDashboard}
-            </a>
+          <nav className="hidden items-center gap-7 sm:flex" aria-label="Main navigation">
+            {navLinks.map((link) => (
+              <a key={`${link.href}-${link.label}`} href={link.href} target={link.external ? '_blank' : undefined} rel={link.external ? 'noopener noreferrer' : undefined} className={link.variant === 'button' ? secondaryButtonClass : 'text-sm font-normal text-neutral-600 transition-colors hover:text-neutral-950'}>
+                {link.label}
+              </a>
+            ))}
           </nav>
+          <MobileDrawerNav title="OpenCI" homeHref={copy.homeHref} links={navLinks} ariaLabel="Main navigation" menuLabel={lang === 'ja' ? 'メニューを開く' : 'Open menu'} closeLabel={lang === 'ja' ? 'メニューを閉じる' : 'Close menu'} />
         </div>
       </header>
 
@@ -388,20 +391,25 @@ function StudioShell({ children }: { children: ReactNode }) {
 }
 
 function StudioHeader() {
+  const navLinks: MobileDrawerLink[] = [
+    { href: '/studio/about/', label: '会社概要' },
+    { href: formUrl, label: 'お問い合わせ', external: true, variant: 'button' },
+  ];
+
   return (
     <header className="sticky top-0 z-50 border-b border-neutral-950/6 bg-white/92 py-4 backdrop-blur-md">
       <div className={`${containerClass} flex items-center justify-between gap-6`}>
         <a href="/studio/" className="text-lg font-semibold tracking-tight text-neutral-950 transition-opacity hover:opacity-70" aria-label="Homepage">
           OpenCI Studio
         </a>
-        <nav className="flex items-center gap-5 sm:gap-8" aria-label="Studio navigation">
-          <a href="/studio/about/" className="text-sm font-normal text-neutral-600 transition-colors hover:text-neutral-950">
-            会社概要
-          </a>
-          <a href={formUrl} target="_blank" rel="noopener noreferrer" className={secondaryButtonClass}>
-            お問い合わせ
-          </a>
+        <nav className="hidden items-center gap-8 sm:flex" aria-label="Studio navigation">
+          {navLinks.map((link) => (
+            <a key={`${link.href}-${link.label}`} href={link.href} target={link.external ? '_blank' : undefined} rel={link.external ? 'noopener noreferrer' : undefined} className={link.variant === 'button' ? secondaryButtonClass : 'text-sm font-normal text-neutral-600 transition-colors hover:text-neutral-950'}>
+              {link.label}
+            </a>
+          ))}
         </nav>
+        <MobileDrawerNav title="OpenCI Studio" homeHref="/studio/" links={navLinks} ariaLabel="Studio navigation" menuLabel="メニューを開く" closeLabel="メニューを閉じる" />
       </div>
     </header>
   );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Replaces mobile header links with a hamburger-triggered left drawer on the landing pages.
- Reuses the existing navigation links for CI/CD and Studio headers.
- Adds drawer dismissal for backdrop clicks, close button, Escape, and link taps.

Closes https://github.com/openci-org/openci/issues/1786

## Testing
- `npm run lint`
- `npm run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c3a1fb11-9139-4fc0-bbcc-5fd88590230f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c3a1fb11-9139-4fc0-bbcc-5fd88590230f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- ima-linked-issue:start -->
Fixes #1786
Ima: IMA-282
<!-- ima-linked-issue:end -->