### PR TITLE
[codex] Remove build job debug logs

### DIFF
--- a/apps/dashboard/lib/build_logs/build_jobs_provider.dart
+++ b/apps/dashboard/lib/build_logs/build_jobs_provider.dart
@@ -3,7 +3,6 @@ import 'package:dashboard/firebase/firestore.dart';
 import 'package:dashboard/firebase/functions.dart';
 import 'package:dashboard/users/user_provider.dart';
 import 'package:dashboard/utilities/date_time_converter.dart';
-import 'package:flutter/foundation.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -32,7 +31,6 @@ class BuildJobs extends _$BuildJobs {
     final initialJobs = _sortedBuildJobs(
       initialResult.docs.map((doc) => _buildJobFromData(doc.id, doc.data())),
     );
-    _debugBuildJobsResult('execute', teamId, initialJobs);
     yield initialJobs;
 
     yield* query.snapshots().map(
@@ -40,7 +38,6 @@ class BuildJobs extends _$BuildJobs {
         final jobs = _sortedBuildJobs(
           result.docs.map((doc) => _buildJobFromData(doc.id, doc.data())),
         );
-        _debugBuildJobsResult('subscribe', teamId, jobs);
         return jobs;
       },
     );
@@ -176,13 +173,4 @@ BuildJob _buildJobFromData(String id, Map<String, dynamic> job) {
 
 List<BuildJob> _sortedBuildJobs(Iterable<BuildJob> jobs) {
   return jobs.toList()..sort((a, b) => b.createdAt.compareTo(a.createdAt));
-}
-
-void _debugBuildJobsResult(String source, String teamId, List<BuildJob> jobs) {
-  if (!kDebugMode) return;
-  final first = jobs.isEmpty ? null : jobs.first;
-  debugPrint(
-    '[OpenCI] ListBuildJobsForTeam $source teamId=$teamId '
-    'count=${jobs.length} first=${first?.id} firstCreatedAt=${first?.createdAt.toIso8601String()}',
-  );
 }


### PR DESCRIPTION
## Summary
- Remove the debug-only build job list logging from the dashboard provider.
- Drop the now-unused `flutter/foundation.dart` import.

## Impact
This stops repeated console output such as `[OpenCI] ListBuildJobsForTeam execute/subscribe ...` while preserving the build job query and subscription behavior.

## Validation
- `flutter analyze`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **その他の改善**
  * ビルドジョブプロバイダーの内部デバッグロギング機能を削除しました。ジョブの取得・ソート機能の動作に変更はありません。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openci-org/openci/pull/1975?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->