### PR TITLE
feat: increase runs history limit IMA-299

### DIFF
--- a/apps/dashboard/lib/build_logs/build_jobs_provider.dart
+++ b/apps/dashboard/lib/build_logs/build_jobs_provider.dart
@@ -10,6 +10,8 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 part 'build_jobs_provider.freezed.dart';
 part 'build_jobs_provider.g.dart';
 
+const _buildJobsHistoryLimit = 100;
+
 @riverpod
 class BuildJobs extends _$BuildJobs {
   @override
@@ -24,7 +26,7 @@ class BuildJobs extends _$BuildJobs {
         .collection(buildJobsCollection)
         .where('teamId', isEqualTo: teamId)
         .orderBy('createdAt', descending: true)
-        .limit(20);
+        .limit(_buildJobsHistoryLimit);
 
     final initialResult = await query.get();
     final initialJobs = _sortedBuildJobs(initialResult.docs.map(_buildJobFromDoc));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Increase the dashboard execution history query limit from 20 to 100 build jobs.
- Extract the limit into a named constant for easier future tuning.

Closes https://github.com/openci-org/openci/issues/1813

## Testing
- `git show --check --stat --oneline HEAD`
- `dart format apps/dashboard/lib/build_logs/build_jobs_provider.dart` (not run: `dart` is not installed in this environment)
- Flutter CI is expected to run via `.openci/flutter-ci-cd.yaml` on the PR.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ed22202c-9751-4529-aaed-b51dbf103d0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ed22202c-9751-4529-aaed-b51dbf103d0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * ビルドジョブの履歴表示件数を20件から100件に増加しました。ダッシュボードのビルドログでより多くの過去記録を確認できるようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- ima-linked-issue:start -->
Fixes #1813
Ima: IMA-299
<!-- ima-linked-issue:end -->