### PR TITLE
Rename dashboard issues module to workspace

### DIFF
--- a/apps/dashboard/lib/workflow/list/workflow_list_page.dart
+++ b/apps/dashboard/lib/workflow/list/workflow_list_page.dart
@@ -1,4 +1,4 @@
-import 'package:dashboard/issues/issue_board_page.dart';
+import 'package:dashboard/workspace/issue_board_page.dart';
 import 'package:dashboard/users/user_provider.dart';
 import 'package:dashboard/utilities/async_error_widget.dart';
 import 'package:flutter/material.dart';

--- a/apps/dashboard/lib/workspace/issue_board_ima_app_shell.dart
+++ b/apps/dashboard/lib/workspace/issue_board_ima_app_shell.dart
@@ -1,0 +1,134 @@
+import 'dart:async';
+
+import 'package:dashboard/utilities/snack_bar_extension.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+const reviewStatusId = 'review';
+const closedStatusId = 'done';
+const boardHorizontalPadding = 16.0;
+const boardBottomPadding = 18.0;
+const boardColumnWidth = 280.0;
+const boardColumnGap = 12.0;
+const compactBoardBreakpoint = 640.0;
+const compactColumnCollapsedLimit = 0;
+const mobileDragStartDelay = Duration(milliseconds: 420);
+const defaultDailyWeightTarget = 20;
+const validIssueWeights = [0, 1, 2, 4, 8, 16, 32];
+const openCiRepositoryUrl = 'https://github.com/openci-org/openci';
+
+enum BoardViewMode { standard, overview }
+
+enum BoardSidePanel { runs, workers, workflows, variables, storeRelease }
+
+enum CompactBoardDestination {
+  issueBoard,
+  runs,
+  workers,
+  workflows,
+  variables,
+  storeRelease,
+}
+
+const boardNavigationDestinations = [
+  CompactBoardDestination.issueBoard,
+  CompactBoardDestination.runs,
+  CompactBoardDestination.workers,
+  CompactBoardDestination.workflows,
+  CompactBoardDestination.variables,
+  CompactBoardDestination.storeRelease,
+];
+
+extension CompactBoardDestinationLabel on CompactBoardDestination {
+  String get label => switch (this) {
+    CompactBoardDestination.issueBoard => 'ワークスペース',
+    CompactBoardDestination.runs => 'CI/CDログ',
+    CompactBoardDestination.workers => 'ワーカー',
+    CompactBoardDestination.workflows => 'CI/CD設定',
+    CompactBoardDestination.variables => '変数',
+    CompactBoardDestination.storeRelease => 'ストアリリース',
+  };
+
+  IconData get icon => switch (this) {
+    CompactBoardDestination.issueBoard => Icons.view_kanban_outlined,
+    CompactBoardDestination.runs => Icons.history_rounded,
+    CompactBoardDestination.workers => Icons.dns_outlined,
+    CompactBoardDestination.workflows => Icons.schema_rounded,
+    CompactBoardDestination.variables => Icons.key_rounded,
+    CompactBoardDestination.storeRelease => Icons.rocket_launch_outlined,
+  };
+
+  IconData get selectedIcon => switch (this) {
+    CompactBoardDestination.issueBoard => Icons.view_kanban_rounded,
+    CompactBoardDestination.runs => Icons.history_rounded,
+    CompactBoardDestination.workers => Icons.dns_rounded,
+    CompactBoardDestination.workflows => Icons.schema_rounded,
+    CompactBoardDestination.variables => Icons.key_rounded,
+    CompactBoardDestination.storeRelease => Icons.rocket_launch_rounded,
+  };
+}
+
+String? normalizedOptionalUrl(String value) {
+  final trimmed = value.trim();
+  return trimmed.isEmpty ? null : trimmed;
+}
+
+String? validateOptionalHttpUrl(String? value) {
+  final trimmed = value?.trim() ?? '';
+  if (trimmed.isEmpty) {
+    return null;
+  }
+
+  final uri = Uri.tryParse(trimmed);
+  final isHttpUrl =
+      uri != null &&
+      uri.hasScheme &&
+      uri.host.isNotEmpty &&
+      (uri.scheme == 'https' || uri.scheme == 'http');
+  return isHttpUrl ? null : 'URL形式で入力してください';
+}
+
+void showFloatingSnackBar(BuildContext context, String message) {
+  showResponsiveSnackBar(
+    context,
+    content: Text(message, maxLines: 1, overflow: TextOverflow.ellipsis),
+    duration: const Duration(milliseconds: 1400),
+  );
+}
+
+void showOverlaySnackBar(BuildContext context, String message) {
+  showResponsiveSnackBar(
+    context,
+    content: Text(message, maxLines: 1, overflow: TextOverflow.ellipsis),
+    duration: const Duration(milliseconds: 1400),
+  );
+}
+
+Future<void> copyTextToClipboard(
+  BuildContext context, {
+  required String text,
+  required String successMessage,
+}) async {
+  final trimmed = text.trim();
+  if (trimmed.isEmpty) {
+    return;
+  }
+
+  await Clipboard.setData(ClipboardData(text: trimmed));
+  if (!context.mounted) {
+    return;
+  }
+
+  showFloatingSnackBar(context, successMessage);
+}
+
+Future<void> launchUrlExternal(String url) async {
+  final uri = Uri.tryParse(url.trim());
+  if (uri == null) {
+    return;
+  }
+  if (await canLaunchUrl(uri)) {
+    await launchUrl(uri, mode: LaunchMode.externalApplication);
+  }
+}

--- a/apps/dashboard/lib/workspace/issue_board_ima_board_columns.dart
+++ b/apps/dashboard/lib/workspace/issue_board_ima_board_columns.dart
@@ -1,0 +1,2074 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_sticky_header/flutter_sticky_header.dart';
+import 'issue_board_ima_issue_cards.dart';
+import 'issue_board_ima_models.dart';
+import 'issue_board_ima_app_shell.dart';
+import 'issue_board_ima_overview.dart';
+
+class BoardColumnView extends StatelessWidget {
+  const BoardColumnView({
+    super.key,
+    required this.column,
+    this.subIssuesByParentId = const {},
+    this.buildStatusesByIssueId = const {},
+    this.issuesByRepositoryNumber = const {},
+    this.startingCursorAgentIssueIds = const {},
+    required this.requiresLongPressDrag,
+    required this.onIssueDropped,
+    this.onIssueLinkedToPullRequest,
+    required this.onAddIssue,
+    required this.onIssueTapped,
+    this.onStartCursorAgent,
+  });
+
+  final BoardColumn column;
+  final Map<String, List<Issue>> subIssuesByParentId;
+  final Map<String, CardBuildStatus> buildStatusesByIssueId;
+  final Map<String, Issue> issuesByRepositoryNumber;
+  final Set<String> startingCursorAgentIssueIds;
+  final bool requiresLongPressDrag;
+  final IssueDropCallback onIssueDropped;
+  final IssuePullRequestLinkCallback? onIssueLinkedToPullRequest;
+  final ValueChanged<String> onAddIssue;
+  final ValueChanged<String> onIssueTapped;
+  final ValueChanged<String>? onStartCursorAgent;
+
+  @override
+  Widget build(BuildContext context) {
+    final visibleIssues = visibleIssuesForColumn(column);
+    final rankIndicesByIssueId = _rankIndicesByIssueId(column.issues);
+    final reviewGroups = column.id == reviewStatusId
+        ? _reviewPullRequestGroupsForIssues(visibleIssues)
+        : const <ReviewPullRequestGroup>[];
+    final acceptsColumnDrop =
+        column.id != reviewStatusId || reviewGroups.isEmpty;
+
+    return DragTarget<IssueDragData>(
+      onWillAcceptWithDetails: (details) =>
+          acceptsColumnDrop && details.data.sourceColumnId != column.id,
+      onAcceptWithDetails: (details) {
+        onIssueDropped(
+          issueId: details.data.issueId,
+          targetColumnId: column.id,
+          targetIndex: column.issues.length,
+        );
+      },
+      builder: (context, candidateData, rejectedData) {
+        final isHovering = candidateData.isNotEmpty;
+
+        return AnimatedContainer(
+          duration: const Duration(milliseconds: 160),
+          width: boardColumnWidth,
+          padding: const EdgeInsets.all(12),
+          decoration: BoxDecoration(
+            color: isHovering
+                ? column.color.withValues(alpha: 0.08)
+                : Colors.white,
+            border: Border.all(
+              color: isHovering
+                  ? column.color.withValues(alpha: 0.45)
+                  : const Color(0xFFE2E8F0),
+            ),
+            borderRadius: BorderRadius.circular(20),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              ColumnHeader(
+                column: column,
+                isCompact: false,
+                onAddIssue: () => onAddIssue(column.id),
+              ),
+              const SizedBox(height: 10),
+              Expanded(
+                child: ListView(
+                  padding: EdgeInsets.zero,
+                  children: [
+                    if (visibleIssues.isEmpty) ...[
+                      EmptyColumnIssueCreator(
+                        columnTitle: column.title,
+                        onPressed: () => onAddIssue(column.id),
+                      ),
+                      const SizedBox(height: 8),
+                    ],
+                    if (reviewGroups.isNotEmpty)
+                      for (final group in reviewGroups) ...[
+                        ReviewPullRequestGroupView(
+                          group: group,
+                          column: column,
+                          subIssuesByParentId: subIssuesByParentId,
+                          buildStatusesByIssueId: buildStatusesByIssueId,
+                          issuesByRepositoryNumber: issuesByRepositoryNumber,
+                          rankIndicesByIssueId: rankIndicesByIssueId,
+                          startingCursorAgentIssueIds:
+                              startingCursorAgentIssueIds,
+                          requiresLongPressDrag: requiresLongPressDrag,
+                          onIssueTapped: onIssueTapped,
+                          onSubIssueTap: onIssueTapped,
+                          onStartCursorAgent: onStartCursorAgent,
+                          onIssueDropped: onIssueDropped,
+                          onIssueLinkedToPullRequest:
+                              onIssueLinkedToPullRequest,
+                        ),
+                        const SizedBox(height: 8),
+                      ]
+                    else
+                      for (
+                        var index = 0;
+                        index < visibleIssues.length;
+                        index++
+                      ) ...[
+                        Builder(
+                          builder: (context) {
+                            final issue = visibleIssues[index];
+                            final rankIndex = rankIndicesByIssueId[issue.id];
+
+                            return IssueCardDropTarget(
+                              key: ValueKey(issue.id),
+                              issue: issue,
+                              subIssues:
+                                  subIssuesByParentId[issue.id] ??
+                                  const <Issue>[],
+                              buildStatus: buildStatusesByIssueId[issue.id],
+                              sourceColumnId: column.id,
+                              index: rankIndex ?? index,
+                              isStartingCursorAgent: startingCursorAgentIssueIds
+                                  .contains(issue.id),
+                              requiresLongPressDrag: requiresLongPressDrag,
+                              onTap: () => onIssueTapped(issue.id),
+                              onSubIssueTap: onIssueTapped,
+                              onStartCursorAgent: onStartCursorAgent == null
+                                  ? null
+                                  : () => onStartCursorAgent!(issue.id),
+                              onIssueDropped: onIssueDropped,
+                            );
+                          },
+                        ),
+                        const SizedBox(height: 8),
+                      ],
+                    IssueDropSlot(
+                      columnId: column.id,
+                      index: column.issues.length,
+                      onIssueDropped: onIssueDropped,
+                      isLast: true,
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}
+
+class CompactBoardColumnView extends StatefulWidget {
+  const CompactBoardColumnView({
+    super.key,
+    required this.column,
+    this.subIssuesByParentId = const {},
+    this.buildStatusesByIssueId = const {},
+    this.issuesByRepositoryNumber = const {},
+    this.startingCursorAgentIssueIds = const {},
+    required this.requiresLongPressDrag,
+    required this.onIssueDropped,
+    this.onIssueLinkedToPullRequest,
+    required this.onAddIssue,
+    required this.onIssueTapped,
+    this.onStartCursorAgent,
+  });
+
+  final BoardColumn column;
+  final Map<String, List<Issue>> subIssuesByParentId;
+  final Map<String, CardBuildStatus> buildStatusesByIssueId;
+  final Map<String, Issue> issuesByRepositoryNumber;
+  final Set<String> startingCursorAgentIssueIds;
+  final bool requiresLongPressDrag;
+  final IssueDropCallback onIssueDropped;
+  final IssuePullRequestLinkCallback? onIssueLinkedToPullRequest;
+  final ValueChanged<String> onAddIssue;
+  final ValueChanged<String> onIssueTapped;
+  final ValueChanged<String>? onStartCursorAgent;
+
+  @override
+  State<CompactBoardColumnView> createState() => _CompactBoardColumnViewState();
+}
+
+class _CompactBoardColumnViewState extends State<CompactBoardColumnView> {
+  var _isShrunk = true;
+
+  @override
+  Widget build(BuildContext context) {
+    final visibleIssues = visibleIssuesForColumn(widget.column);
+    final displayedIssues = _isShrunk
+        ? visibleIssues.take(compactColumnCollapsedLimit).toList()
+        : visibleIssues;
+    final rankIndicesByIssueId = _rankIndicesByIssueId(widget.column.issues);
+    final reviewGroups = widget.column.id == reviewStatusId
+        ? _reviewPullRequestGroupsForIssues(displayedIssues)
+        : const <ReviewPullRequestGroup>[];
+    final acceptsColumnDrop =
+        widget.column.id != reviewStatusId || reviewGroups.isEmpty;
+    final hiddenIssueCount = visibleIssues.length - displayedIssues.length;
+    final canToggleSize = visibleIssues.length > compactColumnCollapsedLimit;
+
+    return DragTarget<IssueDragData>(
+      onWillAcceptWithDetails: (details) =>
+          acceptsColumnDrop && details.data.sourceColumnId != widget.column.id,
+      onAcceptWithDetails: (details) {
+        widget.onIssueDropped(
+          issueId: details.data.issueId,
+          targetColumnId: widget.column.id,
+          targetIndex: widget.column.issues.length,
+        );
+      },
+      builder: (context, candidateData, rejectedData) {
+        final isHovering = candidateData.isNotEmpty;
+
+        return AnimatedContainer(
+          duration: const Duration(milliseconds: 160),
+          width: double.infinity,
+          padding: const EdgeInsets.all(12),
+          decoration: BoxDecoration(
+            color: isHovering
+                ? widget.column.color.withValues(alpha: 0.08)
+                : Colors.white,
+            border: Border.all(
+              color: isHovering
+                  ? widget.column.color.withValues(alpha: 0.45)
+                  : const Color(0xFFE2E8F0),
+            ),
+            borderRadius: BorderRadius.circular(20),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              ColumnHeader(
+                column: widget.column,
+                isCompact: true,
+                onAddIssue: () => widget.onAddIssue(widget.column.id),
+              ),
+              const SizedBox(height: 10),
+              if (visibleIssues.isEmpty) ...[
+                EmptyColumnIssueCreator(
+                  columnTitle: widget.column.title,
+                  onPressed: () => widget.onAddIssue(widget.column.id),
+                ),
+                const SizedBox(height: 8),
+              ],
+              if (reviewGroups.isNotEmpty)
+                for (final group in reviewGroups) ...[
+                  ReviewPullRequestGroupView(
+                    group: group,
+                    column: widget.column,
+                    subIssuesByParentId: widget.subIssuesByParentId,
+                    buildStatusesByIssueId: widget.buildStatusesByIssueId,
+                    issuesByRepositoryNumber: widget.issuesByRepositoryNumber,
+                    rankIndicesByIssueId: rankIndicesByIssueId,
+                    startingCursorAgentIssueIds:
+                        widget.startingCursorAgentIssueIds,
+                    requiresLongPressDrag: widget.requiresLongPressDrag,
+                    onIssueTapped: widget.onIssueTapped,
+                    onSubIssueTap: widget.onIssueTapped,
+                    onStartCursorAgent: widget.onStartCursorAgent,
+                    onIssueDropped: widget.onIssueDropped,
+                    onIssueLinkedToPullRequest:
+                        widget.onIssueLinkedToPullRequest,
+                  ),
+                  const SizedBox(height: 8),
+                ]
+              else
+                for (
+                  var index = 0;
+                  index < displayedIssues.length;
+                  index++
+                ) ...[
+                  Builder(
+                    builder: (context) {
+                      final issue = displayedIssues[index];
+                      final rankIndex = rankIndicesByIssueId[issue.id];
+
+                      return IssueCardDropTarget(
+                        key: ValueKey(issue.id),
+                        issue: issue,
+                        subIssues:
+                            widget.subIssuesByParentId[issue.id] ??
+                            const <Issue>[],
+                        buildStatus: widget.buildStatusesByIssueId[issue.id],
+                        sourceColumnId: widget.column.id,
+                        index: rankIndex ?? index,
+                        isStartingCursorAgent: widget
+                            .startingCursorAgentIssueIds
+                            .contains(issue.id),
+                        requiresLongPressDrag: widget.requiresLongPressDrag,
+                        onTap: () => widget.onIssueTapped(issue.id),
+                        onSubIssueTap: widget.onIssueTapped,
+                        onStartCursorAgent: widget.onStartCursorAgent == null
+                            ? null
+                            : () => widget.onStartCursorAgent!(issue.id),
+                        onIssueDropped: widget.onIssueDropped,
+                      );
+                    },
+                  ),
+                  const SizedBox(height: 8),
+                ],
+              if (canToggleSize) ...[
+                InlineColumnSizeButton(
+                  isShrunk: _isShrunk,
+                  hiddenIssueCount: hiddenIssueCount,
+                  totalIssueCount: visibleIssues.length,
+                  collapsedIssueCount: compactColumnCollapsedLimit,
+                  onPressed: () => setState(() => _isShrunk = !_isShrunk),
+                ),
+                const SizedBox(height: 8),
+              ],
+              IssueDropSlot(
+                columnId: widget.column.id,
+                index: widget.column.issues.length,
+                onIssueDropped: widget.onIssueDropped,
+                isLast: true,
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}
+
+class ReviewPullRequestGroup {
+  const ReviewPullRequestGroup({
+    required this.repository,
+    required this.pullRequest,
+    required this.issues,
+  });
+
+  final String repository;
+  final IssuePullRequest? pullRequest;
+  final List<Issue> issues;
+}
+
+class _MutableReviewPullRequestGroup {
+  _MutableReviewPullRequestGroup({
+    required this.repository,
+    required this.pullRequest,
+  });
+
+  final String repository;
+  final IssuePullRequest? pullRequest;
+  final List<Issue> issues = [];
+}
+
+class _ReviewLinkedIssueItem {
+  const _ReviewLinkedIssueItem({this.issue, this.reference});
+
+  final Issue? issue;
+  final IssuePullRequestLinkedIssue? reference;
+
+  int get number => reference?.number ?? issue?.githubNumber ?? 0;
+}
+
+List<ReviewPullRequestGroup> _reviewPullRequestGroupsForIssues(
+  List<Issue> issues,
+) {
+  final groups = <String, _MutableReviewPullRequestGroup>{};
+  for (final issue in issues) {
+    final pullRequest = issue.pullRequests.isEmpty
+        ? null
+        : issue.pullRequests.last;
+    final repository = issue.repo;
+    final key = pullRequest == null
+        ? 'without-pull-request'
+        : '$repository#${pullRequest.number}';
+    final group = groups.putIfAbsent(
+      key,
+      () => _MutableReviewPullRequestGroup(
+        repository: repository,
+        pullRequest: pullRequest,
+      ),
+    );
+    group.issues.add(issue);
+  }
+
+  return [
+    for (final group in groups.values)
+      ReviewPullRequestGroup(
+        repository: group.repository,
+        pullRequest: group.pullRequest,
+        issues: List.unmodifiable(group.issues),
+      ),
+  ]..sort(_compareReviewPullRequestGroups);
+}
+
+int _compareReviewPullRequestGroups(
+  ReviewPullRequestGroup a,
+  ReviewPullRequestGroup b,
+) {
+  final aCreatedAt = a.pullRequest?.createdAt;
+  final bCreatedAt = b.pullRequest?.createdAt;
+  if (aCreatedAt != null && bCreatedAt != null) {
+    final createdAtCompare = aCreatedAt.compareTo(bCreatedAt);
+    if (createdAtCompare != 0) {
+      return createdAtCompare;
+    }
+  } else if (aCreatedAt != null) {
+    return -1;
+  } else if (bCreatedAt != null) {
+    return 1;
+  }
+
+  final rankCompare = _firstReviewIssueRank(a).compareTo(
+    _firstReviewIssueRank(b),
+  );
+  if (rankCompare != 0) {
+    return rankCompare;
+  }
+
+  final repositoryCompare = a.repository.compareTo(b.repository);
+  if (repositoryCompare != 0) {
+    return repositoryCompare;
+  }
+
+  return (a.pullRequest?.number ?? 0).compareTo(b.pullRequest?.number ?? 0);
+}
+
+double _firstReviewIssueRank(ReviewPullRequestGroup group) {
+  return group.issues.isEmpty ? double.infinity : group.issues.first.rank;
+}
+
+List<_ReviewLinkedIssueItem> _linkedIssueItemsForPullRequest({
+  required ReviewPullRequestGroup group,
+  required Map<String, Issue> issuesByRepositoryNumber,
+}) {
+  final pullRequest = group.pullRequest;
+  final seenNumbers = <int>{};
+  final items = <_ReviewLinkedIssueItem>[];
+
+  for (final reference
+      in pullRequest?.linkedIssues ?? const <IssuePullRequestLinkedIssue>[]) {
+    final issue =
+        issuesByRepositoryNumber[issueRepositoryNumberKey(
+          group.repository,
+          reference.number,
+        )];
+    if (issue != null &&
+        !issue.pullRequests.any(
+          (issuePullRequest) => issuePullRequest.number == pullRequest?.number,
+        )) {
+      continue;
+    }
+    seenNumbers.add(reference.number);
+    items.add(_ReviewLinkedIssueItem(issue: issue, reference: reference));
+  }
+
+  for (final issue in group.issues) {
+    final issueNumber = issue.githubNumber;
+    if (issueNumber > 0 && seenNumbers.contains(issueNumber)) {
+      continue;
+    }
+    if (issueNumber > 0) {
+      seenNumbers.add(issueNumber);
+    }
+    items.add(_ReviewLinkedIssueItem(issue: issue));
+  }
+
+  return items;
+}
+
+class ReviewPullRequestGroupView extends StatelessWidget {
+  const ReviewPullRequestGroupView({
+    super.key,
+    required this.group,
+    required this.column,
+    required this.subIssuesByParentId,
+    required this.buildStatusesByIssueId,
+    required this.issuesByRepositoryNumber,
+    required this.rankIndicesByIssueId,
+    required this.startingCursorAgentIssueIds,
+    required this.requiresLongPressDrag,
+    required this.onIssueTapped,
+    required this.onSubIssueTap,
+    required this.onIssueDropped,
+    this.onIssueLinkedToPullRequest,
+    this.onStartCursorAgent,
+  });
+
+  final ReviewPullRequestGroup group;
+  final BoardColumn column;
+  final Map<String, List<Issue>> subIssuesByParentId;
+  final Map<String, CardBuildStatus> buildStatusesByIssueId;
+  final Map<String, Issue> issuesByRepositoryNumber;
+  final Map<String, int> rankIndicesByIssueId;
+  final Set<String> startingCursorAgentIssueIds;
+  final bool requiresLongPressDrag;
+  final ValueChanged<String> onIssueTapped;
+  final ValueChanged<String> onSubIssueTap;
+  final IssueDropCallback onIssueDropped;
+  final IssuePullRequestLinkCallback? onIssueLinkedToPullRequest;
+  final ValueChanged<String>? onStartCursorAgent;
+
+  @override
+  Widget build(BuildContext context) {
+    final pullRequest = group.pullRequest;
+    final linkedIssueItems = _linkedIssueItemsForPullRequest(
+      group: group,
+      issuesByRepositoryNumber: issuesByRepositoryNumber,
+    );
+    final buildStatus = pullRequest == null
+        ? null
+        : group.issues.isEmpty
+        ? null
+        : buildStatusesByIssueId[group.issues.first.id];
+    final title = pullRequest?.title ?? 'PR未紐づけ';
+    final url = pullRequest?.url;
+    final isOpenPullRequest =
+        pullRequest != null &&
+        !pullRequest.merged &&
+        pullRequest.state.toLowerCase() == 'open';
+    final stateLabel = pullRequest == null
+        ? 'no PR'
+        : pullRequest.merged
+        ? 'merged'
+        : pullRequest.state;
+    final stateColor = pullRequest == null
+        ? const Color(0xFF64748B)
+        : pullRequest.merged
+        ? const Color(0xFF7C3AED)
+        : pullRequest.state == 'closed'
+        ? const Color(0xFFB45309)
+        : const Color(0xFF15803D);
+    final groupIssueIds = group.issues.map((issue) => issue.id).toSet();
+
+    void handleIssueDropped({
+      required String issueId,
+      required String targetColumnId,
+      required int targetIndex,
+      bool clearPullRequests = false,
+    }) {
+      final targetPullRequest = pullRequest;
+      final onLink = onIssueLinkedToPullRequest;
+      if (targetPullRequest != null &&
+          onLink != null &&
+          !groupIssueIds.contains(issueId)) {
+        unawaited(
+          onLink(
+            issueId: issueId,
+            repository: group.repository,
+            pullRequest: targetPullRequest,
+          ),
+        );
+        return;
+      }
+
+      onIssueDropped(
+        issueId: issueId,
+        targetColumnId: targetColumnId,
+        targetIndex: targetIndex,
+        clearPullRequests: clearPullRequests || pullRequest == null,
+      );
+    }
+
+    return DragTarget<IssueDragData>(
+      onWillAcceptWithDetails: (details) =>
+          pullRequest != null &&
+          onIssueLinkedToPullRequest != null &&
+          !groupIssueIds.contains(details.data.issueId),
+      onAcceptWithDetails: (details) {
+        handleIssueDropped(
+          issueId: details.data.issueId,
+          targetColumnId: column.id,
+          targetIndex: column.issues.length,
+        );
+      },
+      builder: (context, candidateData, rejectedData) {
+        final isGroupHovering = candidateData.isNotEmpty;
+        return Container(
+          padding: const EdgeInsets.all(8),
+          decoration: BoxDecoration(
+            color: isGroupHovering
+                ? const Color(0xFFEFF6FF)
+                : const Color(0xFFF8FAFC),
+            border: Border.all(
+              color: isGroupHovering
+                  ? const Color(0xFF60A5FA)
+                  : const Color(0xFFE2E8F0),
+            ),
+            borderRadius: BorderRadius.circular(18),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              DragTarget<IssueDragData>(
+                onWillAcceptWithDetails: (details) =>
+                    pullRequest != null &&
+                    onIssueLinkedToPullRequest != null &&
+                    !groupIssueIds.contains(details.data.issueId),
+                onAcceptWithDetails: (details) {
+                  final targetPullRequest = pullRequest;
+                  final onLink = onIssueLinkedToPullRequest;
+                  if (targetPullRequest == null || onLink == null) {
+                    return;
+                  }
+
+                  unawaited(
+                    onLink(
+                      issueId: details.data.issueId,
+                      repository: group.repository,
+                      pullRequest: targetPullRequest,
+                    ),
+                  );
+                },
+                builder: (context, candidateData, rejectedData) {
+                  final isHovering = candidateData.isNotEmpty;
+                  return AnimatedContainer(
+                    duration: const Duration(milliseconds: 150),
+                    decoration: BoxDecoration(
+                      color: isHovering
+                          ? const Color(0xFFEFF6FF)
+                          : Colors.transparent,
+                      border: Border.all(
+                        color: isHovering
+                            ? const Color(0xFF60A5FA)
+                            : Colors.transparent,
+                      ),
+                      borderRadius: BorderRadius.circular(14),
+                    ),
+                    child: Material(
+                      color: Colors.transparent,
+                      borderRadius: BorderRadius.circular(14),
+                      clipBehavior: Clip.antiAlias,
+                      child: InkWell(
+                        onTap: url == null
+                            ? null
+                            : () => unawaited(launchUrlExternal(url)),
+                        child: Padding(
+                          padding: const EdgeInsets.fromLTRB(8, 7, 8, 9),
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Row(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: [
+                                  Container(
+                                    width: 30,
+                                    height: 30,
+                                    decoration: BoxDecoration(
+                                      color: const Color(0xFFEFF6FF),
+                                      borderRadius: BorderRadius.circular(11),
+                                    ),
+                                    child: const Icon(
+                                      Icons.alt_route_rounded,
+                                      size: 17,
+                                      color: Color(0xFF2563EB),
+                                    ),
+                                  ),
+                                  const SizedBox(width: 9),
+                                  Expanded(
+                                    child: Column(
+                                      crossAxisAlignment:
+                                          CrossAxisAlignment.start,
+                                      children: [
+                                        Text(
+                                          pullRequest == null
+                                              ? 'PRなし'
+                                              : '${group.repository} #${pullRequest.number}',
+                                          maxLines: 1,
+                                          overflow: TextOverflow.ellipsis,
+                                          style: const TextStyle(
+                                            color: Color(0xFF475569),
+                                            fontSize: 12,
+                                            fontWeight: FontWeight.w900,
+                                          ),
+                                        ),
+                                        const SizedBox(height: 2),
+                                        Text(
+                                          title,
+                                          maxLines: 2,
+                                          overflow: TextOverflow.ellipsis,
+                                          style: const TextStyle(
+                                            color: Color(0xFF0F172A),
+                                            fontWeight: FontWeight.w900,
+                                            height: 1.25,
+                                          ),
+                                        ),
+                                      ],
+                                    ),
+                                  ),
+                                ],
+                              ),
+                              const SizedBox(height: 9),
+                              Wrap(
+                                spacing: 6,
+                                runSpacing: 6,
+                                crossAxisAlignment: WrapCrossAlignment.center,
+                                children: [
+                                  if (!isOpenPullRequest)
+                                    ReviewGroupPill(
+                                      label: stateLabel,
+                                      color: stateColor,
+                                      icon: pullRequest?.merged == true
+                                          ? Icons.call_merge_rounded
+                                          : Icons.circle_rounded,
+                                    ),
+                                  BuildStatusBadge(status: buildStatus),
+                                ],
+                              ),
+                            ],
+                          ),
+                        ),
+                      ),
+                    ),
+                  );
+                },
+              ),
+              const SizedBox(height: 6),
+              for (final entry in linkedIssueItems.indexed) ...[
+                Builder(
+                  builder: (context) {
+                    final item = entry.$2;
+                    final issue = item.issue;
+                    if (issue == null) {
+                      final reference = item.reference;
+                      if (reference == null) {
+                        return const SizedBox.shrink();
+                      }
+                      return ReviewLinkedIssueReferenceCard(
+                        reference: reference,
+                      );
+                    }
+
+                    final isReviewColumnIssue = group.issues.any(
+                      (candidate) => candidate.id == issue.id,
+                    );
+                    if (!isReviewColumnIssue) {
+                      return GestureDetector(
+                        behavior: HitTestBehavior.opaque,
+                        onTap: () => onIssueTapped(issue.id),
+                        child: ReviewGroupIssueCard(issue: issue),
+                      );
+                    }
+
+                    final rankIndex = rankIndicesByIssueId[issue.id];
+
+                    return IssueCardDropTarget(
+                      key: ValueKey(issue.id),
+                      issue: issue,
+                      subIssues:
+                          subIssuesByParentId[issue.id] ?? const <Issue>[],
+                      buildStatus: pullRequest == null
+                          ? buildStatusesByIssueId[issue.id]
+                          : null,
+                      isReviewGroupCard: true,
+                      sourceColumnId: column.id,
+                      index: rankIndex ?? entry.$1,
+                      isStartingCursorAgent: startingCursorAgentIssueIds
+                          .contains(
+                            issue.id,
+                          ),
+                      requiresLongPressDrag: requiresLongPressDrag,
+                      onTap: () => onIssueTapped(issue.id),
+                      onSubIssueTap: onSubIssueTap,
+                      onStartCursorAgent: onStartCursorAgent == null
+                          ? null
+                          : () => onStartCursorAgent!(issue.id),
+                      onIssueDropped: handleIssueDropped,
+                    );
+                  },
+                ),
+                if (entry.$1 != linkedIssueItems.length - 1)
+                  const SizedBox(height: 8),
+              ],
+            ],
+          ),
+        );
+      },
+    );
+  }
+}
+
+class ReviewGroupPill extends StatelessWidget {
+  const ReviewGroupPill({
+    super.key,
+    required this.label,
+    required this.color,
+    required this.icon,
+  });
+
+  final String label;
+  final Color color;
+  final IconData icon;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 7, vertical: 4),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.09),
+        border: Border.all(color: color.withValues(alpha: 0.22)),
+        borderRadius: BorderRadius.circular(999),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: 11, color: color),
+          const SizedBox(width: 4),
+          Text(
+            label,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: TextStyle(
+              color: color,
+              fontSize: 12,
+              fontWeight: FontWeight.w900,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class InlineColumnSizeButton extends StatelessWidget {
+  const InlineColumnSizeButton({
+    super.key,
+    required this.isShrunk,
+    required this.hiddenIssueCount,
+    required this.totalIssueCount,
+    required this.collapsedIssueCount,
+    required this.onPressed,
+  });
+
+  final bool isShrunk;
+  final int hiddenIssueCount;
+  final int totalIssueCount;
+  final int collapsedIssueCount;
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    final label = isShrunk
+        ? 'さらに$hiddenIssueCount件表示（全$totalIssueCount件）'
+        : collapsedIssueCount == 0
+        ? '縮小して件数だけ表示'
+        : '縮小して先頭$collapsedIssueCount件だけ表示';
+    return SizedBox(
+      width: double.infinity,
+      child: OutlinedButton.icon(
+        onPressed: onPressed,
+        icon: Icon(
+          isShrunk
+              ? Icons.keyboard_arrow_down_rounded
+              : Icons.keyboard_arrow_up_rounded,
+          size: 20,
+        ),
+        label: Text(label),
+        style: OutlinedButton.styleFrom(
+          alignment: Alignment.centerLeft,
+          foregroundColor: const Color(0xFF2563EB),
+          backgroundColor: const Color(0xFFEFF6FF),
+          side: const BorderSide(color: Color(0xFFBFDBFE)),
+          padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+          textStyle: const TextStyle(fontWeight: FontWeight.w800),
+        ),
+      ),
+    );
+  }
+}
+
+class OverviewBoard extends StatelessWidget {
+  const OverviewBoard({
+    super.key,
+    required this.columns,
+    required this.isCompact,
+    required this.onIssueTapped,
+    required this.onIssueDropped,
+  });
+
+  final List<BoardColumn> columns;
+  final bool isCompact;
+  final ValueChanged<String> onIssueTapped;
+  final IssueDropCallback onIssueDropped;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Expanded(
+          child: OverviewList(
+            columns: columns,
+            isCompact: isCompact,
+            onIssueTapped: onIssueTapped,
+            onIssueDropped: onIssueDropped,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class OverviewList extends StatelessWidget {
+  const OverviewList({
+    super.key,
+    required this.columns,
+    required this.isCompact,
+    required this.onIssueTapped,
+    required this.onIssueDropped,
+  });
+
+  final List<BoardColumn> columns;
+  final bool isCompact;
+  final ValueChanged<String> onIssueTapped;
+  final IssueDropCallback onIssueDropped;
+
+  @override
+  Widget build(BuildContext context) {
+    final bottomPadding = isCompact ? boardBottomPadding + 72 : 14.0;
+
+    if (isCompact) {
+      return CompactOverviewList(
+        columns: columns,
+        bottomPadding: bottomPadding,
+        onIssueTapped: onIssueTapped,
+        onIssueDropped: onIssueDropped,
+      );
+    }
+
+    final allIssues = [
+      for (final column in columns)
+        for (final issue in visibleIssuesForColumn(column)) issue,
+    ];
+    final totalWeight = allIssues.fold<int>(
+      0,
+      (total, issue) =>
+          total +
+          (issue.statusId == closedStatusId
+              ? issue.resolution?.actualWeight ?? 0
+              : issue.weightEstimate?.value ?? 0),
+    );
+    final summary = OverviewSummaryCard(
+      issueCount: allIssues.length,
+      totalWeight: totalWeight,
+      columnCount: columns.length,
+    );
+
+    return Column(
+      children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(
+            boardHorizontalPadding,
+            4,
+            boardHorizontalPadding,
+            0,
+          ),
+          child: summary,
+        ),
+        const SizedBox(height: 8),
+        Expanded(
+          child: SingleChildScrollView(
+            padding: EdgeInsets.fromLTRB(
+              boardHorizontalPadding,
+              0,
+              boardHorizontalPadding,
+              bottomPadding,
+            ),
+            scrollDirection: Axis.horizontal,
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                for (final column in columns) ...[
+                  SizedBox(
+                    width: 286,
+                    child: OverviewSection(
+                      key: ValueKey(column.id),
+                      column: column,
+                      isCompact: false,
+                      requiresLongPressDrag: false,
+                      fillHeight: true,
+                      onIssueTapped: onIssueTapped,
+                      onIssueDropped: onIssueDropped,
+                    ),
+                  ),
+                  if (column != columns.last) const SizedBox(width: 8),
+                ],
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class CompactOverviewList extends StatefulWidget {
+  const CompactOverviewList({
+    super.key,
+    required this.columns,
+    required this.bottomPadding,
+    required this.onIssueTapped,
+    required this.onIssueDropped,
+  });
+
+  final List<BoardColumn> columns;
+  final double bottomPadding;
+  final ValueChanged<String> onIssueTapped;
+  final IssueDropCallback onIssueDropped;
+
+  @override
+  State<CompactOverviewList> createState() => _CompactOverviewListState();
+}
+
+class _CompactOverviewListState extends State<CompactOverviewList> {
+  final _expandedColumnIds = <String>{};
+
+  @override
+  Widget build(BuildContext context) {
+    return CustomScrollView(
+      slivers: [
+        for (final entry in widget.columns.indexed) ...[
+          SliverStickyHeader(
+            header: Padding(
+              padding: EdgeInsets.fromLTRB(
+                boardHorizontalPadding,
+                entry.$1 == 0 ? 4 : 8,
+                boardHorizontalPadding,
+                0,
+              ),
+              child: OverviewSectionHeader(
+                column: entry.$2,
+                isShrunk: !_expandedColumnIds.contains(entry.$2.id),
+                onToggleSize: () => setState(() {
+                  final columnId = entry.$2.id;
+                  if (!_expandedColumnIds.remove(columnId)) {
+                    _expandedColumnIds.add(columnId);
+                  }
+                }),
+              ),
+            ),
+            sliver: _expandedColumnIds.contains(entry.$2.id)
+                ? SliverPadding(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: boardHorizontalPadding,
+                    ),
+                    sliver: SliverToBoxAdapter(
+                      child: _CompactOverviewSectionBody(
+                        column: entry.$2,
+                        onIssueTapped: widget.onIssueTapped,
+                        onIssueDropped: widget.onIssueDropped,
+                      ),
+                    ),
+                  )
+                : const SliverToBoxAdapter(child: SizedBox.shrink()),
+          ),
+        ],
+        SliverToBoxAdapter(child: SizedBox(height: widget.bottomPadding)),
+      ],
+    );
+  }
+}
+
+class OverviewSectionHeader extends StatelessWidget {
+  const OverviewSectionHeader({
+    super.key,
+    required this.column,
+    required this.isShrunk,
+    required this.onToggleSize,
+    this.borderRadius = const BorderRadius.all(Radius.circular(18)),
+  });
+
+  final BoardColumn column;
+  final bool isShrunk;
+  final VoidCallback onToggleSize;
+  final BorderRadius borderRadius;
+
+  @override
+  Widget build(BuildContext context) {
+    final visibleIssues = visibleIssuesForColumn(column);
+    final totalWeight = visibleIssues.fold<int>(
+      0,
+      (total, issue) =>
+          total +
+          (issue.statusId == closedStatusId
+              ? issue.resolution?.actualWeight ?? 0
+              : issue.weightEstimate?.value ?? 0),
+    );
+
+    return Material(
+      color: const Color(0xFFFAFBFC),
+      elevation: 0,
+      shape: RoundedRectangleBorder(
+        borderRadius: borderRadius,
+        side: const BorderSide(color: Color(0xFFE2E8F0)),
+      ),
+      clipBehavior: Clip.antiAlias,
+      child: InkWell(
+        onTap: onToggleSize,
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(10, 9, 8, 8),
+          child: Row(
+            children: [
+              Container(
+                width: 7,
+                height: 24,
+                decoration: BoxDecoration(
+                  color: column.color,
+                  borderRadius: BorderRadius.circular(999),
+                ),
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  column.title,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: const TextStyle(
+                    color: Color(0xFF0F172A),
+                    fontSize: 13,
+                    fontWeight: FontWeight.w900,
+                  ),
+                ),
+              ),
+              const SizedBox(width: 8),
+              _OverviewMiniPill(
+                label: '${visibleIssues.length}件 / W$totalWeight',
+                foregroundColor: column.color,
+                backgroundColor: column.color.withValues(alpha: 0.1),
+              ),
+              const SizedBox(width: 4),
+              Icon(
+                isShrunk
+                    ? Icons.keyboard_arrow_down_rounded
+                    : Icons.keyboard_arrow_up_rounded,
+                size: 22,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _CompactOverviewSectionBody extends StatelessWidget {
+  const _CompactOverviewSectionBody({
+    required this.column,
+    required this.onIssueTapped,
+    required this.onIssueDropped,
+  });
+
+  final BoardColumn column;
+  final ValueChanged<String> onIssueTapped;
+  final IssueDropCallback onIssueDropped;
+
+  @override
+  Widget build(BuildContext context) {
+    final visibleIssues = visibleIssuesForColumn(column);
+
+    return DecoratedBox(
+      decoration: const BoxDecoration(
+        color: Colors.white,
+        border: Border.fromBorderSide(BorderSide(color: Color(0xFFE2E8F0))),
+        borderRadius: BorderRadius.vertical(bottom: Radius.circular(18)),
+      ),
+      child: ClipRRect(
+        borderRadius: const BorderRadius.vertical(bottom: Radius.circular(18)),
+        child: Column(
+          children: [
+            for (final entry in visibleIssues.indexed) ...[
+              Builder(
+                builder: (context) {
+                  final issue = entry.$2;
+                  final rankIndex = column.issues.indexWhere(
+                    (candidate) => candidate.id == issue.id,
+                  );
+                  return OverviewIssueDropTarget(
+                    issue: issue,
+                    columnId: column.id,
+                    index: rankIndex < 0 ? entry.$1 : rankIndex,
+                    accentColor: column.color,
+                    isCompact: true,
+                    requiresLongPressDrag: true,
+                    onIssueTapped: onIssueTapped,
+                    onIssueDropped: onIssueDropped,
+                  );
+                },
+              ),
+              if (entry.$1 != visibleIssues.length - 1)
+                const Divider(height: 1, color: Color(0xFFE2E8F0)),
+            ],
+            OverviewColumnDropSlot(
+              columnId: column.id,
+              index: column.issues.length,
+              onIssueDropped: onIssueDropped,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class OverviewSummaryCard extends StatelessWidget {
+  const OverviewSummaryCard({
+    super.key,
+    required this.issueCount,
+    required this.totalWeight,
+    required this.columnCount,
+  });
+
+  final int issueCount;
+  final int totalWeight;
+  final int columnCount;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 9),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        border: Border.all(color: const Color(0xFFE2E8F0)),
+        borderRadius: BorderRadius.circular(16),
+      ),
+      child: Wrap(
+        spacing: 8,
+        runSpacing: 8,
+        crossAxisAlignment: WrapCrossAlignment.center,
+        children: [
+          const Text(
+            '全体リスト',
+            style: TextStyle(
+              color: Color(0xFF0F172A),
+              fontSize: 13,
+              fontWeight: FontWeight.w900,
+            ),
+          ),
+          _OverviewMiniPill(
+            label: '$issueCount件',
+            foregroundColor: const Color(0xFF2563EB),
+            backgroundColor: const Color(0xFFEFF6FF),
+          ),
+          _OverviewMiniPill(
+            label: 'W$totalWeight',
+            foregroundColor: const Color(0xFF15803D),
+            backgroundColor: const Color(0xFFDCFCE7),
+          ),
+          _OverviewMiniPill(
+            label: '$columnCount列',
+            foregroundColor: const Color(0xFF64748B),
+            backgroundColor: const Color(0xFFF1F5F9),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class OverviewSection extends StatefulWidget {
+  const OverviewSection({
+    super.key,
+    required this.column,
+    required this.isCompact,
+    required this.requiresLongPressDrag,
+    required this.onIssueTapped,
+    required this.onIssueDropped,
+    this.fillHeight = false,
+  });
+
+  final BoardColumn column;
+  final bool isCompact;
+  final bool requiresLongPressDrag;
+  final ValueChanged<String> onIssueTapped;
+  final IssueDropCallback onIssueDropped;
+  final bool fillHeight;
+
+  @override
+  State<OverviewSection> createState() => _OverviewSectionState();
+}
+
+class _OverviewSectionState extends State<OverviewSection> {
+  late var _isShrunk = widget.isCompact;
+
+  @override
+  void didUpdateWidget(covariant OverviewSection oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.isCompact != widget.isCompact) {
+      _isShrunk = widget.isCompact;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final visibleIssues = visibleIssuesForColumn(widget.column);
+    final displayedIssues = widget.isCompact && _isShrunk
+        ? visibleIssues.take(compactColumnCollapsedLimit).toList()
+        : visibleIssues;
+    final hiddenIssueCount = visibleIssues.length - displayedIssues.length;
+    final canToggleSize =
+        widget.isCompact && visibleIssues.length > compactColumnCollapsedLimit;
+    final showDropSlot = !widget.isCompact || !_isShrunk;
+    final totalWeight = visibleIssues.fold<int>(
+      0,
+      (total, issue) =>
+          total +
+          (issue.statusId == closedStatusId
+              ? issue.resolution?.actualWeight ?? 0
+              : issue.weightEstimate?.value ?? 0),
+    );
+
+    return DragTarget<IssueDragData>(
+      onWillAcceptWithDetails: (details) =>
+          details.data.sourceColumnId != widget.column.id,
+      onAcceptWithDetails: (details) {
+        widget.onIssueDropped(
+          issueId: details.data.issueId,
+          targetColumnId: widget.column.id,
+          targetIndex: widget.column.issues.length,
+        );
+      },
+      builder: (context, candidateData, rejectedData) {
+        final isHovering = candidateData.isNotEmpty;
+        return AnimatedContainer(
+          duration: const Duration(milliseconds: 140),
+          decoration: BoxDecoration(
+            color: isHovering
+                ? widget.column.color.withValues(alpha: 0.06)
+                : Colors.white,
+            border: Border.all(
+              color: isHovering
+                  ? widget.column.color.withValues(alpha: 0.38)
+                  : const Color(0xFFE2E8F0),
+            ),
+            borderRadius: BorderRadius.circular(18),
+          ),
+          clipBehavior: Clip.antiAlias,
+          child: Column(
+            children: [
+              Container(
+                padding: const EdgeInsets.fromLTRB(10, 9, 10, 8),
+                color: const Color(0xFFFAFBFC),
+                child: Row(
+                  children: [
+                    Container(
+                      width: 7,
+                      height: 24,
+                      decoration: BoxDecoration(
+                        color: widget.column.color,
+                        borderRadius: BorderRadius.circular(999),
+                      ),
+                    ),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            widget.column.title,
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: const TextStyle(
+                              color: Color(0xFF0F172A),
+                              fontSize: 13,
+                              fontWeight: FontWeight.w900,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                    const SizedBox(width: 8),
+                    _OverviewMiniPill(
+                      label: '${visibleIssues.length}件 / W$totalWeight',
+                      foregroundColor: widget.column.color,
+                      backgroundColor: widget.column.color.withValues(
+                        alpha: 0.1,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              if (widget.fillHeight)
+                Expanded(
+                  child: ListView(
+                    padding: EdgeInsets.zero,
+                    children: [
+                      ..._issueRows(displayedIssues),
+                      if (canToggleSize)
+                        Padding(
+                          padding: const EdgeInsets.only(bottom: 6),
+                          child: InlineColumnSizeButton(
+                            isShrunk: _isShrunk,
+                            hiddenIssueCount: hiddenIssueCount,
+                            totalIssueCount: visibleIssues.length,
+                            collapsedIssueCount: compactColumnCollapsedLimit,
+                            onPressed: () =>
+                                setState(() => _isShrunk = !_isShrunk),
+                          ),
+                        ),
+                      if (showDropSlot)
+                        OverviewColumnDropSlot(
+                          columnId: widget.column.id,
+                          index: widget.column.issues.length,
+                          onIssueDropped: widget.onIssueDropped,
+                        ),
+                    ],
+                  ),
+                )
+              else ...[
+                ..._issueRows(displayedIssues),
+                if (canToggleSize)
+                  Padding(
+                    padding: const EdgeInsets.fromLTRB(10, 8, 10, 6),
+                    child: InlineColumnSizeButton(
+                      isShrunk: _isShrunk,
+                      hiddenIssueCount: hiddenIssueCount,
+                      totalIssueCount: visibleIssues.length,
+                      collapsedIssueCount: compactColumnCollapsedLimit,
+                      onPressed: () => setState(() => _isShrunk = !_isShrunk),
+                    ),
+                  ),
+                if (showDropSlot)
+                  OverviewColumnDropSlot(
+                    columnId: widget.column.id,
+                    index: widget.column.issues.length,
+                    onIssueDropped: widget.onIssueDropped,
+                  ),
+              ],
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  List<Widget> _issueRows(List<Issue> visibleIssues) {
+    final rankIndicesByIssueId = _rankIndicesByIssueId(widget.column.issues);
+    return [
+      for (final entry in visibleIssues.indexed) ...[
+        Builder(
+          builder: (context) {
+            final issue = entry.$2;
+            final rankIndex = rankIndicesByIssueId[issue.id];
+            return OverviewIssueDropTarget(
+              key: ValueKey(issue.id),
+              issue: issue,
+              columnId: widget.column.id,
+              index: rankIndex ?? entry.$1,
+              accentColor: widget.column.color,
+              isCompact: widget.isCompact,
+              requiresLongPressDrag: widget.requiresLongPressDrag,
+              onIssueTapped: widget.onIssueTapped,
+              onIssueDropped: widget.onIssueDropped,
+            );
+          },
+        ),
+        if (entry.$1 != visibleIssues.length - 1)
+          const Divider(height: 1, color: Color(0xFFE2E8F0)),
+      ],
+    ];
+  }
+}
+
+class OverviewIssueDropTarget extends StatelessWidget {
+  const OverviewIssueDropTarget({
+    super.key,
+    required this.issue,
+    required this.columnId,
+    required this.index,
+    required this.accentColor,
+    required this.isCompact,
+    required this.requiresLongPressDrag,
+    required this.onIssueTapped,
+    required this.onIssueDropped,
+  });
+
+  final Issue issue;
+  final String columnId;
+  final int index;
+  final Color accentColor;
+  final bool isCompact;
+  final bool requiresLongPressDrag;
+  final ValueChanged<String> onIssueTapped;
+  final IssueDropCallback onIssueDropped;
+
+  @override
+  Widget build(BuildContext context) {
+    return DragTarget<IssueDragData>(
+      onWillAcceptWithDetails: (details) => details.data.issueId != issue.id,
+      onAcceptWithDetails: (details) {
+        onIssueDropped(
+          issueId: details.data.issueId,
+          targetColumnId: columnId,
+          targetIndex: index,
+        );
+      },
+      builder: (context, candidateData, rejectedData) {
+        final isHovering = candidateData.isNotEmpty;
+        return Column(
+          children: [
+            AnimatedContainer(
+              duration: const Duration(milliseconds: 120),
+              height: isHovering ? 4 : 0,
+              margin: const EdgeInsets.symmetric(horizontal: 10),
+              decoration: BoxDecoration(
+                color: accentColor,
+                borderRadius: BorderRadius.circular(999),
+              ),
+            ),
+            OverviewIssueRow(
+              issue: issue,
+              sourceColumnId: columnId,
+              accentColor: accentColor,
+              isCompact: isCompact,
+              requiresLongPressDrag: requiresLongPressDrag,
+              onTap: () => onIssueTapped(issue.id),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}
+
+class OverviewColumnDropSlot extends StatelessWidget {
+  const OverviewColumnDropSlot({
+    super.key,
+    required this.columnId,
+    required this.index,
+    required this.onIssueDropped,
+  });
+
+  final String columnId;
+  final int index;
+  final IssueDropCallback onIssueDropped;
+
+  @override
+  Widget build(BuildContext context) {
+    return DragTarget<IssueDragData>(
+      onWillAcceptWithDetails: (details) => true,
+      onAcceptWithDetails: (details) {
+        onIssueDropped(
+          issueId: details.data.issueId,
+          targetColumnId: columnId,
+          targetIndex: index,
+        );
+      },
+      builder: (context, candidateData, rejectedData) {
+        final isHovering = candidateData.isNotEmpty;
+        return AnimatedContainer(
+          duration: const Duration(milliseconds: 120),
+          height: isHovering ? 34 : 10,
+          margin: const EdgeInsets.fromLTRB(10, 6, 10, 8),
+          decoration: BoxDecoration(
+            color: isHovering
+                ? const Color(0xFFEFF6FF)
+                : const Color(0xFFF8FAFC),
+            border: Border.all(
+              color: isHovering
+                  ? const Color(0xFF93C5FD)
+                  : const Color(0xFFE2E8F0),
+            ),
+            borderRadius: BorderRadius.circular(12),
+          ),
+          alignment: Alignment.center,
+          child: isHovering
+              ? const Text(
+                  'ここに移動',
+                  style: TextStyle(
+                    color: Color(0xFF2563EB),
+                    fontSize: 11,
+                    fontWeight: FontWeight.w900,
+                  ),
+                )
+              : const SizedBox.shrink(),
+        );
+      },
+    );
+  }
+}
+
+class OverviewIssueRow extends StatelessWidget {
+  const OverviewIssueRow({
+    super.key,
+    required this.issue,
+    required this.sourceColumnId,
+    required this.accentColor,
+    required this.isCompact,
+    required this.requiresLongPressDrag,
+    required this.onTap,
+  });
+
+  final Issue issue;
+  final String sourceColumnId;
+  final Color accentColor;
+  final bool isCompact;
+  final bool requiresLongPressDrag;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final repoName = _overviewRepoName(issue.repo);
+    final weight = issue.statusId == closedStatusId
+        ? issue.resolution?.actualWeight
+        : issue.weightEstimate?.value;
+    final weightPill = weight == null
+        ? const SizedBox(width: 38)
+        : _OverviewMiniPill(
+            label: 'W$weight',
+            foregroundColor: accentColor,
+            backgroundColor: accentColor.withValues(alpha: 0.1),
+          );
+
+    final row = _OverviewIssueRowContent(
+      repoName: repoName,
+      title: issue.title,
+      weightPill: weightPill,
+      isCompact: isCompact,
+    );
+
+    final data = IssueDragData(
+      issueId: issue.id,
+      sourceColumnId: sourceColumnId,
+    );
+    final feedback = Material(
+      color: Colors.transparent,
+      child: SizedBox(
+        width: isCompact ? 320 : 286,
+        child: DecoratedBox(
+          decoration: BoxDecoration(
+            color: Colors.white,
+            border: Border.all(color: accentColor.withValues(alpha: 0.35)),
+            borderRadius: BorderRadius.circular(12),
+            boxShadow: [
+              BoxShadow(
+                color: Colors.black.withValues(alpha: 0.16),
+                blurRadius: 20,
+                offset: const Offset(0, 10),
+              ),
+            ],
+          ),
+          child: row,
+        ),
+      ),
+    );
+    final child = Material(
+      color: Colors.transparent,
+      child: InkWell(onTap: onTap, child: row),
+    );
+
+    if (requiresLongPressDrag) {
+      return LongPressDraggable<IssueDragData>(
+        data: data,
+        delay: mobileDragStartDelay,
+        feedback: feedback,
+        childWhenDragging: Opacity(opacity: 0.35, child: row),
+        child: child,
+      );
+    }
+
+    return Draggable<IssueDragData>(
+      data: data,
+      feedback: feedback,
+      childWhenDragging: Opacity(opacity: 0.35, child: row),
+      child: child,
+    );
+  }
+}
+
+class _OverviewIssueRowContent extends StatelessWidget {
+  const _OverviewIssueRowContent({
+    required this.repoName,
+    required this.title,
+    required this.weightPill,
+    required this.isCompact,
+  });
+
+  final String repoName;
+  final String title;
+  final Widget weightPill;
+  final bool isCompact;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: EdgeInsets.fromLTRB(
+        10,
+        isCompact ? 9 : 7,
+        10,
+        isCompact ? 9 : 7,
+      ),
+      child: Row(
+        crossAxisAlignment: isCompact
+            ? CrossAxisAlignment.start
+            : CrossAxisAlignment.center,
+        children: [
+          SizedBox(
+            width: isCompact ? 58 : 72,
+            child: Text(
+              repoName,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: const TextStyle(
+                color: Color(0xFF64748B),
+                fontSize: 11,
+                fontWeight: FontWeight.w900,
+              ),
+            ),
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              title,
+              maxLines: isCompact ? 2 : 1,
+              overflow: TextOverflow.ellipsis,
+              style: const TextStyle(
+                color: Color(0xFF0F172A),
+                fontSize: 13,
+                fontWeight: FontWeight.w800,
+                height: 1.24,
+              ),
+            ),
+          ),
+          const SizedBox(width: 8),
+          Align(alignment: Alignment.topRight, child: weightPill),
+        ],
+      ),
+    );
+  }
+}
+
+String _overviewRepoName(String repo) {
+  final parts = repo.split('/');
+  return parts.isEmpty ? repo : parts.last;
+}
+
+class _OverviewMiniPill extends StatelessWidget {
+  const _OverviewMiniPill({
+    required this.label,
+    required this.foregroundColor,
+    required this.backgroundColor,
+  });
+
+  final String label;
+  final Color foregroundColor;
+  final Color backgroundColor;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+      decoration: BoxDecoration(
+        color: backgroundColor,
+        borderRadius: BorderRadius.circular(999),
+      ),
+      child: Text(
+        label,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+        style: TextStyle(
+          color: foregroundColor,
+          fontSize: 10,
+          fontWeight: FontWeight.w900,
+        ),
+      ),
+    );
+  }
+}
+
+List<Issue> visibleIssuesForColumn(BoardColumn column) {
+  if (column.id != closedStatusId) {
+    return column.issues;
+  }
+
+  return [...column.issues]..sort(compareDoneIssues);
+}
+
+Map<String, int> _rankIndicesByIssueId(List<Issue> issues) {
+  return {
+    for (final entry in issues.indexed) entry.$2.id: entry.$1,
+  };
+}
+
+List<Issue> subIssuesForParent(Issue parent, List<Issue> allIssues) {
+  final subIssues = allIssues
+      .where((issue) => issue.parentIssue?.issueId == parent.id)
+      .toList();
+  subIssues.sort((left, right) => left.rank.compareTo(right.rank));
+  return subIssues;
+}
+
+Map<String, List<Issue>> subIssuesByParentId(List<Issue> allIssues) {
+  final subIssuesByParentId = <String, List<Issue>>{};
+  for (final issue in allIssues) {
+    final parentId = issue.parentIssue?.issueId;
+    if (parentId == null || parentId.isEmpty) {
+      continue;
+    }
+    subIssuesByParentId.putIfAbsent(parentId, () => []).add(issue);
+  }
+  for (final subIssues in subIssuesByParentId.values) {
+    subIssues.sort((left, right) => left.rank.compareTo(right.rank));
+  }
+  return subIssuesByParentId;
+}
+
+List<Issue> descendantSubIssuesForParent(Issue parent, List<Issue> allIssues) {
+  final descendants = <Issue>[];
+  final seenIssueIds = <String>{parent.id};
+  var frontier = <Issue>[parent];
+
+  while (frontier.isNotEmpty) {
+    final nextFrontier = <Issue>[];
+    for (final issue in frontier) {
+      final children = subIssuesForParent(issue, allIssues);
+      for (final child in children) {
+        if (!seenIssueIds.add(child.id)) {
+          continue;
+        }
+        descendants.add(child);
+        nextFrontier.add(child);
+      }
+    }
+    frontier = nextFrontier;
+  }
+
+  return descendants;
+}
+
+int compareDoneIssues(Issue left, Issue right) {
+  final leftClosedAt = left.closedAt;
+  final rightClosedAt = right.closedAt;
+
+  if (leftClosedAt != null && rightClosedAt != null) {
+    final closedAtComparison = rightClosedAt.compareTo(leftClosedAt);
+    if (closedAtComparison != 0) {
+      return closedAtComparison;
+    }
+  }
+
+  return left.rank.compareTo(right.rank);
+}
+
+class ColumnHeader extends StatelessWidget {
+  const ColumnHeader({
+    super.key,
+    required this.column,
+    required this.isCompact,
+    required this.onAddIssue,
+  });
+
+  final BoardColumn column;
+  final bool isCompact;
+  final VoidCallback onAddIssue;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Container(
+          width: 8,
+          height: 34,
+          decoration: BoxDecoration(
+            color: column.color,
+            borderRadius: BorderRadius.circular(999),
+          ),
+        ),
+        const SizedBox(width: 8),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      column.title,
+                      overflow: TextOverflow.ellipsis,
+                      style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                        fontWeight: FontWeight.w700,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 6),
+                  CountPill(count: column.issues.length),
+                  const SizedBox(width: 2),
+                  AddIssueToColumnButton(
+                    columnTitle: column.title,
+                    isCompact: isCompact,
+                    onPressed: onAddIssue,
+                  ),
+                ],
+              ),
+              const SizedBox(height: 2),
+              Text(
+                column.description,
+                style: Theme.of(
+                  context,
+                ).textTheme.bodySmall?.copyWith(color: const Color(0xFF64748B)),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class AddIssueToColumnButton extends StatelessWidget {
+  const AddIssueToColumnButton({
+    super.key,
+    required this.columnTitle,
+    required this.isCompact,
+    required this.onPressed,
+  });
+
+  final String columnTitle;
+  final bool isCompact;
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    final buttonSize = isCompact ? 36.0 : 26.0;
+    final iconSize = isCompact ? 24.0 : 16.0;
+
+    return SizedBox.square(
+      dimension: buttonSize,
+      child: IconButton(
+        tooltip: '$columnTitleにissueを作成',
+        padding: EdgeInsets.zero,
+        constraints: BoxConstraints.tightFor(
+          width: buttonSize,
+          height: buttonSize,
+        ),
+        onPressed: onPressed,
+        icon: Icon(Icons.add_rounded, size: iconSize),
+      ),
+    );
+  }
+}
+
+class CountPill extends StatelessWidget {
+  const CountPill({super.key, required this.count});
+
+  final int count;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 7, vertical: 3),
+      decoration: BoxDecoration(
+        color: const Color(0xFFF1F5F9),
+        borderRadius: BorderRadius.circular(999),
+      ),
+      child: Text(
+        '$count',
+        style: const TextStyle(
+          color: Color(0xFF475569),
+          fontWeight: FontWeight.w700,
+          fontSize: 12,
+        ),
+      ),
+    );
+  }
+}
+
+class EmptyColumnIssueCreator extends StatelessWidget {
+  const EmptyColumnIssueCreator({
+    super.key,
+    required this.columnTitle,
+    required this.onPressed,
+  });
+
+  final String columnTitle;
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: const Color(0xFFF8FAFC),
+        border: Border.all(color: const Color(0xFFE2E8F0)),
+        borderRadius: BorderRadius.circular(16),
+      ),
+      child: Column(
+        children: [
+          const Icon(Icons.inbox_outlined, color: Color(0xFF94A3B8), size: 24),
+          const SizedBox(height: 6),
+          const Text(
+            'まだチケットがありません',
+            style: TextStyle(
+              color: Color(0xFF64748B),
+              fontWeight: FontWeight.w700,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Tooltip(
+            message: '$columnTitleにチケットを作成',
+            child: OutlinedButton(
+              onPressed: onPressed,
+              child: const Text('+ チケット作成'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class IssueDropSlot extends StatelessWidget {
+  const IssueDropSlot({
+    super.key,
+    required this.columnId,
+    required this.index,
+    required this.onIssueDropped,
+    this.isLast = false,
+  });
+
+  final String columnId;
+  final int index;
+  final IssueDropCallback onIssueDropped;
+  final bool isLast;
+
+  @override
+  Widget build(BuildContext context) {
+    return DragTarget<IssueDragData>(
+      onWillAcceptWithDetails: (_) => true,
+      onAcceptWithDetails: (details) {
+        onIssueDropped(
+          issueId: details.data.issueId,
+          targetColumnId: columnId,
+          targetIndex: index,
+        );
+      },
+      builder: (context, candidateData, rejectedData) {
+        final isHovering = candidateData.isNotEmpty;
+
+        return AnimatedContainer(
+          duration: const Duration(milliseconds: 120),
+          height: isHovering ? 42 : (isLast ? 54 : 6),
+          margin: EdgeInsets.only(bottom: isLast ? 0 : 4),
+          decoration: BoxDecoration(
+            color: isHovering ? const Color(0xFFE0F2FE) : Colors.transparent,
+            border: Border.all(
+              color: isHovering ? const Color(0xFF38BDF8) : Colors.transparent,
+            ),
+            borderRadius: BorderRadius.circular(14),
+          ),
+          alignment: Alignment.center,
+          child: isHovering
+              ? const Text(
+                  'ここに移動',
+                  style: TextStyle(
+                    color: Color(0xFF0369A1),
+                    fontWeight: FontWeight.w700,
+                  ),
+                )
+              : null,
+        );
+      },
+    );
+  }
+}

--- a/apps/dashboard/lib/workspace/issue_board_ima_board_page.dart
+++ b/apps/dashboard/lib/workspace/issue_board_ima_board_page.dart
@@ -1,0 +1,2427 @@
+import 'dart:async';
+import 'dart:math' as math;
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:cloud_functions/cloud_functions.dart';
+import 'package:dashboard/build_logs/synced_spinner.dart';
+import 'package:dashboard/firebase/callable_function_names.dart';
+import 'package:dashboard/firebase/firestore.dart' show buildJobsCollection;
+import 'package:dashboard/firebase/functions.dart';
+import 'package:dashboard/utilities/snack_bar_extension.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:intl/intl.dart';
+import 'package:url_launcher/url_launcher.dart';
+import 'issue_board_ima_utils.dart';
+import 'issue_board_ima_toolbar_search.dart';
+import 'issue_board_ima_issue_editor.dart';
+import 'issue_board_ima_navigation.dart';
+import 'issue_board_ima_board_columns.dart';
+import 'issue_board_ima_models.dart';
+import 'issue_board_ima_app_shell.dart';
+import 'issue_board_ima_overview.dart';
+
+class IssueBoardPage extends StatefulWidget {
+  const IssueBoardPage({
+    super.key,
+    this.workspaceId = '',
+    this.workspaceName = '個人ワークスペース',
+    this.onSwitchTeam,
+  });
+
+  final String workspaceId;
+  final String workspaceName;
+  final VoidCallback? onSwitchTeam;
+
+  @override
+  State<IssueBoardPage> createState() => _IssueBoardPageState();
+}
+
+class _IssueBoardPageState extends State<IssueBoardPage> {
+  final _scaffoldKey = GlobalKey<ScaffoldState>();
+  final _boardScrollController = ScrollController();
+  late final String _workspaceId;
+  StreamSubscription<QuerySnapshot<Map<String, dynamic>>>? _issuesSubscription;
+  StreamSubscription<DocumentSnapshot<Map<String, dynamic>>>?
+  _githubConnectionSubscription;
+  StreamSubscription<QuerySnapshot<Map<String, dynamic>>>?
+  _buildJobsSubscription;
+  StreamSubscription<DocumentSnapshot<Map<String, dynamic>>>?
+  _workspaceSettingsSubscription;
+  var _isBootstrapping = true;
+  var _isConnectingGitHub = false;
+  var _isLoadingRepositories = false;
+  var _isImportingIssues = false;
+  var _isSyncingIssues = false;
+  var _isIssueSearchDialogOpen = false;
+  var _hasLoadedIssuesSnapshot = false;
+  String? _githubLogin;
+  String? _loadError;
+  int _enabledRepoCount = 0;
+  int _dailyWeightTarget = defaultDailyWeightTarget;
+  BoardViewMode? _boardViewMode;
+  final BoardSidePanel _sidePanel = BoardSidePanel.workers;
+  CompactBoardDestination _compactDestination =
+      CompactBoardDestination.issueBoard;
+  bool _isDesktopRailCollapsed = false;
+  Set<String> _enabledRepoFullNames = {};
+  final Set<String> _closingIssueIds = {};
+  final Set<String> _estimatingIssueIds = {};
+  final Set<String> _startingCursorAgentIssueIds = {};
+  Map<String, CardBuildStatus> _buildStatusesByPullRequest = {};
+  final List<BoardColumn> _columns = [
+    BoardColumn(
+      id: 'triage',
+      title: 'トリアージ',
+      description: '新着と要件確認',
+      color: const Color(0xFF6366F1),
+      issues: [],
+    ),
+    BoardColumn(
+      id: 'backlog',
+      title: 'バックログ',
+      description: '着手待ち',
+      color: const Color(0xFF0EA5E9),
+      issues: [],
+    ),
+    BoardColumn(
+      id: 'doing',
+      title: '進行中',
+      description: '今やっていること',
+      color: const Color(0xFFF59E0B),
+      issues: [],
+    ),
+    BoardColumn(
+      id: 'review',
+      title: 'レビュー',
+      description: 'レビューと検証',
+      color: const Color(0xFFA855F7),
+      issues: [],
+    ),
+    BoardColumn(
+      id: 'done',
+      title: '完了',
+      description: '今週完了',
+      color: const Color(0xFF22C55E),
+      issues: [],
+    ),
+  ];
+
+  FirebaseFirestore get _firestore => FirebaseFirestore.instance;
+
+  FirebaseFunctions get _functions => firebaseFunctions;
+
+  bool get _isBusy =>
+      _isConnectingGitHub ||
+      _isLoadingRepositories ||
+      _isImportingIssues ||
+      _isSyncingIssues;
+
+  List<String> get _enabledRepositoryOptions =>
+      (_enabledRepoFullNames.toList()..sort());
+
+  @override
+  void initState() {
+    super.initState();
+    HardwareKeyboard.instance.addHandler(_handleIssueBoardKeyEvent);
+    final user = FirebaseAuth.instance.currentUser;
+    _workspaceId = widget.workspaceId.isNotEmpty
+        ? widget.workspaceId
+        : user?.uid ?? '';
+    unawaited(_bootstrapWorkspace());
+  }
+
+  bool _handleIssueBoardKeyEvent(KeyEvent event) {
+    if (event is! KeyDownEvent) {
+      return false;
+    }
+
+    if (!mounted || ModalRoute.of(context)?.isCurrent != true) {
+      return false;
+    }
+
+    if (event.logicalKey != LogicalKeyboardKey.keyK ||
+        !HardwareKeyboard.instance.isMetaPressed) {
+      return false;
+    }
+
+    unawaited(_openIssueSearchDialog());
+    return true;
+  }
+
+  void _selectCompactDestination(CompactBoardDestination destination) {
+    if (_compactDestination == destination) {
+      return;
+    }
+    setState(() => _compactDestination = destination);
+  }
+
+  Future<void> _bootstrapWorkspace() async {
+    if (_workspaceId.isEmpty) {
+      return;
+    }
+
+    try {
+      await _ensureWorkspace();
+      _listenToWorkspace();
+    } catch (error) {
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _isBootstrapping = false;
+        _loadError = friendlyError(error);
+      });
+    }
+  }
+
+  Future<void> _ensureWorkspace() async {
+    final user = FirebaseAuth.instance.currentUser;
+    if (user == null) {
+      return;
+    }
+
+    final batch = _firestore.batch();
+    final now = FieldValue.serverTimestamp();
+    final workspaceRef = _firestore.doc('workspaces/$_workspaceId');
+    final isPersonalWorkspace = _workspaceId == user.uid;
+    if (isPersonalWorkspace) {
+      batch.set(workspaceRef, {
+        'ownerUid': user.uid,
+        'name': widget.workspaceName,
+        'updatedAt': now,
+        'createdAt': now,
+      }, SetOptions(merge: true));
+      batch.set(workspaceRef.collection('members').doc(user.uid), {
+        'role': 'owner',
+        'updatedAt': now,
+        'createdAt': now,
+      }, SetOptions(merge: true));
+    }
+
+    for (final column in _columns) {
+      batch.set(
+        workspaceRef.collection('statuses').doc(column.id),
+        {
+          'title': column.title,
+          'description': column.description,
+          'updatedAt': now,
+          'createdAt': now,
+        },
+        SetOptions(merge: true),
+      );
+    }
+
+    await batch.commit();
+  }
+
+  void _listenToWorkspace() {
+    final workspaceRef = _firestore.doc('workspaces/$_workspaceId');
+    _issuesSubscription = workspaceRef
+        .collection('issues')
+        .orderBy('rank')
+        .snapshots()
+        .listen(_replaceIssuesFromSnapshot, onError: _handleStreamError);
+    _githubConnectionSubscription = workspaceRef
+        .collection('githubConnections')
+        .doc('default')
+        .snapshots()
+        .listen(_replaceGitHubConnection, onError: _handleStreamError);
+    _buildJobsSubscription = _firestore
+        .collection(buildJobsCollection)
+        .where('teamId', isEqualTo: _workspaceId)
+        .orderBy('createdAt', descending: true)
+        .limit(200)
+        .snapshots()
+        .listen(_replaceBuildStatuses, onError: _handleStreamError);
+    _workspaceSettingsSubscription = workspaceRef.snapshots().listen(
+      _replaceWorkspaceSettings,
+      onError: _handleStreamError,
+    );
+  }
+
+  void _replaceWorkspaceSettings(DocumentSnapshot<Map<String, dynamic>> doc) {
+    final data = doc.data();
+    if (!mounted || data == null) {
+      return;
+    }
+
+    final storedDailyWeightTarget = data['dailyWeightTarget'];
+    final repoFullNames = asList(
+      data['syncedGitHubRepoFullNames'],
+    ).map(asString).where((repo) => repo.isNotEmpty).toList();
+
+    setState(() {
+      if (storedDailyWeightTarget is int && storedDailyWeightTarget > 0) {
+        _dailyWeightTarget = storedDailyWeightTarget;
+      }
+      _enabledRepoCount = repoFullNames.length;
+      _enabledRepoFullNames = repoFullNames.toSet();
+    });
+  }
+
+  void _replaceIssuesFromSnapshot(
+    QuerySnapshot<Map<String, dynamic>> snapshot,
+  ) {
+    if (!mounted) {
+      return;
+    }
+
+    if (_hasLoadedIssuesSnapshot) {
+      _applyIssueDocumentChanges(snapshot.docChanges);
+      return;
+    }
+
+    final nextColumns = [
+      for (final column in _columns)
+        BoardColumn(
+          id: column.id,
+          title: column.title,
+          description: column.description,
+          color: column.color,
+          issues: [],
+        ),
+    ];
+
+    for (final doc in snapshot.docs) {
+      final issue = Issue.fromDocument(doc);
+      final column = nextColumns.firstWhere(
+        (column) => column.id == issue.statusId,
+        orElse: () => nextColumns.first,
+      );
+      column.issues.add(issue);
+    }
+
+    setState(() {
+      _columns
+        ..clear()
+        ..addAll(nextColumns);
+      _hasLoadedIssuesSnapshot = true;
+      _isBootstrapping = false;
+      _loadError = null;
+    });
+  }
+
+  void _applyIssueDocumentChanges(
+    List<DocumentChange<Map<String, dynamic>>> changes,
+  ) {
+    if (changes.isEmpty) {
+      setState(() {
+        _isBootstrapping = false;
+        _loadError = null;
+      });
+      return;
+    }
+
+    setState(() {
+      for (final change in changes) {
+        switch (change.type) {
+          case DocumentChangeType.added:
+          case DocumentChangeType.modified:
+            final issue = Issue.fromDocument(change.doc);
+            _removeIssueFromColumns(issue.id);
+            _insertIssueInRankOrder(issue);
+            break;
+          case DocumentChangeType.removed:
+            _removeIssueFromColumns(change.doc.id);
+            break;
+        }
+      }
+      _isBootstrapping = false;
+      _loadError = null;
+    });
+  }
+
+  void _removeIssueFromColumns(String issueId) {
+    for (final column in _columns) {
+      column.issues.removeWhere((issue) => issue.id == issueId);
+    }
+  }
+
+  void _insertIssueInRankOrder(Issue issue) {
+    final column = _columns.firstWhere(
+      (column) => column.id == issue.statusId,
+      orElse: () => _columns.first,
+    );
+    final insertIndex = column.issues.indexWhere(
+      (candidate) => candidate.rank > issue.rank,
+    );
+    if (insertIndex == -1) {
+      column.issues.add(issue);
+      return;
+    }
+    column.issues.insert(insertIndex, issue);
+  }
+
+  void _replaceGitHubConnection(DocumentSnapshot<Map<String, dynamic>> doc) {
+    final data = doc.data();
+    if (!mounted) {
+      return;
+    }
+
+    setState(() {
+      _githubLogin = data?['connected'] == true
+          ? asString(data?['login'])
+          : null;
+    });
+  }
+
+  void _replaceBuildStatuses(QuerySnapshot<Map<String, dynamic>> snapshot) {
+    final runsByPullRequest = <String, List<RecentRunSummary>>{};
+    for (final doc in snapshot.docs) {
+      final run = RecentRunSummary.fromDoc(doc);
+      if (run == null || run.pullRequestNumber <= 0 || run.repository.isEmpty) {
+        continue;
+      }
+      runsByPullRequest
+          .putIfAbsent(
+            buildStatusKey(run.repository, run.pullRequestNumber),
+            () => [],
+          )
+          .add(run);
+    }
+
+    final nextStatuses = <String, CardBuildStatus>{};
+    for (final entry in runsByPullRequest.entries) {
+      final status = CardBuildStatus.fromRuns(entry.value);
+      if (status != null) {
+        nextStatuses[entry.key] = status;
+      }
+    }
+
+    if (!mounted ||
+        buildStatusMapSignature(_buildStatusesByPullRequest) ==
+            buildStatusMapSignature(nextStatuses)) {
+      return;
+    }
+
+    setState(() => _buildStatusesByPullRequest = nextStatuses);
+  }
+
+  void _handleStreamError(Object error) {
+    if (!mounted) {
+      return;
+    }
+
+    setState(() {
+      _isBootstrapping = false;
+      _loadError = friendlyError(error);
+    });
+  }
+
+  Future<void> _moveIssue({
+    required String issueId,
+    required String targetColumnId,
+    required int targetIndex,
+    bool clearPullRequests = false,
+  }) async {
+    final sourceColumn = _columns.firstWhere(
+      (column) => column.issues.any((issue) => issue.id == issueId),
+    );
+    final sourceIndex = sourceColumn.issues.indexWhere(
+      (issue) => issue.id == issueId,
+    );
+    final targetColumn = _columns.firstWhere(
+      (column) => column.id == targetColumnId,
+    );
+
+    if (sourceColumn.id == targetColumnId &&
+        sourceIndex == targetIndex &&
+        !clearPullRequests) {
+      return;
+    }
+
+    final movingIssue = sourceColumn.issues[sourceIndex];
+    final targetIssues = [
+      for (final issue in targetColumn.issues)
+        if (issue.id != issueId) issue,
+    ];
+    final normalizedTargetIndex =
+        sourceColumn.id == targetColumnId && sourceIndex < targetIndex
+        ? targetIndex - 1
+        : targetIndex;
+    final insertIndex = normalizedTargetIndex.clamp(0, targetIssues.length);
+    final previousRank = insertIndex == 0
+        ? null
+        : targetIssues[insertIndex - 1].rank;
+    final nextRank = insertIndex >= targetIssues.length
+        ? null
+        : targetIssues[insertIndex].rank;
+    final nextRankValue = rankBetween(previousRank, nextRank);
+    final shouldUnlinkPullRequests =
+        clearPullRequests || targetColumnId != reviewStatusId;
+    _applyOptimisticIssueMove(
+      movingIssue.copyWith(
+        statusId: targetColumnId,
+        rank: nextRankValue,
+        clearClosedAt: targetColumnId != closedStatusId,
+        pullRequests: shouldUnlinkPullRequests
+            ? const <IssuePullRequest>[]
+            : null,
+      ),
+    );
+
+    await _firestore
+        .doc('workspaces/$_workspaceId/issues/${movingIssue.id}')
+        .update({
+          'statusId': targetColumnId,
+          'rank': nextRankValue,
+          if (targetColumnId != closedStatusId) 'closedAt': FieldValue.delete(),
+          if (shouldUnlinkPullRequests) 'pullRequests': FieldValue.delete(),
+          'updatedAt': FieldValue.serverTimestamp(),
+        });
+  }
+
+  void _applyOptimisticIssueMove(Issue issue) {
+    if (!mounted) {
+      return;
+    }
+
+    setState(() {
+      _removeIssueFromColumns(issue.id);
+      _insertIssueInRankOrder(issue);
+    });
+  }
+
+  Future<void> _linkIssueToPullRequest({
+    required String issueId,
+    required String repository,
+    required IssuePullRequest pullRequest,
+  }) async {
+    try {
+      final issue = _columns
+          .expand((column) => column.issues)
+          .firstWhere((issue) => issue.id == issueId);
+      final linkId = pullRequestLinkId(repository, pullRequest.number);
+
+      final issueRef = _firestore.doc(
+        'workspaces/$_workspaceId/issues/$issueId',
+      );
+      final snapshot = await issueRef.get();
+      final data = snapshot.data();
+      Map<String, dynamic>? existingLink;
+      final currentPullRequests = <Map<String, dynamic>>[];
+      for (final value in asList(data?['pullRequests'])) {
+        final pullRequest = asMap(value);
+        if (asString(pullRequest['id']) == linkId) {
+          existingLink = pullRequest;
+        } else {
+          currentPullRequests.add(pullRequest);
+        }
+      }
+      final now = Timestamp.now();
+      final nextPullRequests = [
+        ...currentPullRequests,
+        {
+          'id': linkId,
+          ...pullRequest.toFirestore(repository: repository),
+          'linkedAt': existingLink?['linkedAt'] ?? now,
+          'updatedAt': now,
+        },
+      ];
+      final update = <String, Object?>{
+        'pullRequests': nextPullRequests,
+        'updatedAt': FieldValue.serverTimestamp(),
+      };
+
+      if (issue.statusId != reviewStatusId &&
+          issue.statusId != closedStatusId) {
+        final reviewColumn = _columns.firstWhere(
+          (column) => column.id == reviewStatusId,
+        );
+        final reviewIssues = [
+          for (final candidate in reviewColumn.issues)
+            if (candidate.id != issueId) candidate,
+        ];
+        final previousRank = reviewIssues.isEmpty
+            ? null
+            : reviewIssues.last.rank;
+        update['statusId'] = reviewStatusId;
+        update['rank'] = rankBetween(previousRank, null);
+      }
+
+      final nextStatusId = asString(update['statusId'], issue.statusId);
+      final nextRank = update['rank'] is double
+          ? update['rank']! as double
+          : issue.rank;
+      _applyOptimisticIssueMove(
+        issue.copyWith(
+          statusId: nextStatusId,
+          rank: nextRank,
+          pullRequests: [
+            for (final existingPullRequest in issue.pullRequests)
+              if (existingPullRequest.number != pullRequest.number)
+                existingPullRequest,
+            pullRequest,
+          ],
+        ),
+      );
+
+      await issueRef.update(update);
+      _showSavedSnackBar('PR #${pullRequest.number}に紐づけました');
+    } catch (error) {
+      _showSavedSnackBar(friendlyError(error));
+    }
+  }
+
+  Future<void> _closeIssue(String issueId) async {
+    if (_closingIssueIds.contains(issueId)) {
+      return;
+    }
+
+    final sourceColumn = _columns.firstWhere(
+      (column) => column.issues.any((issue) => issue.id == issueId),
+    );
+    final issue = sourceColumn.issues.firstWhere(
+      (issue) => issue.id == issueId,
+    );
+    if (issue.statusId == closedStatusId) {
+      _showSavedSnackBar('すでに完了しています');
+      return;
+    }
+
+    final allIssues = _columns.expand((column) => column.issues).toList();
+    final subIssuesToClose = descendantSubIssuesForParent(
+      issue,
+      allIssues,
+    ).where((subIssue) => subIssue.statusId != closedStatusId).toList();
+    final closingIssueIds = {
+      issueId,
+      for (final subIssue in subIssuesToClose) subIssue.id,
+    };
+
+    setState(() => _closingIssueIds.addAll(closingIssueIds));
+    try {
+      await _moveIssue(
+        issueId: issueId,
+        targetColumnId: closedStatusId,
+        targetIndex: 0,
+      );
+      if (subIssuesToClose.isNotEmpty) {
+        final batch = _firestore.batch();
+        final nowRank = DateTime.now().millisecondsSinceEpoch.toDouble();
+        for (var index = 0; index < subIssuesToClose.length; index++) {
+          final subIssue = subIssuesToClose[index];
+          batch.update(
+            _firestore.doc('workspaces/$_workspaceId/issues/${subIssue.id}'),
+            {
+              'statusId': closedStatusId,
+              'rank': nowRank + index + 1,
+              'updatedAt': FieldValue.serverTimestamp(),
+            },
+          );
+        }
+        await batch.commit();
+      }
+      _showSavedSnackBar(
+        subIssuesToClose.isEmpty
+            ? '完了にしました'
+            : '${subIssuesToClose.length}件のsub-issueと一緒に完了にしました',
+      );
+    } catch (error) {
+      _showSavedSnackBar(friendlyError(error));
+    } finally {
+      if (mounted) {
+        setState(() => _closingIssueIds.removeAll(closingIssueIds));
+      }
+    }
+  }
+
+  Future<void> _openAddIssueDialog({String? initialColumnId}) async {
+    final useBottomSheet = _usesBottomSheetEditor;
+    final draft = await _showIssueEditor<NewIssueDraft>(
+      useBottomSheet: useBottomSheet,
+      builder: (context) => AddIssueDialog(
+        columns: _columns,
+        repositoryOptions: _enabledRepositoryOptions,
+        initialColumnId: initialColumnId,
+        isBottomSheet: useBottomSheet,
+      ),
+    );
+
+    if (draft == null) {
+      return;
+    }
+
+    try {
+      await _addIssue(draft);
+      _showSavedSnackBar('保存しました');
+    } catch (error) {
+      _showSavedSnackBar(friendlyError(error));
+    }
+  }
+
+  Future<void> _openEditIssueDialog(String issueId) async {
+    final sourceColumn = _columns.firstWhere(
+      (column) => column.issues.any((issue) => issue.id == issueId),
+    );
+    final issue = sourceColumn.issues.firstWhere(
+      (issue) => issue.id == issueId,
+    );
+    final allIssues = _columns.expand((column) => column.issues).toList();
+
+    final useBottomSheet = _usesBottomSheetEditor;
+    final result = await _showIssueEditor<Object?>(
+      useBottomSheet: useBottomSheet,
+      builder: (context) => AddIssueDialog(
+        columns: _columns,
+        repositoryOptions: _enabledRepositoryOptions,
+        initialIssue: issue,
+        allIssues: allIssues,
+        initialColumnId: sourceColumn.id,
+        buildStatusesByPullRequest: _buildStatusesByPullRequest,
+        isEstimatingWeight: _estimatingIssueIds.contains(issueId),
+        onEstimateIssueWeight: _estimateIssueWeight,
+        onOverrideIssueWeight: _overrideIssueWeight,
+        isStartingCursorAgent: _startingCursorAgentIssueIds.contains(issueId),
+        onStartCursorAgent: _startCursorAgent,
+        onCreateGitHubSubIssue: _createGitHubSubIssue,
+        isBottomSheet: useBottomSheet,
+        workspaceId: _workspaceId,
+      ),
+    );
+
+    if (result == null) {
+      return;
+    }
+
+    if (result is CloseIssueDialogResult) {
+      await _closeIssue(result.issueId);
+      return;
+    }
+
+    if (result is EditIssueDialogResult) {
+      try {
+        await _updateIssue(issueId: result.issueId, draft: result.draft);
+        _showSavedSnackBar('保存しました');
+      } catch (error) {
+        _showSavedSnackBar(friendlyError(error));
+      }
+      return;
+    }
+
+    if (result is! NewIssueDraft) {
+      return;
+    }
+
+    try {
+      await _updateIssue(issueId: issueId, draft: result);
+      _showSavedSnackBar('保存しました');
+    } catch (error) {
+      _showSavedSnackBar(friendlyError(error));
+    }
+  }
+
+  Future<void> _openIssueSearchDialog() async {
+    if (_isIssueSearchDialogOpen) {
+      return;
+    }
+
+    _isIssueSearchDialogOpen = true;
+    final hasIssues = _columns.any((column) => column.issues.isNotEmpty);
+    if (!hasIssues) {
+      _isIssueSearchDialogOpen = false;
+      _showSavedSnackBar('検索できるIssueがありません');
+      return;
+    }
+
+    final result = await showDialog<IssueSearchDialogResult>(
+      context: context,
+      builder: (context) => IssueSearchDialog(columns: _columns),
+    ).whenComplete(() => _isIssueSearchDialogOpen = false);
+    if (result == null || !mounted) {
+      return;
+    }
+
+    await _openEditIssueDialog(result.issueId);
+  }
+
+  bool get _usesBottomSheetEditor =>
+      MediaQuery.sizeOf(context).width < compactBoardBreakpoint;
+
+  Future<T?> _showIssueEditor<T>({
+    required bool useBottomSheet,
+    required WidgetBuilder builder,
+  }) {
+    if (useBottomSheet) {
+      return showModalBottomSheet<T>(
+        context: context,
+        isScrollControlled: true,
+        useSafeArea: true,
+        backgroundColor: Colors.transparent,
+        builder: builder,
+      );
+    }
+
+    return showDialog<T>(context: context, builder: builder);
+  }
+
+  Future<void> _addIssue(NewIssueDraft draft) async {
+    final targetColumn = _columns.firstWhere(
+      (column) => column.id == draft.columnId,
+    );
+    final rank = targetColumn.issues.isEmpty
+        ? DateTime.now().millisecondsSinceEpoch.toDouble()
+        : targetColumn.issues.first.rank - 1000;
+
+    final docRef = _firestore
+        .collection('workspaces/$_workspaceId/issues')
+        .doc();
+
+    await docRef.set({
+      'title': draft.title,
+      'body': draft.body,
+      'repo': draft.repo,
+      'labels': draft.labels,
+      'comments': 0,
+      'priority': draft.priority.name,
+      'statusId': draft.columnId,
+      'rank': rank,
+      if (draft.githubUrl != null) 'githubIssue': {'url': draft.githubUrl},
+      if (draft.dueDate != null) 'dueDate': Timestamp.fromDate(draft.dueDate!),
+      'updatedAt': FieldValue.serverTimestamp(),
+      'createdAt': FieldValue.serverTimestamp(),
+    });
+
+    if (draft.repo.isNotEmpty) {
+      unawaited(
+        _callFunction('createGitHubIssue', {
+          ..._issueDraftToFunctionData(draft, rank: rank),
+          'issueId': docRef.id,
+        }),
+      );
+    }
+  }
+
+  Future<void> _estimateIssueWeight(String issueId) async {
+    if (_estimatingIssueIds.contains(issueId)) {
+      return;
+    }
+
+    setState(() => _estimatingIssueIds.add(issueId));
+    try {
+      await _callFunction('estimateIssueWeight', {
+        'workspaceId': _workspaceId,
+        'issueId': issueId,
+        'force': true,
+      });
+      _showSavedSnackBar('Weightを推定しました');
+    } catch (error) {
+      _showSavedSnackBar(friendlyError(error));
+    } finally {
+      if (mounted) {
+        setState(() => _estimatingIssueIds.remove(issueId));
+      }
+    }
+  }
+
+  Future<void> _overrideIssueWeight({
+    required String issueId,
+    required IssueWeightOverrideDraft draft,
+  }) async {
+    final issue = _columns
+        .expand((column) => column.issues)
+        .firstWhere((issue) => issue.id == issueId);
+    final now = FieldValue.serverTimestamp();
+    final updatedBy = FirebaseAuth.instance.currentUser?.uid;
+    final actualWeight = draft.actualWeight;
+    final data = <String, Object?>{
+      'weightEstimate.value': draft.estimateWeight,
+      'weightEstimate.status': 'done',
+      'weightEstimate.confidence': 1.0,
+      'weightEstimate.reason': 'Manual override',
+      'weightEstimate.model': 'manual',
+      'weightEstimate.promptVersion': 'manual',
+      'weightEstimate.source': 'manual',
+      'weightEstimate.manualOverride': true,
+      'weightEstimate.overriddenAt': now,
+      'weightEstimate.updatedAt': now,
+      'updatedAt': now,
+    };
+    if (updatedBy != null) {
+      data['weightEstimate.requestedBy'] = updatedBy;
+    }
+
+    if (issue.statusId == closedStatusId) {
+      data['resolution.weightValue'] = draft.estimateWeight;
+      if (actualWeight != null) {
+        data['resolution.actualWeight'] = actualWeight;
+        data['resolution.weightDelta'] = draft.estimateWeight - actualWeight;
+        data['resolution.actualWeightSource'] = 'manual';
+        data['resolution.actualWeightManualOverride'] = true;
+        data['resolution.actualWeightOverriddenAt'] = now;
+        if (updatedBy != null) {
+          data['resolution.actualWeightOverriddenBy'] = updatedBy;
+        }
+      }
+    }
+
+    await _firestore
+        .doc('workspaces/$_workspaceId/issues/$issueId')
+        .update(data);
+    _showSavedSnackBar('Weightを上書きしました');
+  }
+
+  Future<void> _startCursorAgent(String issueId) async {
+    if (_startingCursorAgentIssueIds.contains(issueId)) {
+      return;
+    }
+
+    setState(() => _startingCursorAgentIssueIds.add(issueId));
+    try {
+      await _callFunction('startIssueCursorAgent', {
+        'workspaceId': _workspaceId,
+        'issueId': issueId,
+      });
+      _showSavedSnackBar('Cursor agentを開始しました');
+    } catch (error) {
+      _showSavedSnackBar(friendlyError(error));
+    } finally {
+      if (mounted) {
+        setState(() => _startingCursorAgentIssueIds.remove(issueId));
+      }
+    }
+  }
+
+  Future<Map<String, dynamic>> _createGitHubSubIssue({
+    required String parentIssueId,
+    required String title,
+    required String body,
+  }) async {
+    final parentIssue = _columns
+        .expand((column) => column.issues)
+        .firstWhere((issue) => issue.id == parentIssueId);
+    final parentGithubUrl = parentIssue.githubUrl;
+    final subIssueRef = _firestore
+        .collection('workspaces/$_workspaceId/issues')
+        .doc();
+    final rank = DateTime.now().millisecondsSinceEpoch.toDouble();
+    final subIssueSummary = <String, Object?>{
+      'issueId': subIssueRef.id,
+      'number': 0,
+      'title': title,
+      'url': null,
+      'state': 'open',
+    };
+
+    await subIssueRef.set({
+      'title': title,
+      'body': body,
+      'repo': parentIssue.repo,
+      'labels': parentIssue.labels,
+      'comments': 0,
+      'priority': parentIssue.priority.name,
+      'statusId': parentIssue.statusId,
+      'rank': rank,
+      'githubIssue': {
+        'state': 'open',
+        'parentIssue': {
+          'issueId': parentIssueId,
+          'number': _issueNumberFromDisplayId(parentIssue.displayId),
+          'url': ?parentGithubUrl,
+        },
+      },
+      'updatedAt': FieldValue.serverTimestamp(),
+      'createdAt': FieldValue.serverTimestamp(),
+    });
+    final nextSummaryTotal = (parentIssue.subIssuesSummary?.total ?? 0) + 1;
+    final nextSummaryCompleted = parentIssue.subIssuesSummary?.completed ?? 0;
+    await _firestore
+        .doc('workspaces/$_workspaceId/issues/$parentIssueId')
+        .update({
+          'githubIssue.subIssues': FieldValue.arrayUnion([subIssueSummary]),
+          'githubIssue.subIssuesSummary': {
+            'total': nextSummaryTotal,
+            'completed': nextSummaryCompleted,
+            'percentCompleted': nextSummaryTotal <= 0
+                ? 0
+                : (nextSummaryCompleted / nextSummaryTotal * 100).round(),
+          },
+          'updatedAt': FieldValue.serverTimestamp(),
+        });
+
+    unawaited(
+      _callFunction('createGitHubSubIssue', {
+        'workspaceId': _workspaceId,
+        'parentIssueId': parentIssueId,
+        'issueId': subIssueRef.id,
+        'title': title,
+        'body': body,
+      }).catchError((Object error) {
+        if (mounted) {
+          showOverlaySnackBar(context, friendlyError(error));
+        }
+        return <String, dynamic>{};
+      }),
+    );
+    return {'issueId': subIssueRef.id, 'number': 0, 'url': ''};
+  }
+
+  Future<IssuePullRequest> _createIssuePullRequest({
+    required String issueId,
+    required String repository,
+    required String head,
+    required String base,
+    required String title,
+    required String body,
+  }) async {
+    final data = await _callFunction(createIssuePullRequestFunction, {
+      'workspaceId': _workspaceId,
+      'issueId': issueId,
+      'repository': repository,
+      'head': head,
+      if (base.isNotEmpty) 'base': base,
+      if (title.isNotEmpty) 'title': title,
+      if (body.isNotEmpty) 'body': body,
+      'draft': false,
+    });
+    return IssuePullRequest.fromMap(asMap(data['pullRequest']));
+  }
+
+  Future<WorkspaceRecentBranchList> _loadWorkspaceRecentBranches() async {
+    final data = await _callFunction(listWorkspaceRecentBranchesFunction, {
+      'workspaceId': _workspaceId,
+      'limit': 40,
+    });
+    return WorkspaceRecentBranchList.fromMap(asMap(data));
+  }
+
+  Future<IssuePullRequest> _createPullRequestFromRecentBranch(
+    WorkspaceRecentBranch branch,
+  ) async {
+    if (!branch.hasIssue) {
+      throw StateError('issueに紐づくbranchを選んでください');
+    }
+
+    final pullRequest = await _createIssuePullRequest(
+      issueId: branch.issueId,
+      repository: branch.repository,
+      head: branch.name,
+      base: branch.base,
+      title: '',
+      body: '',
+    );
+    _showSavedSnackBar('PR #${pullRequest.number}を作成しました');
+    return pullRequest;
+  }
+
+  int _issueNumberFromDisplayId(String displayId) {
+    if (!displayId.startsWith('#')) {
+      return 0;
+    }
+    return int.tryParse(displayId.substring(1)) ?? 0;
+  }
+
+  Map<String, Object?> _issueDraftToFunctionData(
+    NewIssueDraft draft, {
+    required double rank,
+  }) {
+    return {
+      'workspaceId': _workspaceId,
+      'title': draft.title,
+      'body': draft.body,
+      'repo': draft.repo,
+      'labels': draft.labels,
+      'statusId': draft.columnId,
+      'priority': draft.priority.name,
+      'rank': rank,
+      if (draft.dueDate != null) 'dueDate': draft.dueDate!.toIso8601String(),
+    };
+  }
+
+  Future<void> _updateIssue({
+    required String issueId,
+    required NewIssueDraft draft,
+  }) async {
+    final issue = _columns
+        .expand((column) => column.issues)
+        .firstWhere((issue) => issue.id == issueId);
+
+    final data = _issueDraftToFirestore(draft, rank: issue.rank)
+      ..remove('createdAt')
+      ..remove('comments');
+
+    await _firestore
+        .doc('workspaces/$_workspaceId/issues/$issueId')
+        .update(data);
+  }
+
+  Map<String, Object?> _issueDraftToFirestore(
+    NewIssueDraft draft, {
+    required double rank,
+  }) {
+    return {
+      'title': draft.title,
+      'body': draft.body,
+      'repo': draft.repo,
+      'labels': draft.labels,
+      'comments': 0,
+      'priority': draft.priority.name,
+      'statusId': draft.columnId,
+      'rank': rank,
+      'githubIssue.url': draft.githubUrl ?? FieldValue.delete(),
+      'dueDate': draft.dueDate == null
+          ? FieldValue.delete()
+          : Timestamp.fromDate(draft.dueDate!),
+      'updatedAt': FieldValue.serverTimestamp(),
+      'createdAt': FieldValue.serverTimestamp(),
+    };
+  }
+
+  void _showSavedSnackBar(String message) {
+    if (!mounted) {
+      return;
+    }
+
+    showResponsiveSnackBar(
+      context,
+      content: Text(message),
+      duration: const Duration(milliseconds: 1400),
+    );
+  }
+
+  Future<void> _connectGitHub() async {
+    if (_isConnectingGitHub) {
+      return;
+    }
+
+    setState(() => _isConnectingGitHub = true);
+    try {
+      final data = await _callFunction('connectGitHub', {
+        'workspaceId': _workspaceId,
+      });
+      _showSavedSnackBar('GitHub Appに${asString(data['login'])}として接続しました');
+    } catch (error) {
+      if (isGitHubAppNotInstalledError(error)) {
+        try {
+          await _launchGitHubSetup();
+          _showSavedSnackBar('GitHub Appのインストール画面を開きました');
+        } catch (setupError) {
+          _showSavedSnackBar(friendlyError(setupError));
+        }
+      } else {
+        _showSavedSnackBar(friendlyError(error));
+      }
+    } finally {
+      if (mounted) {
+        setState(() => _isConnectingGitHub = false);
+      }
+    }
+  }
+
+  Future<void> _launchGitHubSetup() async {
+    final data = await _callFunction('createGitHubSetupUrl', {
+      'teamId': _workspaceId,
+    });
+    final url = asString(data['url']);
+    if (url.isEmpty) {
+      throw StateError('GitHub setup URL was not returned');
+    }
+    final uri = Uri.tryParse(url);
+    if (uri == null || !await canLaunchUrl(uri)) {
+      throw StateError('GitHub setup URL could not be opened');
+    }
+    await launchUrl(uri, mode: LaunchMode.externalApplication);
+  }
+
+  Future<void> _selectRepositories() async {
+    if (_isLoadingRepositories) {
+      return;
+    }
+
+    setState(() => _isLoadingRepositories = true);
+    try {
+      final selected = await showModalBottomSheet<Set<String>>(
+        context: context,
+        isScrollControlled: true,
+        showDragHandle: true,
+        useSafeArea: true,
+        builder: (context) => RepositoryPickerBottomSheet(
+          initiallySelected: _enabledRepoFullNames,
+          loadRepositories: _loadGitHubRepositories,
+        ),
+      );
+      if (selected == null) {
+        return;
+      }
+
+      final selectedRepoFullNames = selected.toList()..sort();
+      await _firestore.doc('workspaces/$_workspaceId').set({
+        'syncedGitHubRepoFullNames': selectedRepoFullNames,
+        'updatedAt': FieldValue.serverTimestamp(),
+      }, SetOptions(merge: true));
+      _showSavedSnackBar('${selected.length}件のrepoを選択しました');
+    } catch (error) {
+      _showSavedSnackBar(friendlyError(error));
+    } finally {
+      if (mounted) {
+        setState(() => _isLoadingRepositories = false);
+      }
+    }
+  }
+
+  Future<List<GitHubRepository>> _loadGitHubRepositories() async {
+    final data = await _callFunction('listGitHubRepositories', {
+      'workspaceId': _workspaceId,
+    });
+    return asList(data['repositories'])
+        .map((repo) => GitHubRepository.fromMap(asMap(repo)))
+        .where((repo) => repo.fullName.isNotEmpty)
+        .toList();
+  }
+
+  Future<void> _importGitHubIssues() async {
+    if (_isImportingIssues) {
+      return;
+    }
+
+    if (_enabledRepoCount == 0) {
+      _showSavedSnackBar('先に同期するrepoを選択してください');
+      return;
+    }
+
+    setState(() => _isImportingIssues = true);
+    try {
+      final data = await _callFunction('importGitHubIssues', {
+        'workspaceId': _workspaceId,
+      });
+      _showSavedSnackBar(
+        '${asInt(data['repositories'])}件のrepoから${asInt(data['imported'])}件のissueを取り込みました',
+      );
+    } catch (error) {
+      _showSavedSnackBar(friendlyError(error));
+    } finally {
+      if (mounted) {
+        setState(() => _isImportingIssues = false);
+      }
+    }
+  }
+
+  Future<void> _syncGitHubIssues() async {
+    if (_isSyncingIssues) {
+      return;
+    }
+
+    setState(() => _isSyncingIssues = true);
+    try {
+      final data = await _callFunction('syncGitHubIssues', {
+        'workspaceId': _workspaceId,
+      });
+      _showSavedSnackBar(
+        '${asInt(data['synced'])}件同期、${asInt(data['failed'])}件失敗',
+      );
+    } catch (error) {
+      _showSavedSnackBar(friendlyError(error));
+    } finally {
+      if (mounted) {
+        setState(() => _isSyncingIssues = false);
+      }
+    }
+  }
+
+  Future<Map<String, dynamic>> _callFunction(
+    String name,
+    Map<String, Object?> data,
+  ) async {
+    final result = await _functions.httpsCallable(name).call(data);
+    return asMap(result.data);
+  }
+
+  DailyProgressStats _dailyProgressStats(List<Issue> closedIssues) {
+    final now = DateTime.now();
+    final today = dateOnly(now);
+    final tomorrow = today.add(const Duration(days: 1));
+    final recentStart = today.subtract(const Duration(days: 29));
+    final paceBuckets = <DateTime, DailyPaceBucket>{};
+
+    for (final issue in closedIssues) {
+      final closedAt = issue.closedAt;
+      if (closedAt == null) {
+        continue;
+      }
+      final closedDate = dateOnly(closedAt);
+      final weight = issueProgressWeight(issue);
+
+      if (!closedDate.isBefore(recentStart) && closedDate.isBefore(tomorrow)) {
+        final bucket = paceBuckets.putIfAbsent(
+          closedDate,
+          DailyPaceBucket.new,
+        );
+        bucket.add(closedAt: closedAt, weight: weight, now: now);
+      }
+    }
+
+    final history = [
+      for (var index = 0; index < 30; index++)
+        DailyProgressHistoryDay(
+          date: today.subtract(Duration(days: index)),
+          completedWeight:
+              paceBuckets[today.subtract(Duration(days: index))]?.totalWeight ??
+              0,
+          completedCount:
+              paceBuckets[today.subtract(Duration(days: index))]
+                  ?.completedCount ??
+              0,
+          morningWeight:
+              paceBuckets[today.subtract(Duration(days: index))]
+                  ?.morningWeight ??
+              0,
+          afternoonWeight:
+              paceBuckets[today.subtract(Duration(days: index))]
+                  ?.afternoonWeight ??
+              0,
+        ),
+    ];
+    final todayBucket = paceBuckets[today] ?? DailyPaceBucket();
+    final historicalBuckets = [
+      for (final entry in paceBuckets.entries)
+        if (entry.key != today) entry.value,
+    ];
+    final recentWeight = history.fold<int>(
+      0,
+      (total, day) => total + day.completedWeight,
+    );
+    final prediction = buildDailyProgressPrediction(
+      targetWeight: _dailyWeightTarget,
+      todayBucket: todayBucket,
+      historicalBuckets: historicalBuckets,
+      now: now,
+    );
+
+    return DailyProgressStats(
+      targetWeight: _dailyWeightTarget,
+      completedWeight: todayBucket.totalWeight,
+      completedCount: todayBucket.completedCount,
+      recentAverageWeight: recentWeight / 30,
+      history: history,
+      prediction: prediction,
+    );
+  }
+
+  Future<void> _recomputeResolutionWeights() async {
+    try {
+      final result = await _callFunction('recomputeResolutionWeights', {
+        'workspaceId': _workspaceId,
+      });
+      if (mounted) {
+        _showSavedSnackBar(
+          'Weight再計算: ${result['updated']}件更新, ${result['skipped']}件スキップ',
+        );
+      }
+    } catch (error) {
+      if (mounted) {
+        _showSavedSnackBar(friendlyError(error));
+      }
+    }
+  }
+
+  Future<void> _openDailyWeightTargetDialog(DailyProgressStats stats) async {
+    final nextTarget = await showModalBottomSheet<int>(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: Colors.transparent,
+      builder: (context) => DailyProgressSheet(
+        currentTarget: _dailyWeightTarget,
+        stats: stats,
+        onRecomputeWeights: _recomputeResolutionWeights,
+      ),
+    );
+
+    if (nextTarget == null || !mounted) {
+      return;
+    }
+
+    setState(() => _dailyWeightTarget = nextTarget);
+    unawaited(
+      _firestore.doc('workspaces/$_workspaceId').update({
+        'dailyWeightTarget': nextTarget,
+        'updatedAt': FieldValue.serverTimestamp(),
+      }),
+    );
+  }
+
+  @override
+  void dispose() {
+    HardwareKeyboard.instance.removeHandler(_handleIssueBoardKeyEvent);
+    unawaited(_issuesSubscription?.cancel());
+    unawaited(_githubConnectionSubscription?.cancel());
+    unawaited(_buildJobsSubscription?.cancel());
+    unawaited(_workspaceSettingsSubscription?.cancel());
+    _boardScrollController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final openIssues = _columns.fold<int>(
+      0,
+      (total, column) =>
+          column.id == closedStatusId ? total : total + column.issues.length,
+    );
+    final closedIssues = _columns
+        .where((col) => col.id == closedStatusId)
+        .expand((col) => col.issues)
+        .toList();
+    final dailyProgressStats = _dailyProgressStats(closedIssues);
+    final isCompactLayout =
+        MediaQuery.sizeOf(context).width < compactBoardBreakpoint;
+    final boardViewMode =
+        _boardViewMode ??
+        (isCompactLayout ? BoardViewMode.overview : BoardViewMode.standard);
+    final isConnected = _githubLogin != null && _githubLogin!.isNotEmpty;
+    final canShowRecentBranches = isConnected && _enabledRepoCount > 0;
+    final onSignOut = FirebaseAuth.instance.signOut;
+    void onRunsTap() => _selectCompactDestination(CompactBoardDestination.runs);
+    void onWorkersTap() =>
+        _selectCompactDestination(CompactBoardDestination.workers);
+    void onWorkflowsTap() =>
+        _selectCompactDestination(CompactBoardDestination.workflows);
+    void onVariablesTap() =>
+        _selectCompactDestination(CompactBoardDestination.variables);
+    void onStoreReleaseTap() =>
+        _selectCompactDestination(CompactBoardDestination.storeRelease);
+
+    return SyncedSpinnerScope(
+      child: _IssueBoardShortcuts(
+        onAddIssue: () => unawaited(_openAddIssueDialog()),
+        onSearchIssues: () => unawaited(_openIssueSearchDialog()),
+        onToggleNavigation: () {
+          if (isCompactLayout) {
+            return;
+          }
+          setState(
+            () => _isDesktopRailCollapsed = !_isDesktopRailCollapsed,
+          );
+        },
+        onDestinationSelected: _selectCompactDestination,
+        child: Scaffold(
+          key: _scaffoldKey,
+          backgroundColor: const Color(0xFFF4F7FB),
+          endDrawer: isCompactLayout
+              ? null
+              : Drawer(
+                  width: _sidePanel == BoardSidePanel.workers ? 420 : 560,
+                  shape: const RoundedRectangleBorder(
+                    side: BorderSide(color: Color(0xFFE2E8F0)),
+                    borderRadius: BorderRadius.horizontal(
+                      left: Radius.circular(22),
+                    ),
+                  ),
+                  child: Builder(
+                    builder: (context) => BoardSidePanelDrawer(
+                      panel: _sidePanel,
+                      onDismiss: () => Navigator.of(context).maybePop(),
+                    ),
+                  ),
+                ),
+          appBar: isCompactLayout
+              ? AppBar(
+                  title: Text(
+                    _compactDestination.label,
+                    style: const TextStyle(fontWeight: FontWeight.w900),
+                  ),
+                  backgroundColor: const Color(0xFFF4F7FB),
+                  foregroundColor: const Color(0xFF0F172A),
+                  elevation: 0,
+                  scrolledUnderElevation: 0,
+                  actions:
+                      _compactDestination == CompactBoardDestination.issueBoard
+                      ? [
+                          IconButton(
+                            tooltip: 'issueを検索',
+                            onPressed: () =>
+                                unawaited(_openIssueSearchDialog()),
+                            icon: const Icon(Icons.search_rounded),
+                          ),
+                          CompactBoardViewModeButton(
+                            value: boardViewMode,
+                            onChanged: (mode) =>
+                                setState(() => _boardViewMode = mode),
+                          ),
+                          const SizedBox(width: 4),
+                        ]
+                      : null,
+                )
+              : null,
+          drawer: isCompactLayout
+              ? CompactBoardDrawer(
+                  isConnected: isConnected,
+                  isBusy: _isBusy,
+                  repoCount: _enabledRepoCount,
+                  onConnectGitHub: _connectGitHub,
+                  onSelectRepositories: _selectRepositories,
+                  onImportIssues: _importGitHubIssues,
+                  onSyncIssues: _syncGitHubIssues,
+                  onSearchIssues: _openIssueSearchDialog,
+                  onSignOut: onSignOut,
+                  workspaceName: widget.workspaceName,
+                  onSwitchTeam: widget.onSwitchTeam,
+                  selectedDestination: _compactDestination,
+                  onIssueBoardTap: () => _selectCompactDestination(
+                    CompactBoardDestination.issueBoard,
+                  ),
+                  onRunsTap: onRunsTap,
+                  onWorkersTap: onWorkersTap,
+                  onWorkflowsTap: onWorkflowsTap,
+                  onVariablesTap: onVariablesTap,
+                  onStoreReleaseTap: onStoreReleaseTap,
+                )
+              : null,
+          floatingActionButton:
+              isCompactLayout &&
+                  _compactDestination == CompactBoardDestination.issueBoard
+              ? FloatingActionButton.extended(
+                  onPressed: () => unawaited(_openAddIssueDialog()),
+                  icon: const Icon(Icons.add_rounded),
+                  label: const Text('新規'),
+                )
+              : null,
+          body: LayoutBuilder(
+            builder: (context, constraints) {
+              final content = SafeArea(
+                child: _compactDestination != CompactBoardDestination.issueBoard
+                    ? CompactDestinationBody(destination: _compactDestination)
+                    : Column(
+                        children: [
+                          if (!isCompactLayout)
+                            BoardHeader(
+                              openIssues: openIssues,
+                              closedIssues: closedIssues,
+                              dailyProgressStats: dailyProgressStats,
+                              onChangeDailyWeightTarget: () => unawaited(
+                                _openDailyWeightTargetDialog(
+                                  dailyProgressStats,
+                                ),
+                              ),
+                              onWorkerOverviewTap: onWorkersTap,
+                              recentBranches: canShowRecentBranches
+                                  ? RecentRemoteBranchesMetric(
+                                      key: ValueKey(
+                                        'overview-${_enabledRepositoryOptions.join('|')}',
+                                      ),
+                                      isCompact: false,
+                                      isEmbedded: true,
+                                      loadBranches:
+                                          _loadWorkspaceRecentBranches,
+                                      onCreatePullRequest:
+                                          _createPullRequestFromRecentBranch,
+                                      onOpenIssue: (issueId) => unawaited(
+                                        _openEditIssueDialog(issueId),
+                                      ),
+                                    )
+                                  : null,
+                            ),
+                          if (_isBootstrapping) const LinearProgressIndicator(),
+                          if (isCompactLayout)
+                            DailyProgressStrip(
+                              stats: dailyProgressStats,
+                              isCompact: true,
+                              onTap: () => unawaited(
+                                _openDailyWeightTargetDialog(
+                                  dailyProgressStats,
+                                ),
+                              ),
+                            ),
+                          BoardToolbar(
+                            onConnectGitHub: _connectGitHub,
+                            onSelectRepositories: _selectRepositories,
+                            onImportIssues: _importGitHubIssues,
+                            onSyncIssues: _syncGitHubIssues,
+                            onSearchIssues: _openIssueSearchDialog,
+                            boardViewMode: boardViewMode,
+                            onBoardViewModeChanged: (mode) =>
+                                setState(() => _boardViewMode = mode),
+                            githubLogin: _githubLogin,
+                            repoCount: _enabledRepoCount,
+                            isBusy: _isBusy,
+                            onRunsTap: onRunsTap,
+                            onWorkersTap: onWorkersTap,
+                            onWorkflowsTap: onWorkflowsTap,
+                            onVariablesTap: onVariablesTap,
+                            onStoreReleaseTap: onStoreReleaseTap,
+                            showNavigationActions: isCompactLayout,
+                          ),
+                          if (isCompactLayout && canShowRecentBranches)
+                            RecentRemoteBranchesMetric(
+                              key: ValueKey(
+                                _enabledRepositoryOptions.join('|'),
+                              ),
+                              isCompact: isCompactLayout,
+                              isEmbedded: false,
+                              loadBranches: _loadWorkspaceRecentBranches,
+                              onCreatePullRequest:
+                                  _createPullRequestFromRecentBranch,
+                              onOpenIssue: (issueId) =>
+                                  unawaited(_openEditIssueDialog(issueId)),
+                            ),
+                          if (_loadError != null)
+                            Padding(
+                              padding: const EdgeInsets.fromLTRB(20, 0, 20, 12),
+                              child: Text(
+                                _loadError!,
+                                style: TextStyle(
+                                  color: Theme.of(context).colorScheme.error,
+                                  fontWeight: FontWeight.w700,
+                                ),
+                              ),
+                            ),
+                          Expanded(
+                            child: LayoutBuilder(
+                              builder: (context, constraints) {
+                                final boardHeight = constraints.maxHeight > 32
+                                    ? constraints.maxHeight - 24
+                                    : constraints.maxHeight;
+                                final isCompactBoard =
+                                    constraints.maxWidth <
+                                    compactBoardBreakpoint;
+                                final allIssues = _columns
+                                    .expand((column) => column.issues)
+                                    .toList();
+                                final subIssuesByParentIdMap =
+                                    subIssuesByParentId(
+                                      allIssues,
+                                    );
+                                final buildStatusesByIssueIdMap =
+                                    buildStatusesByIssueId(
+                                      allIssues,
+                                      _buildStatusesByPullRequest,
+                                    );
+                                final issuesByRepositoryNumberMap =
+                                    issuesByRepositoryNumber(allIssues);
+
+                                if (boardViewMode == BoardViewMode.overview) {
+                                  return OverviewBoard(
+                                    columns: _columns,
+                                    isCompact: isCompactBoard,
+                                    onIssueTapped: _openEditIssueDialog,
+                                    onIssueDropped: _moveIssue,
+                                  );
+                                }
+
+                                if (isCompactBoard) {
+                                  return ListView.separated(
+                                    controller: _boardScrollController,
+                                    padding: const EdgeInsets.fromLTRB(
+                                      boardHorizontalPadding,
+                                      12,
+                                      boardHorizontalPadding,
+                                      boardBottomPadding + 72,
+                                    ),
+                                    itemCount: _columns.length,
+                                    separatorBuilder: (_, _) =>
+                                        const SizedBox(height: boardColumnGap),
+                                    itemBuilder: (context, index) {
+                                      final column = _columns[index];
+                                      return CompactBoardColumnView(
+                                        key: ValueKey(column.id),
+                                        column: column,
+                                        subIssuesByParentId:
+                                            subIssuesByParentIdMap,
+                                        buildStatusesByIssueId:
+                                            buildStatusesByIssueIdMap,
+                                        issuesByRepositoryNumber:
+                                            issuesByRepositoryNumberMap,
+                                        startingCursorAgentIssueIds:
+                                            _startingCursorAgentIssueIds,
+                                        requiresLongPressDrag: true,
+                                        onIssueDropped: _moveIssue,
+                                        onIssueLinkedToPullRequest:
+                                            _linkIssueToPullRequest,
+                                        onAddIssue: (columnId) => unawaited(
+                                          _openAddIssueDialog(
+                                            initialColumnId: columnId,
+                                          ),
+                                        ),
+                                        onIssueTapped: _openEditIssueDialog,
+                                        onStartCursorAgent: _startCursorAgent,
+                                      );
+                                    },
+                                  );
+                                }
+
+                                return Scrollbar(
+                                  controller: _boardScrollController,
+                                  thumbVisibility: true,
+                                  child: SingleChildScrollView(
+                                    controller: _boardScrollController,
+                                    padding: const EdgeInsets.fromLTRB(
+                                      boardHorizontalPadding,
+                                      12,
+                                      boardHorizontalPadding,
+                                      boardBottomPadding,
+                                    ),
+                                    scrollDirection: Axis.horizontal,
+                                    child: SizedBox(
+                                      height: boardHeight,
+                                      child: Row(
+                                        crossAxisAlignment:
+                                            CrossAxisAlignment.start,
+                                        children: [
+                                          for (final column in _columns) ...[
+                                            BoardColumnView(
+                                              key: ValueKey(column.id),
+                                              column: column,
+                                              subIssuesByParentId:
+                                                  subIssuesByParentIdMap,
+                                              buildStatusesByIssueId:
+                                                  buildStatusesByIssueIdMap,
+                                              issuesByRepositoryNumber:
+                                                  issuesByRepositoryNumberMap,
+                                              startingCursorAgentIssueIds:
+                                                  _startingCursorAgentIssueIds,
+                                              requiresLongPressDrag: false,
+                                              onIssueDropped: _moveIssue,
+                                              onIssueLinkedToPullRequest:
+                                                  _linkIssueToPullRequest,
+                                              onAddIssue: (columnId) =>
+                                                  unawaited(
+                                                    _openAddIssueDialog(
+                                                      initialColumnId: columnId,
+                                                    ),
+                                                  ),
+                                              onIssueTapped:
+                                                  _openEditIssueDialog,
+                                              onStartCursorAgent:
+                                                  _startCursorAgent,
+                                            ),
+                                            if (column != _columns.last)
+                                              const SizedBox(
+                                                width: boardColumnGap,
+                                              ),
+                                          ],
+                                        ],
+                                      ),
+                                    ),
+                                  ),
+                                );
+                              },
+                            ),
+                          ),
+                        ],
+                      ),
+              );
+
+              if (isCompactLayout) {
+                return content;
+              }
+
+              return Row(
+                children: [
+                  DesktopBoardNavigationRail(
+                    selectedDestination: _compactDestination,
+                    workspaceName: widget.workspaceName,
+                    extended:
+                        constraints.maxWidth >= 960 && !_isDesktopRailCollapsed,
+                    onSwitchTeam: widget.onSwitchTeam,
+                    onSignOut: onSignOut,
+                    onCollapsedChanged: (collapsed) =>
+                        setState(() => _isDesktopRailCollapsed = collapsed),
+                    onDestinationSelected: _selectCompactDestination,
+                  ),
+                  const VerticalDivider(width: 1, color: Color(0xFFE2E8F0)),
+                  Expanded(child: content),
+                ],
+              );
+            },
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class RecentRemoteBranchesMetric extends StatefulWidget {
+  const RecentRemoteBranchesMetric({
+    super.key,
+    required this.isCompact,
+    required this.loadBranches,
+    required this.onCreatePullRequest,
+    required this.onOpenIssue,
+    this.isEmbedded = false,
+  });
+
+  final bool isCompact;
+  final bool isEmbedded;
+  final WorkspaceRecentBranchLoadCallback loadBranches;
+  final WorkspaceRecentBranchCreatePullRequestCallback onCreatePullRequest;
+  final ValueChanged<String> onOpenIssue;
+
+  @override
+  State<RecentRemoteBranchesMetric> createState() =>
+      _RecentRemoteBranchesMetricState();
+}
+
+class _RecentRemoteBranchesMetricState
+    extends State<RecentRemoteBranchesMetric> {
+  late Future<WorkspaceRecentBranchList> _branchesFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _branchesFuture = widget.loadBranches();
+  }
+
+  Future<WorkspaceRecentBranchList> _reloadBranches() {
+    final future = widget.loadBranches();
+    if (mounted) {
+      setState(() {
+        _branchesFuture = future;
+      });
+    }
+    return future;
+  }
+
+  Future<void> _openBranchesDialog() async {
+    await showDialog<void>(
+      context: context,
+      builder: (dialogContext) => _RecentRemoteBranchesDialog(
+        initialBranchesFuture: _branchesFuture,
+        reloadBranches: _reloadBranches,
+        onCreatePullRequest: widget.onCreatePullRequest,
+        onOpenIssue: (issueId) {
+          Navigator.of(dialogContext).maybePop();
+          widget.onOpenIssue(issueId);
+        },
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<WorkspaceRecentBranchList>(
+      future: _branchesFuture,
+      builder: (context, snapshot) {
+        final hasError = snapshot.hasError;
+        final isLoading = snapshot.connectionState != ConnectionState.done;
+        final branches = snapshot.data?.branches ?? const [];
+        final latestPushedAt = _latestBranchPushedAt(branches);
+        final value = isLoading || hasError ? '-' : '${branches.length}個';
+        final detail = isLoading
+            ? '読み込み中'
+            : hasError
+            ? '読み込みエラー'
+            : branches.isEmpty
+            ? '最近なし'
+            : '最終更新 ${_formatRecentBranchPushedAt(latestPushedAt)}';
+        final valueColor = hasError
+            ? const Color(0xFFDC2626)
+            : branches.isEmpty
+            ? const Color(0xFF64748B)
+            : const Color(0xFF2563EB);
+
+        if (widget.isEmbedded) {
+          return Tooltip(
+            message: '最近 push されたブランチからPRを作成',
+            child: _RecentBranchesTapTarget(
+              onTap: () => unawaited(_openBranchesDialog()),
+              child: OverviewMetric(
+                label: 'ブランチ',
+                value: value,
+                detail: detail,
+                valueColor: valueColor,
+                width: 112,
+              ),
+            ),
+          );
+        }
+
+        final horizontalPadding = widget.isCompact ? 12.0 : 20.0;
+        return Padding(
+          padding: EdgeInsets.fromLTRB(
+            horizontalPadding,
+            0,
+            horizontalPadding,
+            8,
+          ),
+          child: Material(
+            color: Colors.white,
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(14),
+              side: const BorderSide(color: Color(0xFFE2E8F0)),
+            ),
+            clipBehavior: Clip.antiAlias,
+            child: InkWell(
+              onTap: () => unawaited(_openBranchesDialog()),
+              child: Padding(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 14,
+                  vertical: 10,
+                ),
+                child: Row(
+                  children: [
+                    const Icon(
+                      Icons.account_tree_rounded,
+                      color: Color(0xFF2563EB),
+                      size: 20,
+                    ),
+                    const SizedBox(width: 10),
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          const Text(
+                            'ブランチ',
+                            style: TextStyle(
+                              color: Color(0xFF64748B),
+                              fontSize: 12,
+                              fontWeight: FontWeight.w800,
+                            ),
+                          ),
+                          const SizedBox(height: 1),
+                          Row(
+                            children: [
+                              Text(
+                                value,
+                                style: TextStyle(
+                                  color: valueColor,
+                                  fontSize: 18,
+                                  fontWeight: FontWeight.w900,
+                                ),
+                              ),
+                              const SizedBox(width: 10),
+                              Expanded(
+                                child: Text(
+                                  detail,
+                                  maxLines: 1,
+                                  overflow: TextOverflow.ellipsis,
+                                  style: const TextStyle(
+                                    color: Color(0xFF64748B),
+                                    fontSize: 12,
+                                    fontWeight: FontWeight.w700,
+                                  ),
+                                ),
+                              ),
+                            ],
+                          ),
+                        ],
+                      ),
+                    ),
+                    const Icon(
+                      Icons.chevron_right_rounded,
+                      color: Color(0xFF94A3B8),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _RecentBranchesTapTarget extends StatelessWidget {
+  const _RecentBranchesTapTarget({required this.onTap, required this.child});
+
+  final VoidCallback onTap;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(onTap: onTap, child: child);
+  }
+}
+
+class _RecentRemoteBranchesDialog extends StatefulWidget {
+  const _RecentRemoteBranchesDialog({
+    required this.initialBranchesFuture,
+    required this.reloadBranches,
+    required this.onCreatePullRequest,
+    required this.onOpenIssue,
+  });
+
+  final Future<WorkspaceRecentBranchList> initialBranchesFuture;
+  final WorkspaceRecentBranchLoadCallback reloadBranches;
+  final WorkspaceRecentBranchCreatePullRequestCallback onCreatePullRequest;
+  final ValueChanged<String> onOpenIssue;
+
+  @override
+  State<_RecentRemoteBranchesDialog> createState() =>
+      _RecentRemoteBranchesDialogState();
+}
+
+class _RecentRemoteBranchesDialogState
+    extends State<_RecentRemoteBranchesDialog> {
+  late Future<WorkspaceRecentBranchList> _branchesFuture;
+  final Set<String> _createdBranchKeys = {};
+  var _creatingBranchKey = '';
+
+  @override
+  void initState() {
+    super.initState();
+    _branchesFuture = widget.initialBranchesFuture;
+  }
+
+  void _reload() {
+    final future = widget.reloadBranches();
+    setState(() {
+      _branchesFuture = future;
+      _createdBranchKeys.clear();
+      _creatingBranchKey = '';
+    });
+  }
+
+  Future<void> _createPullRequest(WorkspaceRecentBranch branch) async {
+    if (_creatingBranchKey.isNotEmpty || !branch.hasIssue) {
+      return;
+    }
+
+    setState(() => _creatingBranchKey = branch.key);
+    try {
+      await widget.onCreatePullRequest(branch);
+      if (mounted) {
+        setState(() => _createdBranchKeys.add(branch.key));
+      }
+    } catch (error) {
+      if (mounted) {
+        showResponsiveSnackBar(
+          context,
+          content: Text(friendlyError(error)),
+          duration: const Duration(milliseconds: 1800),
+        );
+      }
+    } finally {
+      if (mounted) {
+        setState(() => _creatingBranchKey = '');
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final size = MediaQuery.sizeOf(context);
+    final maxHeight = math.min(680.0, math.max(360.0, size.height - 48));
+
+    return Dialog(
+      insetPadding: const EdgeInsets.symmetric(horizontal: 20, vertical: 24),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+      clipBehavior: Clip.antiAlias,
+      child: ConstrainedBox(
+        constraints: BoxConstraints(maxWidth: 720, maxHeight: maxHeight),
+        child: Column(
+          children: [
+            Padding(
+              padding: const EdgeInsets.fromLTRB(18, 16, 10, 12),
+              child: Row(
+                children: [
+                  const Icon(
+                    Icons.account_tree_rounded,
+                    color: Color(0xFF2563EB),
+                  ),
+                  const SizedBox(width: 10),
+                  const Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          '最近のブランチ',
+                          style: TextStyle(
+                            color: Color(0xFF0F172A),
+                            fontSize: 18,
+                            fontWeight: FontWeight.w900,
+                          ),
+                        ),
+                        Text(
+                          'remote に push されたブランチからPRを作成',
+                          style: TextStyle(
+                            color: Color(0xFF64748B),
+                            fontSize: 12,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  IconButton(
+                    tooltip: '再読み込み',
+                    onPressed: _reload,
+                    icon: const Icon(Icons.refresh_rounded),
+                  ),
+                  IconButton(
+                    tooltip: '閉じる',
+                    onPressed: () => Navigator.of(context).maybePop(),
+                    icon: const Icon(Icons.close_rounded),
+                  ),
+                ],
+              ),
+            ),
+            const Divider(height: 1, color: Color(0xFFE2E8F0)),
+            Expanded(
+              child: FutureBuilder<WorkspaceRecentBranchList>(
+                future: _branchesFuture,
+                builder: (context, snapshot) {
+                  if (snapshot.connectionState != ConnectionState.done) {
+                    return const Center(
+                      child: SizedBox.square(
+                        dimension: 28,
+                        child: CircularProgressIndicator(strokeWidth: 2.5),
+                      ),
+                    );
+                  }
+                  if (snapshot.hasError) {
+                    return _RecentRemoteBranchesEmptyState(
+                      icon: Icons.error_outline_rounded,
+                      title: 'ブランチを読み込めませんでした',
+                      actionLabel: '再試行',
+                      onAction: _reload,
+                    );
+                  }
+
+                  final branches = snapshot.data?.branches ?? const [];
+                  if (branches.isEmpty) {
+                    return _RecentRemoteBranchesEmptyState(
+                      icon: Icons.account_tree_outlined,
+                      title: '最近 push されたブランチはありません',
+                      actionLabel: '再読み込み',
+                      onAction: _reload,
+                    );
+                  }
+
+                  return ListView.separated(
+                    padding: const EdgeInsets.fromLTRB(16, 14, 16, 16),
+                    itemCount: branches.length,
+                    separatorBuilder: (_, _) => const SizedBox(height: 10),
+                    itemBuilder: (context, index) {
+                      final branch = branches[index];
+                      return _RecentRemoteBranchDialogRow(
+                        branch: branch,
+                        isCreating: _creatingBranchKey == branch.key,
+                        isCreated: _createdBranchKeys.contains(branch.key),
+                        isAnyCreating: _creatingBranchKey.isNotEmpty,
+                        onCreate: () => unawaited(_createPullRequest(branch)),
+                        onOpenIssue: branch.hasIssue
+                            ? () => widget.onOpenIssue(branch.issueId)
+                            : null,
+                      );
+                    },
+                  );
+                },
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _RecentRemoteBranchDialogRow extends StatelessWidget {
+  const _RecentRemoteBranchDialogRow({
+    required this.branch,
+    required this.isCreating,
+    required this.isCreated,
+    required this.isAnyCreating,
+    required this.onCreate,
+    required this.onOpenIssue,
+  });
+
+  final WorkspaceRecentBranch branch;
+  final bool isCreating;
+  final bool isCreated;
+  final bool isAnyCreating;
+  final VoidCallback onCreate;
+  final VoidCallback? onOpenIssue;
+
+  @override
+  Widget build(BuildContext context) {
+    final canCreate = branch.hasIssue && !isAnyCreating && !isCreated;
+    final buttonLabel = isCreated
+        ? '作成済み'
+        : isCreating
+        ? '作成中'
+        : branch.hasIssue
+        ? 'PR作成'
+        : 'issueなし';
+
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: const Color(0xFFF8FAFC),
+        border: Border.all(color: const Color(0xFFE2E8F0)),
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          final isNarrow = constraints.maxWidth < 500;
+          final details = Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  const Icon(
+                    Icons.account_tree_rounded,
+                    size: 16,
+                    color: Color(0xFF64748B),
+                  ),
+                  const SizedBox(width: 7),
+                  Expanded(
+                    child: Tooltip(
+                      message: '${branch.repository}:${branch.name}',
+                      child: Text(
+                        branch.name,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: const TextStyle(
+                          color: Color(0xFF0F172A),
+                          fontSize: 14,
+                          fontWeight: FontWeight.w900,
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 5),
+              Text(
+                '${branch.repository} / base ${branch.base} / ${_formatRecentBranchPushedAt(branch.pushedAt)}',
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: const TextStyle(
+                  color: Color(0xFF64748B),
+                  fontSize: 12,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+              if (branch.hasIssue) ...[
+                const SizedBox(height: 8),
+                Align(
+                  alignment: Alignment.centerLeft,
+                  child: Tooltip(
+                    message: branch.issueTitle,
+                    child: InkWell(
+                      onTap: onOpenIssue,
+                      borderRadius: BorderRadius.circular(999),
+                      child: Container(
+                        constraints: const BoxConstraints(maxWidth: 220),
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 8,
+                          vertical: 5,
+                        ),
+                        decoration: BoxDecoration(
+                          color: const Color(0xFFDCFCE7),
+                          borderRadius: BorderRadius.circular(999),
+                          border: Border.all(color: const Color(0xFF86EFAC)),
+                        ),
+                        child: Text(
+                          branch.issueKey.isEmpty
+                              ? branch.issueId
+                              : '${branch.issueKey} ${branch.issueTitle}',
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: const TextStyle(
+                            color: Color(0xFF166534),
+                            fontSize: 12,
+                            fontWeight: FontWeight.w900,
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ],
+          );
+          final action = SizedBox(
+            height: 34,
+            child: FilledButton.icon(
+              onPressed: canCreate ? onCreate : null,
+              icon: isCreating
+                  ? const SizedBox.square(
+                      dimension: 14,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : Icon(
+                      isCreated
+                          ? Icons.check_rounded
+                          : Icons.call_merge_rounded,
+                      size: 16,
+                    ),
+              label: Text(buttonLabel),
+              style: FilledButton.styleFrom(
+                backgroundColor: const Color(0xFF2563EB),
+                foregroundColor: Colors.white,
+                disabledBackgroundColor: const Color(0xFFE2E8F0),
+                disabledForegroundColor: const Color(0xFF64748B),
+                minimumSize: const Size(0, 34),
+                padding: const EdgeInsets.symmetric(horizontal: 12),
+                textStyle: const TextStyle(
+                  fontSize: 12,
+                  fontWeight: FontWeight.w900,
+                ),
+              ),
+            ),
+          );
+
+          if (isNarrow) {
+            return Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                details,
+                const SizedBox(height: 10),
+                Align(alignment: Alignment.centerRight, child: action),
+              ],
+            );
+          }
+
+          return Row(
+            children: [
+              Expanded(child: details),
+              const SizedBox(width: 14),
+              action,
+            ],
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _RecentRemoteBranchesEmptyState extends StatelessWidget {
+  const _RecentRemoteBranchesEmptyState({
+    required this.icon,
+    required this.title,
+    required this.actionLabel,
+    required this.onAction,
+  });
+
+  final IconData icon;
+  final String title;
+  final String actionLabel;
+  final VoidCallback onAction;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(icon, color: const Color(0xFF94A3B8), size: 34),
+            const SizedBox(height: 10),
+            Text(
+              title,
+              textAlign: TextAlign.center,
+              style: const TextStyle(
+                color: Color(0xFF475569),
+                fontSize: 13,
+                fontWeight: FontWeight.w800,
+              ),
+            ),
+            const SizedBox(height: 12),
+            OutlinedButton.icon(
+              onPressed: onAction,
+              icon: const Icon(Icons.refresh_rounded, size: 17),
+              label: Text(actionLabel),
+              style: OutlinedButton.styleFrom(
+                foregroundColor: const Color(0xFF2563EB),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+DateTime? _latestBranchPushedAt(Iterable<WorkspaceRecentBranch> branches) {
+  DateTime? latest;
+  for (final branch in branches) {
+    final pushedAt = branch.pushedAt;
+    if (pushedAt == null) {
+      continue;
+    }
+    if (latest == null || pushedAt.isAfter(latest)) {
+      latest = pushedAt;
+    }
+  }
+  return latest;
+}
+
+String _formatRecentBranchPushedAt(DateTime? value) {
+  if (value == null) {
+    return '日時なし';
+  }
+
+  final local = value.toLocal();
+  final difference = DateTime.now().difference(local);
+  if (!difference.isNegative) {
+    if (difference.inMinutes < 1) {
+      return 'たった今';
+    }
+    if (difference.inHours < 1) {
+      return '${difference.inMinutes}分前';
+    }
+    if (difference.inDays < 1) {
+      return '${difference.inHours}時間前';
+    }
+    if (difference.inDays < 7) {
+      return '${difference.inDays}日前';
+    }
+  }
+
+  return DateFormat('M/d').format(local);
+}
+
+class _IssueBoardShortcuts extends StatelessWidget {
+  const _IssueBoardShortcuts({
+    required this.onAddIssue,
+    required this.onSearchIssues,
+    required this.onToggleNavigation,
+    required this.onDestinationSelected,
+    required this.child,
+  });
+
+  final VoidCallback onAddIssue;
+  final VoidCallback onSearchIssues;
+  final VoidCallback onToggleNavigation;
+  final ValueChanged<CompactBoardDestination> onDestinationSelected;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final bindings = <ShortcutActivator, VoidCallback>{
+      const SingleActivator(LogicalKeyboardKey.keyN): () {
+        if (_hasTextInputFocus()) {
+          return;
+        }
+        onAddIssue();
+      },
+      const SingleActivator(LogicalKeyboardKey.keyK, meta: true):
+          onSearchIssues,
+      const SingleActivator(LogicalKeyboardKey.digit1, meta: true): () =>
+          onDestinationSelected(CompactBoardDestination.issueBoard),
+      const SingleActivator(LogicalKeyboardKey.digit2, meta: true): () =>
+          onDestinationSelected(CompactBoardDestination.runs),
+      const SingleActivator(LogicalKeyboardKey.digit3, meta: true): () =>
+          onDestinationSelected(CompactBoardDestination.workers),
+      const SingleActivator(LogicalKeyboardKey.digit4, meta: true): () =>
+          onDestinationSelected(CompactBoardDestination.workflows),
+      const SingleActivator(LogicalKeyboardKey.digit5, meta: true): () =>
+          onDestinationSelected(CompactBoardDestination.variables),
+      const SingleActivator(LogicalKeyboardKey.digit6, meta: true): () =>
+          onDestinationSelected(CompactBoardDestination.storeRelease),
+    };
+
+    if (!kIsWeb) {
+      bindings.addAll({
+        const SingleActivator(LogicalKeyboardKey.keyT, meta: true): onAddIssue,
+        const SingleActivator(LogicalKeyboardKey.keyS, meta: true):
+            onToggleNavigation,
+      });
+    }
+
+    return CallbackShortcuts(
+      bindings: bindings,
+      child: Focus(autofocus: true, child: child),
+    );
+  }
+
+  bool _hasTextInputFocus() {
+    final context = FocusManager.instance.primaryFocus?.context;
+    return context?.findAncestorWidgetOfExactType<EditableText>() != null;
+  }
+}

--- a/apps/dashboard/lib/workspace/issue_board_ima_issue_cards.dart
+++ b/apps/dashboard/lib/workspace/issue_board_ima_issue_cards.dart
@@ -1,0 +1,2107 @@
+import 'dart:async';
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+import 'package:material_symbols_icons/symbols.dart';
+import 'issue_board_ima_utils.dart';
+import 'issue_board_ima_board_columns.dart';
+import 'issue_board_ima_models.dart';
+import 'issue_board_ima_app_shell.dart';
+import 'issue_board_ima_overview.dart';
+
+class IssueCardDropTarget extends StatefulWidget {
+  const IssueCardDropTarget({
+    super.key,
+    required this.issue,
+    this.subIssues = const [],
+    this.buildStatus,
+    this.isReviewGroupCard = false,
+    required this.sourceColumnId,
+    required this.index,
+    required this.isStartingCursorAgent,
+    required this.requiresLongPressDrag,
+    required this.onTap,
+    this.onSubIssueTap,
+    this.onStartCursorAgent,
+    required this.onIssueDropped,
+  });
+
+  final Issue issue;
+  final List<Issue> subIssues;
+  final CardBuildStatus? buildStatus;
+  final bool isReviewGroupCard;
+  final String sourceColumnId;
+  final int index;
+  final bool isStartingCursorAgent;
+  final bool requiresLongPressDrag;
+  final VoidCallback onTap;
+  final ValueChanged<String>? onSubIssueTap;
+  final VoidCallback? onStartCursorAgent;
+  final IssueDropCallback onIssueDropped;
+
+  @override
+  State<IssueCardDropTarget> createState() => _IssueCardDropTargetState();
+}
+
+class _IssueCardDropTargetState extends State<IssueCardDropTarget> {
+  final _cardKey = GlobalKey();
+  bool _isHovering = false;
+  bool _insertAfter = false;
+
+  void _updateDropPosition(Offset globalPosition) {
+    final renderObject = _cardKey.currentContext?.findRenderObject();
+
+    if (renderObject is! RenderBox) {
+      return;
+    }
+
+    final localPosition = renderObject.globalToLocal(globalPosition);
+    final nextInsertAfter = localPosition.dy > renderObject.size.height / 2;
+
+    if (_isHovering == true && _insertAfter == nextInsertAfter) {
+      return;
+    }
+
+    setState(() {
+      _isHovering = true;
+      _insertAfter = nextInsertAfter;
+    });
+  }
+
+  void _clearDropPosition() {
+    if (!_isHovering) {
+      return;
+    }
+
+    setState(() => _isHovering = false);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return DragTarget<IssueDragData>(
+      onWillAcceptWithDetails: (details) {
+        _updateDropPosition(details.offset);
+        return true;
+      },
+      onMove: (details) => _updateDropPosition(details.offset),
+      onLeave: (_) => _clearDropPosition(),
+      onAcceptWithDetails: (details) {
+        widget.onIssueDropped(
+          issueId: details.data.issueId,
+          targetColumnId: widget.sourceColumnId,
+          targetIndex: widget.index + (_insertAfter ? 1 : 0),
+        );
+        _clearDropPosition();
+      },
+      builder: (context, candidateData, rejectedData) {
+        return Stack(
+          clipBehavior: Clip.none,
+          children: [
+            KeyedSubtree(
+              key: _cardKey,
+              child: IssueCardDraggable(
+                issue: widget.issue,
+                subIssues: widget.subIssues,
+                buildStatus: widget.buildStatus,
+                isReviewGroupCard: widget.isReviewGroupCard,
+                sourceColumnId: widget.sourceColumnId,
+                isStartingCursorAgent: widget.isStartingCursorAgent,
+                requiresLongPressDrag: widget.requiresLongPressDrag,
+                onTap: widget.onTap,
+                onSubIssueTap: widget.onSubIssueTap,
+                onStartCursorAgent: widget.onStartCursorAgent,
+              ),
+            ),
+            if (_isHovering)
+              Positioned(
+                left: 10,
+                right: 10,
+                top: _insertAfter ? null : -3,
+                bottom: _insertAfter ? -3 : null,
+                child: const DropIndicator(),
+              ),
+          ],
+        );
+      },
+    );
+  }
+}
+
+class DropIndicator extends StatelessWidget {
+  const DropIndicator({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: 6,
+      decoration: BoxDecoration(
+        color: const Color(0xFF38BDF8),
+        borderRadius: BorderRadius.circular(999),
+        boxShadow: [
+          BoxShadow(
+            color: const Color(0xFF38BDF8).withValues(alpha: 0.32),
+            blurRadius: 10,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class IssueCardDraggable extends StatefulWidget {
+  const IssueCardDraggable({
+    super.key,
+    required this.issue,
+    this.subIssues = const [],
+    this.buildStatus,
+    this.isReviewGroupCard = false,
+    required this.sourceColumnId,
+    required this.isStartingCursorAgent,
+    required this.requiresLongPressDrag,
+    required this.onTap,
+    this.onSubIssueTap,
+    this.onStartCursorAgent,
+  });
+
+  final Issue issue;
+  final List<Issue> subIssues;
+  final CardBuildStatus? buildStatus;
+  final bool isReviewGroupCard;
+  final String sourceColumnId;
+  final bool isStartingCursorAgent;
+  final bool requiresLongPressDrag;
+  final VoidCallback onTap;
+  final ValueChanged<String>? onSubIssueTap;
+  final VoidCallback? onStartCursorAgent;
+
+  @override
+  State<IssueCardDraggable> createState() => _IssueCardDraggableState();
+}
+
+class _IssueCardDraggableState extends State<IssueCardDraggable> {
+  static const _liftPreviewDelay = Duration(milliseconds: 280);
+  static const _liftPreviewCancelSlop = 8.0;
+
+  Timer? _liftPreviewTimer;
+  Timer? _tapSuppressionTimer;
+  Offset? _pressStartPosition;
+  bool _isLiftPreviewVisible = false;
+  bool _suppressNextTap = false;
+
+  @override
+  void dispose() {
+    _liftPreviewTimer?.cancel();
+    _tapSuppressionTimer?.cancel();
+    super.dispose();
+  }
+
+  void _startLiftPreviewTimer(PointerDownEvent event) {
+    _liftPreviewTimer?.cancel();
+    _pressStartPosition = event.position;
+    _liftPreviewTimer = Timer(_liftPreviewDelay, () {
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _isLiftPreviewVisible = true;
+        _suppressNextTap = true;
+      });
+    });
+  }
+
+  void _cancelLiftPreview() {
+    _liftPreviewTimer?.cancel();
+    _liftPreviewTimer = null;
+    _pressStartPosition = null;
+
+    if (!_isLiftPreviewVisible || !mounted) {
+      return;
+    }
+
+    setState(() {
+      _isLiftPreviewVisible = false;
+    });
+  }
+
+  void _handlePointerUp() {
+    final shouldSuppressTap = _suppressNextTap;
+    _cancelLiftPreview();
+
+    if (!shouldSuppressTap) {
+      return;
+    }
+
+    _tapSuppressionTimer?.cancel();
+    _tapSuppressionTimer = Timer(const Duration(milliseconds: 250), () {
+      _suppressNextTap = false;
+      _tapSuppressionTimer = null;
+    });
+  }
+
+  void _clearTapSuppression() {
+    _tapSuppressionTimer?.cancel();
+    _tapSuppressionTimer = null;
+    _suppressNextTap = false;
+  }
+
+  void _handleTap() {
+    final shouldSuppressTap = _suppressNextTap;
+    _clearTapSuppression();
+
+    if (shouldSuppressTap) {
+      return;
+    }
+
+    widget.onTap();
+  }
+
+  void _finishDragInteraction() {
+    _cancelLiftPreview();
+    _clearTapSuppression();
+  }
+
+  void _handlePointerMove(PointerMoveEvent event) {
+    final startPosition = _pressStartPosition;
+    if (startPosition == null || _isLiftPreviewVisible) {
+      return;
+    }
+
+    if ((event.position - startPosition).distance > _liftPreviewCancelSlop) {
+      _liftPreviewTimer?.cancel();
+      _liftPreviewTimer = null;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final data = IssueDragData(
+      issueId: widget.issue.id,
+      sourceColumnId: widget.sourceColumnId,
+    );
+    Widget buildCard({
+      bool isDragging = false,
+      bool isDragPlaceholder = false,
+      bool includeActions = true,
+    }) {
+      if (widget.isReviewGroupCard) {
+        return ReviewGroupIssueCard(
+          issue: widget.issue,
+          isDragging: isDragging,
+          isDragPlaceholder: isDragPlaceholder,
+        );
+      }
+
+      return IssueCard(
+        issue: widget.issue,
+        subIssues: widget.subIssues,
+        buildStatus: widget.buildStatus,
+        onSubIssueTap: widget.onSubIssueTap,
+        isDragging: isDragging,
+        isDragPlaceholder: isDragPlaceholder,
+        isStartingCursorAgent: includeActions && widget.isStartingCursorAgent,
+        onStartCursorAgent: includeActions ? widget.onStartCursorAgent : null,
+      );
+    }
+
+    final feedback = Material(
+      color: Colors.transparent,
+      child: SizedBox(
+        width: 290,
+        child: Opacity(
+          opacity: 0.96,
+          child: Transform.translate(
+            offset: const Offset(0, -8),
+            child: Transform.rotate(
+              angle: -0.035,
+              child: Transform.scale(
+                scale: 1.04,
+                child: buildCard(isDragging: true, includeActions: false),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    final childWhenDragging = Transform.scale(
+      scale: 0.98,
+      child: Opacity(
+        opacity: 0.28,
+        child: buildCard(isDragPlaceholder: true, includeActions: false),
+      ),
+    );
+    final child = GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: _handleTap,
+      child: AnimatedScale(
+        scale: _isLiftPreviewVisible ? 1.025 : 1,
+        duration: const Duration(milliseconds: 120),
+        curve: Curves.easeOutCubic,
+        child: AnimatedContainer(
+          duration: const Duration(milliseconds: 120),
+          curve: Curves.easeOutCubic,
+          transform: Matrix4.translationValues(
+            0,
+            _isLiftPreviewVisible ? -6 : 0,
+            0,
+          ),
+          child: buildCard(isDragging: _isLiftPreviewVisible),
+        ),
+      ),
+    );
+
+    final draggable = widget.requiresLongPressDrag
+        ? LongPressDraggable<IssueDragData>(
+            data: data,
+            delay: mobileDragStartDelay,
+            hitTestBehavior: HitTestBehavior.opaque,
+            onDragStarted: _finishDragInteraction,
+            onDragCompleted: _finishDragInteraction,
+            onDraggableCanceled: (_, _) => _finishDragInteraction(),
+            onDragEnd: (_) => _finishDragInteraction(),
+            feedback: feedback,
+            childWhenDragging: childWhenDragging,
+            child: child,
+          )
+        : Draggable<IssueDragData>(
+            data: data,
+            hitTestBehavior: HitTestBehavior.opaque,
+            onDragStarted: _finishDragInteraction,
+            onDragCompleted: _finishDragInteraction,
+            onDraggableCanceled: (_, _) => _finishDragInteraction(),
+            onDragEnd: (_) => _finishDragInteraction(),
+            feedback: feedback,
+            childWhenDragging: childWhenDragging,
+            child: child,
+          );
+
+    if (widget.requiresLongPressDrag) {
+      return draggable;
+    }
+
+    return Listener(
+      onPointerDown: _startLiftPreviewTimer,
+      onPointerMove: _handlePointerMove,
+      onPointerUp: (_) => _handlePointerUp(),
+      onPointerCancel: (_) => _finishDragInteraction(),
+      child: draggable,
+    );
+  }
+}
+
+class IssueCard extends StatelessWidget {
+  const IssueCard({
+    super.key,
+    required this.issue,
+    this.subIssues = const [],
+    this.buildStatus,
+    this.onSubIssueTap,
+    this.isDragging = false,
+    this.isDragPlaceholder = false,
+    this.isStartingCursorAgent = false,
+    this.onStartCursorAgent,
+  });
+
+  final Issue issue;
+  final List<Issue> subIssues;
+  final CardBuildStatus? buildStatus;
+  final ValueChanged<String>? onSubIssueTap;
+  final bool isDragging;
+  final bool isDragPlaceholder;
+  final bool isStartingCursorAgent;
+  final VoidCallback? onStartCursorAgent;
+
+  @override
+  Widget build(BuildContext context) {
+    final githubUrl = issue.githubUrl;
+    final weightEstimate = issue.weightEstimate;
+    final cardWeight = issue.statusId == closedStatusId
+        ? issue.resolution?.actualWeight
+        : weightEstimate?.value;
+    final cardWeightTooltip = issue.statusId == closedStatusId
+        ? '実績weight $cardWeight'
+        : 'Weight $cardWeight / 信頼度 ${((weightEstimate?.confidence ?? 0) * 100).round()}%';
+
+    return AnimatedContainer(
+      duration: const Duration(milliseconds: 140),
+      padding: const EdgeInsets.fromLTRB(11, 11, 11, 10),
+      decoration: BoxDecoration(
+        color: isDragPlaceholder ? const Color(0xFFF8FAFC) : Colors.white,
+        border: Border.all(
+          color: isDragging || isDragPlaceholder
+              ? const Color(0xFF38BDF8).withValues(alpha: 0.48)
+              : const Color(0xFFDDE7F0),
+        ),
+        borderRadius: BorderRadius.circular(20),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(
+              alpha: isDragging
+                  ? 0.22
+                  : isDragPlaceholder
+                  ? 0
+                  : 0.035,
+            ),
+            blurRadius: isDragging ? 30 : 14,
+            offset: Offset(0, isDragging ? 18 : 6),
+          ),
+        ],
+      ),
+      clipBehavior: Clip.antiAlias,
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          final isTight = constraints.maxWidth < 300;
+          final body = issue.body.trim();
+          final visibleLabelLimit = isTight ? 3 : 5;
+          final visibleLabels = issue.labels.take(visibleLabelLimit).toList();
+          final hiddenLabelCount = issue.labels.length - visibleLabels.length;
+
+          return Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Expanded(
+                    child: Wrap(
+                      spacing: 6,
+                      runSpacing: 6,
+                      children: [
+                        RepoBadge(repo: issue.repo),
+                        if (cardWeight != null)
+                          WeightBadge(
+                            value: cardWeight,
+                            tooltip: cardWeightTooltip,
+                            isActual: issue.statusId == closedStatusId,
+                          ),
+                      ],
+                    ),
+                  ),
+                  if (githubUrl != null) ...[
+                    const SizedBox(width: 6),
+                    Wrap(
+                      spacing: 4,
+                      runSpacing: 4,
+                      children: [
+                        GitHubLinkCopyButton(url: githubUrl),
+                        CursorAgentCardButton(
+                          issue: issue,
+                          isStarting: isStartingCursorAgent,
+                          onStart: onStartCursorAgent,
+                        ),
+                      ],
+                    ),
+                  ],
+                ],
+              ),
+              const SizedBox(height: 10),
+              Text(
+                issue.title,
+                maxLines: isTight ? 2 : 3,
+                overflow: TextOverflow.ellipsis,
+                style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                  color: const Color(0xFF0F172A),
+                  fontWeight: FontWeight.w700,
+                  height: 1.28,
+                ),
+              ),
+              if (body.isNotEmpty) ...[
+                const SizedBox(height: 6),
+                Text(
+                  body,
+                  maxLines: isTight ? 2 : 3,
+                  overflow: TextOverflow.ellipsis,
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: const Color(0xFF64748B),
+                    height: 1.35,
+                  ),
+                ),
+              ],
+              if (issue.subIssuesSummary != null || subIssues.isNotEmpty) ...[
+                const SizedBox(height: 10),
+                IssueCardSubIssuesSection(
+                  summary: issue.subIssuesSummary,
+                  subIssues: subIssues,
+                  onIssueTap: onSubIssueTap,
+                ),
+              ],
+              if (visibleLabels.isNotEmpty) ...[
+                const SizedBox(height: 10),
+                Wrap(
+                  spacing: 5,
+                  runSpacing: 5,
+                  children: [
+                    for (final label in visibleLabels) LabelPill(label: label),
+                    if (hiddenLabelCount > 0)
+                      LabelPill(label: '+$hiddenLabelCount'),
+                  ],
+                ),
+              ],
+              const SizedBox(height: 11),
+              Wrap(
+                spacing: 6,
+                runSpacing: 6,
+                crossAxisAlignment: WrapCrossAlignment.center,
+                children: [
+                  IssueIdMetaChip(issueId: issue.displayId),
+                  if (issue.dueDate != null)
+                    DueDatePill(dueDate: issue.dueDate!),
+                  if (issue.parentIssue != null)
+                    ParentIssueMetaChip(parentIssue: issue.parentIssue!),
+                  if (issue.pullRequests.isNotEmpty)
+                    PullRequestBadge(pullRequests: issue.pullRequests),
+                  BuildStatusBadge(status: buildStatus),
+                  CommentMetaChip(comments: issue.comments),
+                ],
+              ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+}
+
+class ReviewGroupIssueCard extends StatelessWidget {
+  const ReviewGroupIssueCard({
+    super.key,
+    required this.issue,
+    this.isDragging = false,
+    this.isDragPlaceholder = false,
+  });
+
+  final Issue issue;
+  final bool isDragging;
+  final bool isDragPlaceholder;
+
+  @override
+  Widget build(BuildContext context) {
+    final weight = issue.statusId == closedStatusId
+        ? issue.resolution?.actualWeight
+        : issue.weightEstimate?.value;
+
+    return AnimatedContainer(
+      duration: const Duration(milliseconds: 140),
+      padding: const EdgeInsets.fromLTRB(10, 9, 10, 9),
+      decoration: BoxDecoration(
+        color: isDragPlaceholder ? const Color(0xFFF8FAFC) : Colors.white,
+        border: Border.all(
+          color: isDragging || isDragPlaceholder
+              ? const Color(0xFF38BDF8).withValues(alpha: 0.48)
+              : const Color(0xFFE2E8F0),
+        ),
+        borderRadius: BorderRadius.circular(14),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(
+              alpha: isDragging
+                  ? 0.18
+                  : isDragPlaceholder
+                  ? 0
+                  : 0.02,
+            ),
+            blurRadius: isDragging ? 24 : 8,
+            offset: Offset(0, isDragging ? 14 : 3),
+          ),
+        ],
+      ),
+      clipBehavior: Clip.antiAlias,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Container(
+                padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 3),
+                decoration: BoxDecoration(
+                  color: const Color(0xFFF1F5F9),
+                  borderRadius: BorderRadius.circular(999),
+                ),
+                child: Text(
+                  issue.displayId,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: const TextStyle(
+                    color: Color(0xFF64748B),
+                    fontSize: 11,
+                    fontWeight: FontWeight.w900,
+                  ),
+                ),
+              ),
+              const SizedBox(width: 7),
+              Expanded(
+                child: Text(
+                  issue.title,
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                  style: const TextStyle(
+                    color: Color(0xFF0F172A),
+                    fontSize: 13,
+                    fontWeight: FontWeight.w800,
+                    height: 1.25,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 7),
+          Wrap(
+            spacing: 6,
+            runSpacing: 6,
+            crossAxisAlignment: WrapCrossAlignment.center,
+            children: [
+              if (weight != null)
+                ReviewGroupPill(
+                  label: 'W$weight',
+                  color: issue.statusId == closedStatusId
+                      ? const Color(0xFF15803D)
+                      : const Color(0xFF2563EB),
+                  icon: Icons.speed_rounded,
+                ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class ReviewLinkedIssueReferenceCard extends StatelessWidget {
+  const ReviewLinkedIssueReferenceCard({super.key, required this.reference});
+
+  final IssuePullRequestLinkedIssue reference;
+
+  @override
+  Widget build(BuildContext context) {
+    final isClosed = reference.state == 'closed';
+    final stateColor = isClosed
+        ? const Color(0xFF15803D)
+        : const Color(0xFF64748B);
+
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: reference.url == null
+          ? null
+          : () => unawaited(launchUrlExternal(reference.url!)),
+      child: Container(
+        padding: const EdgeInsets.fromLTRB(10, 9, 10, 9),
+        decoration: BoxDecoration(
+          color: Colors.white,
+          border: Border.all(color: const Color(0xFFE2E8F0)),
+          borderRadius: BorderRadius.circular(14),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Container(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 6,
+                    vertical: 3,
+                  ),
+                  decoration: BoxDecoration(
+                    color: const Color(0xFFF1F5F9),
+                    borderRadius: BorderRadius.circular(999),
+                  ),
+                  child: Text(
+                    '#${reference.number}',
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: const TextStyle(
+                      color: Color(0xFF64748B),
+                      fontSize: 11,
+                      fontWeight: FontWeight.w900,
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 7),
+                Expanded(
+                  child: Text(
+                    reference.title,
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                    style: const TextStyle(
+                      color: Color(0xFF0F172A),
+                      fontSize: 13,
+                      fontWeight: FontWeight.w800,
+                      height: 1.25,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 7),
+            ReviewGroupPill(
+              label: isClosed ? 'closed' : 'open',
+              color: stateColor,
+              icon: isClosed
+                  ? Icons.check_circle_rounded
+                  : Icons.circle_outlined,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class SubIssuesProgressMeter extends StatelessWidget {
+  const SubIssuesProgressMeter({super.key, required this.summary});
+
+  final IssueSubIssuesSummary summary;
+
+  @override
+  Widget build(BuildContext context) {
+    final color = summary.completed == summary.total
+        ? const Color(0xFF16A34A)
+        : Theme.of(context).colorScheme.primary;
+    return Container(
+      padding: const EdgeInsets.fromLTRB(10, 8, 10, 9),
+      decoration: BoxDecoration(
+        color: const Color(0xFFF8FAFC),
+        border: Border.all(color: const Color(0xFFE2E8F0)),
+        borderRadius: BorderRadius.circular(14),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Row(
+            children: [
+              Icon(Icons.account_tree_outlined, size: 14, color: color),
+              const SizedBox(width: 6),
+              Expanded(
+                child: Text(
+                  'Sub-issues ${summary.completed}/${summary.total}',
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: const TextStyle(
+                    color: Color(0xFF475569),
+                    fontSize: 12,
+                    fontWeight: FontWeight.w900,
+                  ),
+                ),
+              ),
+              const SizedBox(width: 8),
+              Text(
+                '${summary.percentCompleted}%',
+                style: TextStyle(
+                  color: color,
+                  fontSize: 12,
+                  fontWeight: FontWeight.w900,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 7),
+          ClipRRect(
+            borderRadius: BorderRadius.circular(999),
+            child: LinearProgressIndicator(
+              minHeight: 5,
+              value: summary.progress,
+              backgroundColor: const Color(0xFFE2E8F0),
+              valueColor: AlwaysStoppedAnimation<Color>(color),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class IssueCardSubIssuesSection extends StatelessWidget {
+  const IssueCardSubIssuesSection({
+    super.key,
+    required this.summary,
+    required this.subIssues,
+    this.onIssueTap,
+  });
+
+  final IssueSubIssuesSummary? summary;
+  final List<Issue> subIssues;
+  final ValueChanged<String>? onIssueTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final currentSummary = summary;
+    final completed = currentSummary?.completed ?? 0;
+    final total = currentSummary?.total ?? subIssues.length;
+    final percentCompleted = currentSummary?.percentCompleted ?? 0;
+    final progress = currentSummary?.progress ?? 0;
+    final color = total > 0 && completed == total
+        ? const Color(0xFF16A34A)
+        : Theme.of(context).colorScheme.primary;
+
+    return Container(
+      decoration: BoxDecoration(
+        color: const Color(0xFFF8FAFC),
+        border: Border.all(color: const Color(0xFFE2E8F0)),
+        borderRadius: BorderRadius.circular(14),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(10, 8, 10, 9),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Row(
+                  children: [
+                    Icon(Icons.account_tree_outlined, size: 14, color: color),
+                    const SizedBox(width: 6),
+                    Expanded(
+                      child: Text(
+                        'Sub-issues $completed/$total',
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: const TextStyle(
+                          color: Color(0xFF475569),
+                          fontSize: 12,
+                          fontWeight: FontWeight.w900,
+                        ),
+                      ),
+                    ),
+                    const SizedBox(width: 8),
+                    Text(
+                      '$percentCompleted%',
+                      style: TextStyle(
+                        color: color,
+                        fontSize: 12,
+                        fontWeight: FontWeight.w900,
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 7),
+                ClipRRect(
+                  borderRadius: BorderRadius.circular(999),
+                  child: LinearProgressIndicator(
+                    minHeight: 5,
+                    value: progress,
+                    backgroundColor: const Color(0xFFE2E8F0),
+                    valueColor: AlwaysStoppedAnimation<Color>(color),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          if (subIssues.isNotEmpty) ...[
+            const Divider(height: 1, color: Color(0xFFE2E8F0)),
+            SubIssuesList(
+              subIssues: subIssues,
+              onIssueTap: onIssueTap,
+              isEmbedded: true,
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class SubIssuesList extends StatelessWidget {
+  const SubIssuesList({
+    super.key,
+    required this.subIssues,
+    this.workspaceId,
+    this.referenceSubIssues = const [],
+    this.onIssueTap,
+    this.isEmbedded = false,
+  });
+
+  final List<Issue> subIssues;
+  final String? workspaceId;
+  final List<IssueSubIssueReference> referenceSubIssues;
+  final ValueChanged<String>? onIssueTap;
+  final bool isEmbedded;
+
+  @override
+  Widget build(BuildContext context) {
+    final rows = <Widget>[
+      for (final issue in subIssues)
+        SubIssueListRow(issue: issue, onTap: onIssueTap),
+      for (final subIssue in referenceSubIssues)
+        SubIssueReferenceRow(
+          subIssue: subIssue,
+          workspaceId: workspaceId,
+          onTap: onIssueTap,
+        ),
+    ];
+    final list = Column(
+      children: [
+        for (final entry in rows.indexed) ...[
+          entry.$2,
+          if (entry.$1 != rows.length - 1)
+            const Divider(height: 1, color: Color(0xFFE2E8F0)),
+        ],
+      ],
+    );
+    if (isEmbedded) {
+      return list;
+    }
+    return Container(
+      decoration: BoxDecoration(
+        color: const Color(0xFFF8FAFC),
+        border: Border.all(color: const Color(0xFFE2E8F0)),
+        borderRadius: BorderRadius.circular(14),
+      ),
+      child: list,
+    );
+  }
+}
+
+class SubIssueReferenceList extends StatelessWidget {
+  const SubIssueReferenceList({
+    super.key,
+    required this.subIssues,
+    this.workspaceId,
+    this.onIssueTap,
+  });
+
+  final List<IssueSubIssueReference> subIssues;
+  final String? workspaceId;
+  final ValueChanged<String>? onIssueTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        color: Colors.white,
+        border: Border.all(color: const Color(0xFFE2E8F0)),
+        borderRadius: BorderRadius.circular(14),
+      ),
+      child: Column(
+        children: [
+          for (final entry in subIssues.indexed) ...[
+            SubIssueReferenceRow(
+              subIssue: entry.$2,
+              workspaceId: workspaceId,
+              onTap: onIssueTap,
+            ),
+            if (entry.$1 != subIssues.length - 1)
+              const Divider(height: 1, color: Color(0xFFE2E8F0)),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class SubIssueListRow extends StatelessWidget {
+  const SubIssueListRow({super.key, required this.issue, this.onTap});
+
+  final Issue issue;
+  final ValueChanged<String>? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final isClosed = issue.statusId == closedStatusId;
+    final isCreating = issue.parentIssue != null && issue.issueKey == null;
+    final iconColor = isClosed
+        ? const Color(0xFF8250DF)
+        : const Color(0xFF1F883D);
+    return InkWell(
+      onTap: onTap == null || isCreating ? null : () => onTap!(issue.id),
+      borderRadius: BorderRadius.circular(12),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 9, vertical: 7),
+        child: Row(
+          children: [
+            Icon(
+              isClosed
+                  ? Icons.check_circle_outline_rounded
+                  : Icons.radio_button_unchecked_rounded,
+              size: 15,
+              color: iconColor,
+            ),
+            const SizedBox(width: 7),
+            Expanded(
+              child: Text(
+                issue.title,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: TextStyle(
+                  color: isClosed
+                      ? const Color(0xFF64748B)
+                      : const Color(0xFF334155),
+                  fontSize: 12,
+                  fontWeight: FontWeight.w800,
+                  decoration: isClosed ? TextDecoration.lineThrough : null,
+                ),
+              ),
+            ),
+            const SizedBox(width: 7),
+            isCreating
+                ? const _SubIssueCreatingBadge()
+                : Text(
+                    issue.displayId,
+                    style: const TextStyle(
+                      color: Color(0xFF94A3B8),
+                      fontSize: 11,
+                      fontWeight: FontWeight.w900,
+                    ),
+                  ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class SubIssueReferenceRow extends StatelessWidget {
+  const SubIssueReferenceRow({
+    super.key,
+    required this.subIssue,
+    this.workspaceId,
+    this.onTap,
+  });
+
+  final IssueSubIssueReference subIssue;
+  final String? workspaceId;
+  final ValueChanged<String>? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final issueId = subIssue.issueId;
+    final currentWorkspaceId = workspaceId;
+    if (issueId.isNotEmpty &&
+        currentWorkspaceId != null &&
+        currentWorkspaceId.isNotEmpty) {
+      return StreamBuilder<DocumentSnapshot<Map<String, dynamic>>>(
+        stream: FirebaseFirestore.instance
+            .doc('workspaces/$currentWorkspaceId/issues/$issueId')
+            .snapshots(),
+        builder: (context, snapshot) {
+          final issueSnapshot = snapshot.data;
+          if (issueSnapshot != null && issueSnapshot.exists) {
+            final issue = Issue.fromDocument(issueSnapshot);
+            if (issue.issueKey == null) {
+              return _SubIssueReferenceContent(
+                title: issue.title,
+                isClosed: issue.statusId == closedStatusId,
+                isCreating: true,
+              );
+            }
+            return SubIssueListRow(issue: issue, onTap: onTap);
+          }
+          return _SubIssueReferenceContent(
+            title: subIssue.title,
+            isClosed: subIssue.state == 'closed',
+            isCreating: true,
+          );
+        },
+      );
+    }
+    return _SubIssueReferenceContent(
+      title: subIssue.title,
+      isClosed: subIssue.state == 'closed',
+      trailingLabel: subIssue.number > 0 ? '#${subIssue.number}' : '',
+      onTap: onTap == null || issueId.isEmpty ? null : () => onTap!(issueId),
+    );
+  }
+}
+
+class _SubIssueReferenceContent extends StatelessWidget {
+  const _SubIssueReferenceContent({
+    required this.title,
+    required this.isClosed,
+    this.trailingLabel = '',
+    this.isCreating = false,
+    this.onTap,
+  });
+
+  final String title;
+  final bool isClosed;
+  final String trailingLabel;
+  final bool isCreating;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final iconColor = isClosed
+        ? const Color(0xFF8250DF)
+        : const Color(0xFF1F883D);
+    return InkWell(
+      onTap: isCreating ? null : onTap,
+      borderRadius: BorderRadius.circular(12),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 9, vertical: 7),
+        child: Row(
+          children: [
+            Icon(
+              isClosed
+                  ? Icons.check_circle_outline_rounded
+                  : Icons.radio_button_unchecked_rounded,
+              size: 15,
+              color: iconColor,
+            ),
+            const SizedBox(width: 7),
+            Expanded(
+              child: Text(
+                title,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: TextStyle(
+                  color: isClosed
+                      ? const Color(0xFF64748B)
+                      : const Color(0xFF334155),
+                  fontSize: 12,
+                  fontWeight: FontWeight.w800,
+                  decoration: isClosed ? TextDecoration.lineThrough : null,
+                ),
+              ),
+            ),
+            const SizedBox(width: 7),
+            isCreating
+                ? const _SubIssueCreatingBadge()
+                : Text(
+                    trailingLabel,
+                    style: const TextStyle(
+                      color: Color(0xFF94A3B8),
+                      fontSize: 11,
+                      fontWeight: FontWeight.w900,
+                    ),
+                  ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SubIssueCreatingBadge extends StatelessWidget {
+  const _SubIssueCreatingBadge();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 7, vertical: 4),
+      decoration: BoxDecoration(
+        color: const Color(0xFFFFFBEB),
+        borderRadius: BorderRadius.circular(999),
+        border: Border.all(color: const Color(0xFFFDE68A)),
+      ),
+      child: const Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          SizedBox(
+            width: 10,
+            height: 10,
+            child: CircularProgressIndicator(
+              strokeWidth: 2,
+              color: Color(0xFFD97706),
+            ),
+          ),
+          SizedBox(width: 5),
+          Text(
+            '作成中',
+            style: TextStyle(
+              color: Color(0xFF92400E),
+              fontSize: 10,
+              fontWeight: FontWeight.w900,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class IssueIdMetaChip extends StatelessWidget {
+  const IssueIdMetaChip({super.key, required this.issueId});
+
+  final String issueId;
+
+  @override
+  Widget build(BuildContext context) {
+    return IssueMetaChip(
+      label: issueId,
+      trailing: IssueIdCopyButton(issueId: issueId),
+    );
+  }
+}
+
+class ParentIssueMetaChip extends StatelessWidget {
+  const ParentIssueMetaChip({super.key, required this.parentIssue});
+
+  final IssueParentIssue parentIssue;
+
+  @override
+  Widget build(BuildContext context) {
+    return IssueMetaChip(
+      icon: Icons.account_tree_outlined,
+      label: parentIssue.number > 0
+          ? 'Parent #${parentIssue.number}'
+          : 'Parent',
+    );
+  }
+}
+
+class CommentMetaChip extends StatelessWidget {
+  const CommentMetaChip({super.key, required this.comments});
+
+  final int comments;
+
+  @override
+  Widget build(BuildContext context) {
+    return IssueMetaChip(
+      icon: Icons.chat_bubble_outline_rounded,
+      label: '$comments',
+    );
+  }
+}
+
+class IssueMetaChip extends StatelessWidget {
+  const IssueMetaChip({
+    super.key,
+    required this.label,
+    this.icon,
+    this.leading,
+    this.trailing,
+  });
+
+  final String label;
+  final IconData? icon;
+  final Widget? leading;
+  final Widget? trailing;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: EdgeInsets.fromLTRB(
+        leading == null && icon == null ? 8 : 5,
+        3,
+        6,
+        3,
+      ),
+      decoration: BoxDecoration(
+        color: const Color(0xFFF8FAFC),
+        border: Border.all(color: const Color(0xFFE2E8F0)),
+        borderRadius: BorderRadius.circular(999),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          if (leading != null) ...[
+            leading!,
+            const SizedBox(width: 5),
+          ] else if (icon != null) ...[
+            Icon(icon, size: 13, color: const Color(0xFF94A3B8)),
+            const SizedBox(width: 4),
+          ],
+          ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 96),
+            child: Text(
+              label,
+              overflow: TextOverflow.ellipsis,
+              style: const TextStyle(
+                color: Color(0xFF64748B),
+                fontSize: 12,
+                fontWeight: FontWeight.w800,
+              ),
+            ),
+          ),
+          if (trailing != null) ...[const SizedBox(width: 1), trailing!],
+        ],
+      ),
+    );
+  }
+}
+
+class IssueIdCopyButton extends StatelessWidget {
+  const IssueIdCopyButton({super.key, required this.issueId});
+
+  final String issueId;
+
+  @override
+  Widget build(BuildContext context) {
+    return _CopyFeedbackIconButton(
+      tooltip: 'Issue IDをコピー',
+      copiedTooltip: 'Issue IDをコピーしました',
+      text: issueId,
+      successMessage: 'Issue IDをコピーしました',
+      icon: const Icon(
+        Icons.copy_rounded,
+        size: 13,
+        color: Color(0xFF94A3B8),
+      ),
+      iconSize: 13,
+      dimension: 22,
+    );
+  }
+}
+
+class PullRequestBadge extends StatelessWidget {
+  const PullRequestBadge({super.key, required this.pullRequests});
+
+  final List<IssuePullRequest> pullRequests;
+
+  @override
+  Widget build(BuildContext context) {
+    final latest = pullRequests.last;
+    final label = pullRequests.length == 1
+        ? 'PR #${latest.number}'
+        : '${pullRequests.length} PRs';
+    final prUrl = latest.url;
+    return Tooltip(
+      message: prUrl ?? 'Linked pull request',
+      child: GestureDetector(
+        onTap: prUrl != null ? () => unawaited(launchUrlExternal(prUrl)) : null,
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 7, vertical: 4),
+          decoration: BoxDecoration(
+            color: const Color(0xFFEFF6FF),
+            border: Border.all(color: const Color(0xFFBFDBFE)),
+            borderRadius: BorderRadius.circular(999),
+          ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const Icon(
+                Icons.alt_route_rounded,
+                size: 14,
+                color: Color(0xFF0EA5E9),
+              ),
+              const SizedBox(width: 4),
+              Text(
+                label,
+                style: const TextStyle(
+                  color: Color(0xFF0369A1),
+                  fontSize: 12,
+                  fontWeight: FontWeight.w800,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class GitHubLinkCopyButton extends StatelessWidget {
+  const GitHubLinkCopyButton({super.key, required this.url});
+
+  final String url;
+
+  @override
+  Widget build(BuildContext context) {
+    return _CopyFeedbackIconButton(
+      tooltip: 'GitHubリンクをコピー',
+      copiedTooltip: 'GitHubリンクをコピーしました',
+      text: url,
+      successMessage: 'GitHubリンクをコピーしました',
+      icon: const _CopyLinkIcon(),
+      iconSize: 14,
+      dimension: 26,
+    );
+  }
+}
+
+class _CopyLinkIcon extends StatelessWidget {
+  const _CopyLinkIcon();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Icon(
+      Symbols.link_2_rounded,
+      size: 17,
+      color: Color(0xFF475569),
+    );
+  }
+}
+
+class _CopyFeedbackIconButton extends StatefulWidget {
+  const _CopyFeedbackIconButton({
+    required this.tooltip,
+    required this.copiedTooltip,
+    required this.text,
+    required this.successMessage,
+    required this.icon,
+    required this.iconSize,
+    required this.dimension,
+  });
+
+  final String tooltip;
+  final String copiedTooltip;
+  final String text;
+  final String successMessage;
+  final Widget icon;
+  final double iconSize;
+  final double dimension;
+
+  @override
+  State<_CopyFeedbackIconButton> createState() =>
+      _CopyFeedbackIconButtonState();
+}
+
+class _CopyFeedbackIconButtonState extends State<_CopyFeedbackIconButton> {
+  bool _copied = false;
+  int _copyVersion = 0;
+
+  Future<void> _handleCopy() async {
+    final version = ++_copyVersion;
+    await copyTextToClipboard(
+      context,
+      text: widget.text,
+      successMessage: widget.successMessage,
+    );
+    if (!mounted) return;
+    setState(() => _copied = true);
+    await Future<void>.delayed(const Duration(milliseconds: 1500));
+    if (!mounted || version != _copyVersion) return;
+    setState(() => _copied = false);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox.square(
+      dimension: widget.dimension,
+      child: IconButton(
+        tooltip: _copied ? widget.copiedTooltip : widget.tooltip,
+        padding: EdgeInsets.zero,
+        visualDensity: VisualDensity.compact,
+        onPressed: () => unawaited(_handleCopy()),
+        icon: AnimatedSwitcher(
+          duration: const Duration(milliseconds: 180),
+          switchInCurve: Curves.easeOutBack,
+          switchOutCurve: Curves.easeIn,
+          transitionBuilder: (child, animation) {
+            return ScaleTransition(scale: animation, child: child);
+          },
+          child: _copied
+              ? Icon(
+                  Icons.check_rounded,
+                  key: const ValueKey('copied'),
+                  size: widget.iconSize,
+                  color: const Color(0xFF22C55E),
+                )
+              : KeyedSubtree(
+                  key: const ValueKey('copyIcon'),
+                  child: widget.icon,
+                ),
+        ),
+      ),
+    );
+  }
+}
+
+class CursorAgentCardButton extends StatelessWidget {
+  const CursorAgentCardButton({
+    super.key,
+    required this.issue,
+    required this.isStarting,
+    this.onStart,
+  });
+
+  final Issue issue;
+  final bool isStarting;
+  final VoidCallback? onStart;
+
+  @override
+  Widget build(BuildContext context) {
+    final hasPullRequest = issue.pullRequests.isNotEmpty;
+    final isRunning = issue.cursorAgent?.isActive == true && !hasPullRequest;
+    final isBusy = isStarting || isRunning;
+    return SizedBox.square(
+      dimension: 26,
+      child: IconButton(
+        tooltip: isRunning ? 'Cursor agentを実行中' : 'Cursor agentを開始',
+        padding: EdgeInsets.zero,
+        visualDensity: VisualDensity.compact,
+        onPressed: isBusy ? null : onStart,
+        icon: isBusy
+            ? const SizedBox.square(
+                dimension: 14,
+                child: CircularProgressIndicator(strokeWidth: 2),
+              )
+            : const Icon(Icons.smart_toy_outlined, size: 16),
+      ),
+    );
+  }
+}
+
+class RepoBadge extends StatelessWidget {
+  const RepoBadge({super.key, required this.repo});
+
+  final String repo;
+
+  @override
+  Widget build(BuildContext context) {
+    return ConstrainedBox(
+      constraints: const BoxConstraints(maxWidth: 150),
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 7, vertical: 4),
+        decoration: BoxDecoration(
+          color: const Color(0xFFF8FAFC),
+          border: Border.all(color: const Color(0xFFE2E8F0)),
+          borderRadius: BorderRadius.circular(999),
+        ),
+        child: Text(
+          repo,
+          overflow: TextOverflow.ellipsis,
+          style: const TextStyle(
+            color: Color(0xFF475569),
+            fontSize: 12,
+            fontWeight: FontWeight.w700,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class LabelPill extends StatelessWidget {
+  const LabelPill({super.key, required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return ConstrainedBox(
+      constraints: const BoxConstraints(maxWidth: 128),
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 7, vertical: 3),
+        decoration: BoxDecoration(
+          color: const Color(0xFFF1F5F9),
+          borderRadius: BorderRadius.circular(999),
+        ),
+        child: Text(
+          label,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: const TextStyle(
+            color: Color(0xFF475569),
+            fontSize: 12,
+            fontWeight: FontWeight.w700,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class DueDatePill extends StatelessWidget {
+  const DueDatePill({super.key, required this.dueDate});
+
+  final DateTime dueDate;
+
+  @override
+  Widget build(BuildContext context) {
+    final status = dueDateStatus(dueDate);
+    final colors = switch (status) {
+      DueDateStatus.overdue => (
+        background: const Color(0xFFFEE2E2),
+        foreground: const Color(0xFFB91C1C),
+      ),
+      DueDateStatus.today => (
+        background: const Color(0xFFFFEDD5),
+        foreground: const Color(0xFFC2410C),
+      ),
+      DueDateStatus.soon => (
+        background: const Color(0xFFFEF3C7),
+        foreground: const Color(0xFF92400E),
+      ),
+      DueDateStatus.later => (
+        background: const Color(0xFFEFF6FF),
+        foreground: const Color(0xFF1D4ED8),
+      ),
+    };
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 3),
+      decoration: BoxDecoration(
+        color: colors.background,
+        borderRadius: BorderRadius.circular(999),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(Icons.event_outlined, size: 12, color: colors.foreground),
+          const SizedBox(width: 3),
+          Text(
+            dueDateLabel(dueDate),
+            style: TextStyle(
+              color: colors.foreground,
+              fontSize: 12,
+              fontWeight: FontWeight.w800,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class WeightBadge extends StatelessWidget {
+  const WeightBadge({
+    super.key,
+    required this.value,
+    required this.tooltip,
+    this.isActual = false,
+  });
+
+  final int value;
+  final String tooltip;
+  final bool isActual;
+
+  @override
+  Widget build(BuildContext context) {
+    return Tooltip(
+      message: tooltip,
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 7, vertical: 4),
+        decoration: BoxDecoration(
+          color: isActual ? const Color(0xFFF0FDF4) : const Color(0xFFEEF2FF),
+          border: Border.all(
+            color: isActual ? const Color(0xFFBBF7D0) : const Color(0xFFC7D2FE),
+          ),
+          borderRadius: BorderRadius.circular(999),
+        ),
+        child: Text(
+          'W$value',
+          style: TextStyle(
+            color: isActual ? const Color(0xFF15803D) : const Color(0xFF4338CA),
+            fontSize: 12,
+            fontWeight: FontWeight.w900,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class IssueWeightOverrideDialog extends StatefulWidget {
+  const IssueWeightOverrideDialog({super.key, required this.issue});
+
+  final Issue issue;
+
+  @override
+  State<IssueWeightOverrideDialog> createState() =>
+      _IssueWeightOverrideDialogState();
+}
+
+class _IssueWeightOverrideDialogState extends State<IssueWeightOverrideDialog> {
+  int? _estimateWeight;
+  int? _actualWeight;
+
+  @override
+  void initState() {
+    super.initState();
+    final estimateWeight = widget.issue.weightEstimate?.value;
+    final actualWeight = widget.issue.resolution?.actualWeight;
+    _estimateWeight = validIssueWeights.contains(estimateWeight)
+        ? estimateWeight
+        : null;
+    _actualWeight = validIssueWeights.contains(actualWeight)
+        ? actualWeight
+        : _estimateWeight;
+  }
+
+  void _save() {
+    final estimateWeight = _estimateWeight;
+    if (estimateWeight == null) {
+      return;
+    }
+    final actualWeight = widget.issue.statusId == closedStatusId
+        ? _actualWeight
+        : null;
+    if (widget.issue.statusId == closedStatusId && actualWeight == null) {
+      return;
+    }
+    Navigator.of(context).pop(
+      IssueWeightOverrideDraft(
+        estimateWeight: estimateWeight,
+        actualWeight: actualWeight,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isClosed = widget.issue.statusId == closedStatusId;
+    final canSave =
+        _estimateWeight != null && (!isClosed || _actualWeight != null);
+
+    return AlertDialog(
+      title: const Text('Weight上書き'),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text(
+            'LLM estimateと完了時のactual weightを手動で補正します。',
+            style: TextStyle(color: Color(0xFF64748B)),
+          ),
+          const SizedBox(height: 16),
+          DropdownButtonFormField<int>(
+            initialValue: _estimateWeight,
+            decoration: const InputDecoration(
+              labelText: '推定weight',
+              border: OutlineInputBorder(),
+            ),
+            items: [
+              for (final weight in validIssueWeights)
+                DropdownMenuItem(value: weight, child: Text('W$weight')),
+            ],
+            onChanged: (value) => setState(() => _estimateWeight = value),
+          ),
+          if (isClosed) ...[
+            const SizedBox(height: 14),
+            DropdownButtonFormField<int>(
+              initialValue: _actualWeight,
+              decoration: const InputDecoration(
+                labelText: '実績weight',
+                border: OutlineInputBorder(),
+              ),
+              items: [
+                for (final weight in validIssueWeights)
+                  DropdownMenuItem(value: weight, child: Text('W$weight')),
+              ],
+              onChanged: (value) => setState(() => _actualWeight = value),
+            ),
+          ],
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('キャンセル'),
+        ),
+        FilledButton(
+          onPressed: canSave ? _save : null,
+          child: const Text('保存'),
+        ),
+      ],
+    );
+  }
+}
+
+class IssueWeightPanel extends StatelessWidget {
+  const IssueWeightPanel({
+    super.key,
+    required this.issue,
+    required this.isEstimating,
+    this.isOverriding = false,
+    this.onEstimate,
+    this.onOverride,
+  });
+
+  final Issue issue;
+  final bool isEstimating;
+  final bool isOverriding;
+  final Future<void> Function()? onEstimate;
+  final Future<void> Function()? onOverride;
+
+  @override
+  Widget build(BuildContext context) {
+    final estimate = issue.weightEstimate;
+    final value = estimate?.value;
+    final resolution = issue.resolution;
+    final actualWeight = resolution?.actualWeight;
+    final isClosed = issue.statusId == 'done';
+    final subtitle = switch (estimate?.status) {
+      'done' when estimate?.manualOverride == true && value != null => '手動上書き',
+      'done' when value != null =>
+        '信頼度 ${(estimate!.confidence * 100).round()}%'
+            '${estimate.estimatedAt == null ? '' : ' / ${formatDate(estimate.estimatedAt!)}'}',
+      'failed' => estimate?.error ?? 'Weight推定に失敗しました',
+      'estimating' => 'Weightを推定中...',
+      _ => 'まだ推定していません',
+    };
+    final reason = estimate?.reason;
+
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: const Color(0xFFF8FAFC),
+        border: Border.all(color: const Color(0xFFE2E8F0)),
+        borderRadius: BorderRadius.circular(16),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Container(
+                width: 42,
+                height: 42,
+                alignment: Alignment.center,
+                decoration: BoxDecoration(
+                  color: const Color(0xFFEEF2FF),
+                  borderRadius: BorderRadius.circular(14),
+                ),
+                child: isEstimating
+                    ? const SizedBox.square(
+                        dimension: 18,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : Text(
+                        value == null ? 'W?' : 'W$value',
+                        style: const TextStyle(
+                          color: Color(0xFF4338CA),
+                          fontWeight: FontWeight.w900,
+                        ),
+                      ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const Text(
+                      'LLM weight',
+                      style: TextStyle(
+                        color: Color(0xFF0F172A),
+                        fontWeight: FontWeight.w800,
+                      ),
+                    ),
+                    const SizedBox(height: 3),
+                    Text(
+                      subtitle,
+                      style: const TextStyle(color: Color(0xFF64748B)),
+                    ),
+                    if (reason != null && reason.isNotEmpty) ...[
+                      const SizedBox(height: 6),
+                      Text(
+                        reason,
+                        style: const TextStyle(color: Color(0xFF475569)),
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+              const SizedBox(width: 10),
+              Column(
+                crossAxisAlignment: CrossAxisAlignment.end,
+                children: [
+                  OutlinedButton.icon(
+                    onPressed: isEstimating || isOverriding ? null : onEstimate,
+                    icon: const Icon(Icons.auto_awesome_rounded, size: 16),
+                    label: Text(value == null ? '推定' : '再推定'),
+                  ),
+                  const SizedBox(height: 8),
+                  OutlinedButton.icon(
+                    onPressed: isEstimating || isOverriding ? null : onOverride,
+                    icon: isOverriding
+                        ? const SizedBox.square(
+                            dimension: 16,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          )
+                        : const Icon(Icons.tune_rounded, size: 16),
+                    label: const Text('上書き'),
+                  ),
+                ],
+              ),
+            ],
+          ),
+          if (isClosed && actualWeight != null) ...[
+            const SizedBox(height: 12),
+            _ActualWeightRow(
+              predictedWeight: value,
+              actualWeight: actualWeight,
+              delta: resolution?.weightDelta,
+              isManualOverride: resolution?.actualWeightManualOverride == true,
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _ActualWeightRow extends StatelessWidget {
+  const _ActualWeightRow({
+    required this.predictedWeight,
+    required this.actualWeight,
+    this.delta,
+    this.isManualOverride = false,
+  });
+
+  static const _validWeights = [1, 2, 4, 8, 16, 32];
+
+  static bool _isAdjacent(int a, int b) {
+    final idxA = _validWeights.indexOf(a);
+    final idxB = _validWeights.indexOf(b);
+    if (idxA < 0 || idxB < 0) return (a - b).abs() <= 1;
+    return (idxA - idxB).abs() <= 1;
+  }
+
+  final int? predictedWeight;
+  final int actualWeight;
+  final int? delta;
+  final bool isManualOverride;
+
+  @override
+  Widget build(BuildContext context) {
+    final isExact = predictedWeight == actualWeight;
+    final isClose =
+        predictedWeight != null && _isAdjacent(predictedWeight!, actualWeight);
+    final deltaColor = isExact
+        ? const Color(0xFF15803D)
+        : isClose
+        ? const Color(0xFFA16207)
+        : const Color(0xFFDC2626);
+    final deltaBg = isExact
+        ? const Color(0xFFF0FDF4)
+        : isClose
+        ? const Color(0xFFFEFCE8)
+        : const Color(0xFFFEF2F2);
+    final deltaLabel = delta == null
+        ? ''
+        : delta == 0
+        ? '一致'
+        : delta! > 0
+        ? '過大推定 +$delta'
+        : '過小推定 $delta';
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+      decoration: BoxDecoration(
+        color: deltaBg,
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Row(
+        children: [
+          Icon(Icons.assessment_outlined, size: 16, color: deltaColor),
+          const SizedBox(width: 8),
+          Text(
+            '実績 W$actualWeight',
+            style: TextStyle(
+              color: deltaColor,
+              fontWeight: FontWeight.w800,
+              fontSize: 13,
+            ),
+          ),
+          if (predictedWeight != null) ...[
+            const SizedBox(width: 6),
+            Text(
+              '(予測 W$predictedWeight)',
+              style: TextStyle(color: deltaColor.withAlpha(180), fontSize: 12),
+            ),
+          ],
+          if (isManualOverride) ...[
+            const SizedBox(width: 6),
+            Text(
+              'manual',
+              style: TextStyle(
+                color: deltaColor.withAlpha(180),
+                fontSize: 12,
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+          ],
+          const Spacer(),
+          if (deltaLabel.isNotEmpty)
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+              decoration: BoxDecoration(
+                color: deltaColor.withAlpha(25),
+                borderRadius: BorderRadius.circular(999),
+                border: Border.all(color: deltaColor.withAlpha(60)),
+              ),
+              child: Text(
+                deltaLabel,
+                style: TextStyle(
+                  color: deltaColor,
+                  fontSize: 11,
+                  fontWeight: FontWeight.w800,
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class CursorAgentPanel extends StatelessWidget {
+  const CursorAgentPanel({
+    super.key,
+    required this.issue,
+    required this.isStarting,
+    this.onStart,
+  });
+
+  final Issue issue;
+  final bool isStarting;
+  final Future<void> Function()? onStart;
+
+  @override
+  Widget build(BuildContext context) {
+    final hasGitHubIssue = issue.githubUrl != null;
+    final hasPullRequest = issue.pullRequests.isNotEmpty;
+    final agent = issue.cursorAgent;
+    final isRunning = agent?.isActive == true && !hasPullRequest;
+    final isBusy = isStarting || isRunning;
+    final subtitle = switch (agent?.status) {
+      'running' when !hasPullRequest =>
+        'Cursor agentを実行中です。Run ID: ${agent!.shortRunId}',
+      'starting' when !hasPullRequest => 'Cursor agentを開始中...',
+      'done' || 'running' || 'starting' => 'Cursor agentがpull requestを作成しました。',
+      'failed' => agent?.errorMessage ?? 'Cursor agentの開始に失敗しました。',
+      _ when hasGitHubIssue => 'Cursor Cloud Agentを開始して、このissueの対応PRを作成します。',
+      _ => 'agentを開始する前に、このissueをGitHubに接続してください。',
+    };
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: const Color(0xFFF8FAFC),
+        border: Border.all(color: const Color(0xFFE2E8F0)),
+        borderRadius: BorderRadius.circular(16),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Container(
+            width: 42,
+            height: 42,
+            alignment: Alignment.center,
+            decoration: BoxDecoration(
+              color: const Color(0xFFEFF6FF),
+              borderRadius: BorderRadius.circular(14),
+            ),
+            child: isBusy
+                ? const SizedBox.square(
+                    dimension: 18,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : const Icon(
+                    Icons.smart_toy_outlined,
+                    color: Color(0xFF2563EB),
+                  ),
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const Text(
+                  'Cursor agent',
+                  style: TextStyle(
+                    color: Color(0xFF0F172A),
+                    fontWeight: FontWeight.w800,
+                  ),
+                ),
+                const SizedBox(height: 3),
+                Text(
+                  subtitle,
+                  style: const TextStyle(color: Color(0xFF64748B)),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(width: 10),
+          OutlinedButton.icon(
+            onPressed: hasGitHubIssue && !isBusy ? onStart : null,
+            icon: const Icon(Icons.play_arrow_rounded, size: 18),
+            label: Text(isRunning ? '実行中' : '開始'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/apps/dashboard/lib/workspace/issue_board_ima_issue_editor.dart
+++ b/apps/dashboard/lib/workspace/issue_board_ima_issue_editor.dart
@@ -1,0 +1,4092 @@
+import 'dart:async';
+import 'dart:math' as math;
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:cloud_functions/cloud_functions.dart';
+import 'package:dashboard/firebase/callable_function_names.dart';
+import 'package:dashboard/firebase/firestore.dart' show BuildJobStatus;
+import 'package:dashboard/firebase/functions.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_markdown_plus/flutter_markdown_plus.dart';
+import 'package:re_highlight/languages/bash.dart';
+import 'package:re_highlight/languages/c.dart';
+import 'package:re_highlight/languages/cpp.dart';
+import 'package:re_highlight/languages/csharp.dart';
+import 'package:re_highlight/languages/css.dart';
+import 'package:re_highlight/languages/dart.dart';
+import 'package:re_highlight/languages/dockerfile.dart';
+import 'package:re_highlight/languages/go.dart';
+import 'package:re_highlight/languages/java.dart';
+import 'package:re_highlight/languages/javascript.dart';
+import 'package:re_highlight/languages/json.dart';
+import 'package:re_highlight/languages/kotlin.dart';
+import 'package:re_highlight/languages/markdown.dart';
+import 'package:re_highlight/languages/php.dart';
+import 'package:re_highlight/languages/python.dart';
+import 'package:re_highlight/languages/ruby.dart';
+import 'package:re_highlight/languages/rust.dart';
+import 'package:re_highlight/languages/scss.dart';
+import 'package:re_highlight/languages/shell.dart';
+import 'package:re_highlight/languages/sql.dart';
+import 'package:re_highlight/languages/swift.dart';
+import 'package:re_highlight/languages/typescript.dart';
+import 'package:re_highlight/languages/xml.dart';
+import 'package:re_highlight/languages/yaml.dart';
+import 'package:re_highlight/re_highlight.dart';
+import 'package:re_highlight/styles/github.dart';
+import 'issue_board_ima_issue_cards.dart';
+import 'issue_board_ima_utils.dart';
+import 'issue_board_ima_board_columns.dart';
+import 'issue_board_ima_models.dart';
+import 'issue_board_ima_app_shell.dart';
+import 'issue_board_ima_overview.dart';
+
+class AddIssueDialog extends StatefulWidget {
+  const AddIssueDialog({
+    super.key,
+    required this.columns,
+    required this.repositoryOptions,
+    this.initialIssue,
+    this.allIssues = const [],
+    this.initialColumnId,
+    this.buildStatusesByPullRequest = const {},
+    this.isEstimatingWeight = false,
+    this.onEstimateIssueWeight,
+    this.onOverrideIssueWeight,
+    this.isStartingCursorAgent = false,
+    this.onStartCursorAgent,
+    this.onCreateGitHubSubIssue,
+    this.isBottomSheet = false,
+    this.workspaceId,
+  });
+
+  final List<BoardColumn> columns;
+  final List<String> repositoryOptions;
+  final Issue? initialIssue;
+  final List<Issue> allIssues;
+  final String? initialColumnId;
+  final Map<String, CardBuildStatus> buildStatusesByPullRequest;
+  final bool isEstimatingWeight;
+  final Future<void> Function(String issueId)? onEstimateIssueWeight;
+  final IssueWeightOverrideCallback? onOverrideIssueWeight;
+  final bool isStartingCursorAgent;
+  final Future<void> Function(String issueId)? onStartCursorAgent;
+  final Future<Map<String, dynamic>> Function({
+    required String parentIssueId,
+    required String title,
+    required String body,
+  })?
+  onCreateGitHubSubIssue;
+  final bool isBottomSheet;
+  final String? workspaceId;
+
+  @override
+  State<AddIssueDialog> createState() => _AddIssueDialogState();
+}
+
+class _AddIssueDialogState extends State<AddIssueDialog> {
+  final _formKey = GlobalKey<FormState>();
+  final _titleController = TextEditingController();
+  final _titleFocusNode = FocusNode();
+  final _bodyController = TextEditingController();
+  final _githubUrlController = TextEditingController();
+  final _labelsController = TextEditingController(text: 'feature, mobile');
+  final _subIssueTitleController = TextEditingController();
+  final _subIssueBodyController = TextEditingController();
+  String? _selectedRepo;
+  late String _selectedColumnId;
+  Priority _priority = Priority.medium;
+  DateTime? _dueDate;
+  var _isEstimatingWeight = false;
+  var _isOverridingWeight = false;
+  var _isStartingCursorAgent = false;
+  var _isCreatingSubIssue = false;
+  final List<Issue> _issueStack = [];
+  final Map<String, String> _mergeConflictMessagesByPullRequest = {};
+  Issue? _liveIssue;
+  IssuePullRequest? _selectedPullRequest;
+  StreamSubscription<DocumentSnapshot<Map<String, dynamic>>>?
+  _issueSubscription;
+
+  Issue? get _currentIssue =>
+      _liveIssue ??
+      (_issueStack.isEmpty ? widget.initialIssue : _issueStack.last);
+
+  @override
+  void initState() {
+    super.initState();
+    final issue = widget.initialIssue;
+
+    _selectedColumnId = widget.initialColumnId ?? widget.columns.first.id;
+    _selectedRepo = widget.repositoryOptions.isEmpty
+        ? null
+        : widget.repositoryOptions.first;
+
+    if (issue != null) {
+      _issueStack.add(issue);
+      _setCurrentIssue(issue, listen: true);
+    } else {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) {
+          _titleFocusNode.requestFocus();
+        }
+      });
+    }
+  }
+
+  void _setCurrentIssue(Issue issue, {required bool listen}) {
+    _liveIssue = issue;
+    _titleController.text = issue.title;
+    _bodyController.text = issue.body;
+    _githubUrlController.text = issue.githubUrl ?? '';
+    _selectedRepo = widget.repositoryOptions.contains(issue.repo)
+        ? issue.repo
+        : null;
+    _labelsController.text = issue.labels.join(', ');
+    _priority = issue.priority;
+    _dueDate = issue.dueDate;
+    _subIssueTitleController.clear();
+    _subIssueBodyController.clear();
+    _selectedPullRequest = null;
+    if (listen) {
+      _listenToIssue(issue.id);
+    }
+  }
+
+  void _listenToIssue(String issueId) {
+    final workspaceId = widget.workspaceId;
+    if (workspaceId == null || workspaceId.isEmpty) {
+      return;
+    }
+    final currentSubscription = _issueSubscription;
+    if (currentSubscription != null) {
+      unawaited(currentSubscription.cancel());
+    }
+    _issueSubscription = FirebaseFirestore.instance
+        .doc('workspaces/$workspaceId/issues/$issueId')
+        .snapshots()
+        .listen((snapshot) {
+          if (!mounted || !snapshot.exists) return;
+          final issue = Issue.fromDocument(snapshot);
+          setState(() {
+            _liveIssue = issue;
+            if (_issueStack.isNotEmpty && _issueStack.last.id == issue.id) {
+              _issueStack[_issueStack.length - 1] = issue;
+            }
+          });
+        });
+  }
+
+  @override
+  void dispose() {
+    _issueSubscription?.cancel();
+    _titleController.dispose();
+    _titleFocusNode.dispose();
+    _bodyController.dispose();
+    _githubUrlController.dispose();
+    _labelsController.dispose();
+    _subIssueTitleController.dispose();
+    _subIssueBodyController.dispose();
+    super.dispose();
+  }
+
+  void _saveIssue() {
+    if (!_formKey.currentState!.validate()) {
+      return;
+    }
+
+    final labels = _labelsController.text
+        .split(',')
+        .map((label) => label.trim())
+        .where((label) => label.isNotEmpty)
+        .toList();
+
+    final draft = NewIssueDraft(
+      title: _titleController.text.trim(),
+      body: _bodyController.text.trim(),
+      repo: _selectedRepo ?? '',
+      githubUrl: normalizedOptionalUrl(_githubUrlController.text),
+      labels: labels,
+      columnId: _selectedColumnId,
+      priority: _priority,
+      dueDate: _dueDate,
+    );
+    final currentIssue = _currentIssue;
+    Navigator.of(context).pop(
+      currentIssue == null
+          ? draft
+          : EditIssueDialogResult(issueId: currentIssue.id, draft: draft),
+    );
+  }
+
+  void _closeIssue() {
+    final issue = _currentIssue;
+    if (issue == null) {
+      return;
+    }
+    Navigator.of(context).pop(CloseIssueDialogResult(issue.id));
+  }
+
+  Future<void> _estimateIssueWeight() async {
+    final issue = _currentIssue;
+    final onEstimate = widget.onEstimateIssueWeight;
+    if (issue == null || onEstimate == null || _isEstimatingWeight) {
+      return;
+    }
+
+    setState(() => _isEstimatingWeight = true);
+    try {
+      await onEstimate(issue.id);
+    } finally {
+      if (mounted) {
+        setState(() => _isEstimatingWeight = false);
+      }
+    }
+  }
+
+  Future<void> _overrideIssueWeight() async {
+    final issue = _currentIssue;
+    final onOverride = widget.onOverrideIssueWeight;
+    if (issue == null || onOverride == null || _isOverridingWeight) {
+      return;
+    }
+
+    final draft = await showDialog<IssueWeightOverrideDraft>(
+      context: context,
+      builder: (context) => IssueWeightOverrideDialog(issue: issue),
+    );
+    if (draft == null || !mounted) {
+      return;
+    }
+
+    setState(() => _isOverridingWeight = true);
+    try {
+      await onOverride(issueId: issue.id, draft: draft);
+    } finally {
+      if (mounted) {
+        setState(() => _isOverridingWeight = false);
+      }
+    }
+  }
+
+  Future<void> _startCursorAgent() async {
+    final issue = _currentIssue;
+    final onStart = widget.onStartCursorAgent;
+    if (issue == null || onStart == null || _isStartingCursorAgent) {
+      return;
+    }
+
+    setState(() => _isStartingCursorAgent = true);
+    try {
+      await onStart(issue.id);
+    } finally {
+      if (mounted) {
+        setState(() => _isStartingCursorAgent = false);
+      }
+    }
+  }
+
+  Future<void> _createSubIssue() async {
+    final issue = _currentIssue;
+    final onCreate = widget.onCreateGitHubSubIssue;
+    final title = _subIssueTitleController.text.trim();
+    if (issue == null || onCreate == null || _isCreatingSubIssue) {
+      return;
+    }
+    if (title.isEmpty) {
+      showFloatingSnackBar(context, 'Sub-issue titleを入力してください');
+      return;
+    }
+
+    setState(() => _isCreatingSubIssue = true);
+    try {
+      await onCreate(
+        parentIssueId: issue.id,
+        title: title,
+        body: _subIssueBodyController.text.trim(),
+      );
+      if (!mounted) {
+        return;
+      }
+      _subIssueTitleController.clear();
+      _subIssueBodyController.clear();
+      showOverlaySnackBar(context, 'Sub-issue added');
+    } finally {
+      if (mounted) {
+        setState(() => _isCreatingSubIssue = false);
+      }
+    }
+  }
+
+  Future<void> _openIssueFromSubIssue(String issueId) async {
+    Issue? issue;
+    for (final candidate in widget.allIssues) {
+      if (candidate.id == issueId) {
+        issue = candidate;
+        break;
+      }
+    }
+    if (issue == null) {
+      final workspaceId = widget.workspaceId;
+      if (workspaceId != null && workspaceId.isNotEmpty) {
+        final snapshot = await FirebaseFirestore.instance
+            .doc('workspaces/$workspaceId/issues/$issueId')
+            .get();
+        if (snapshot.exists) {
+          issue = Issue.fromDocument(snapshot);
+        }
+      }
+      if (!mounted) {
+        return;
+      }
+    }
+    if (issue == null) {
+      showFloatingSnackBar(context, 'Issueが見つかりません');
+      return;
+    }
+    final selectedIssue = issue;
+    setState(() {
+      _issueStack.add(selectedIssue);
+      _setCurrentIssue(selectedIssue, listen: true);
+    });
+  }
+
+  void _goBackIssue() {
+    if (_issueStack.length <= 1) {
+      return;
+    }
+    setState(() {
+      _issueStack.removeLast();
+      _setCurrentIssue(_issueStack.last, listen: true);
+    });
+  }
+
+  void _copyGitHubUrl() {
+    unawaited(
+      copyTextToClipboard(
+        context,
+        text: _githubUrlController.text,
+        successMessage: 'GitHubリンクをコピーしました',
+      ),
+    );
+  }
+
+  void _openGitHubUrl() {
+    final url = _githubUrlController.text.trim();
+    if (url.isNotEmpty) {
+      unawaited(launchUrlExternal(url));
+    }
+  }
+
+  Future<IssuePullRequestDiff> _loadPullRequestDiff({
+    required Issue issue,
+    required IssuePullRequest pullRequest,
+  }) async {
+    final workspaceId = widget.workspaceId;
+    if (workspaceId == null || workspaceId.isEmpty) {
+      throw StateError('workspaceId is required');
+    }
+    final result = await firebaseFunctions
+        .httpsCallable(
+          getIssuePullRequestDiffFunction,
+          options: HttpsCallableOptions(timeout: const Duration(seconds: 30)),
+        )
+        .call<Map<String, dynamic>>({
+          'workspaceId': workspaceId,
+          'issueId': issue.id,
+          'repository': issue.repo,
+          'pullRequestNumber': pullRequest.number,
+        });
+    return IssuePullRequestDiff.fromMap(asMap(result.data));
+  }
+
+  void _openPullRequestDiff(IssuePullRequest pullRequest) {
+    if (_currentIssue == null) {
+      return;
+    }
+    setState(() => _selectedPullRequest = pullRequest);
+  }
+
+  void _closePullRequestDiff() {
+    setState(() => _selectedPullRequest = null);
+  }
+
+  Future<bool> _mergePullRequest({
+    required Issue issue,
+    required IssuePullRequest pullRequest,
+  }) async {
+    final workspaceId = widget.workspaceId;
+    if (workspaceId == null || workspaceId.isEmpty) {
+      showFloatingSnackBar(context, 'workspaceId is required');
+      return false;
+    }
+    final confirmed = await _confirmPullRequestMerge(pullRequest);
+    if (confirmed != true) {
+      return false;
+    }
+
+    try {
+      final result = await firebaseFunctions
+          .httpsCallable(
+            mergeIssuePullRequestFunction,
+            options: HttpsCallableOptions(timeout: const Duration(seconds: 45)),
+          )
+          .call<Map<String, dynamic>>({
+            'workspaceId': workspaceId,
+            'issueId': issue.id,
+            'repository': issue.repo,
+            'pullRequestNumber': pullRequest.number,
+            'mergeMethod': 'squash',
+          });
+      final data = asMap(result.data);
+      final merged = data['merged'] == true;
+      if (!mounted) {
+        return merged;
+      }
+      setState(() {
+        _mergeConflictMessagesByPullRequest.remove(
+          _pullRequestMergeConflictKey(issue.repo, pullRequest.number),
+        );
+      });
+      showOverlaySnackBar(
+        context,
+        merged
+            ? 'PR #${pullRequest.number}をマージしました'
+            : asString(data['message'], 'PRのマージ結果を確認してください'),
+      );
+      return merged;
+    } catch (error) {
+      if (mounted) {
+        final conflictMessage = _pullRequestMergeConflictMessage(error);
+        if (conflictMessage == null) {
+          showFloatingSnackBar(context, friendlyError(error));
+        } else {
+          setState(() {
+            _mergeConflictMessagesByPullRequest[_pullRequestMergeConflictKey(
+                  issue.repo,
+                  pullRequest.number,
+                )] =
+                conflictMessage;
+          });
+          showOverlaySnackBar(
+            context,
+            'PR #${pullRequest.number}にconflictがあります',
+          );
+        }
+      }
+      return false;
+    }
+  }
+
+  Future<bool?> _confirmPullRequestMerge(IssuePullRequest pullRequest) {
+    return showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Text('PR #${pullRequest.number}をマージしますか？'),
+        content: Text(
+          'Squash mergeを実行し、このissueを完了へ移動します。\n${pullRequest.title}',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('キャンセル'),
+          ),
+          FilledButton.icon(
+            onPressed: () => Navigator.of(context).pop(true),
+            icon: const Icon(Icons.call_merge_rounded, size: 18),
+            label: const Text('マージする'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _pickDueDate() async {
+    final now = DateTime.now();
+    final initialDate = _dueDate ?? now;
+    final selectedDate = await showDatePicker(
+      context: context,
+      initialDate: initialDate,
+      firstDate: DateTime(now.year - 1),
+      lastDate: DateTime(now.year + 3),
+    );
+
+    if (selectedDate == null) {
+      return;
+    }
+
+    setState(() => _dueDate = dateOnly(selectedDate));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final screenSize = MediaQuery.sizeOf(context);
+    final isCompactDialog = screenSize.width < 560;
+    final maxHeight = screenSize.height * (isCompactDialog ? 0.92 : 0.86);
+    final currentIssue = _currentIssue;
+    final isEditing = currentIssue != null;
+    final canCloseIssue = isEditing && currentIssue.statusId != closedStatusId;
+    final selectedPullRequest = currentIssue == null
+        ? null
+        : _selectedPullRequestForIssue(currentIssue);
+    final isViewingPullRequest = selectedPullRequest != null;
+    final title = isEditing ? 'GitHub issueを編集' : 'GitHub issueを新規作成';
+    final description = isEditing
+        ? '${currentIssue.displayId} の内容を更新します。'
+        : 'GitHub issueを作成してボードへ追加します。';
+    final dialogPadding = EdgeInsets.all(isCompactDialog ? 18 : 24);
+    final dialogBorderRadius = BorderRadius.circular(isCompactDialog ? 22 : 28);
+    final formContent = Form(
+      key: _formKey,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          if (isEditing && _issueStack.length > 1) ...[
+            IssueBreadcrumb(
+              issues: _issueStack,
+              onBack: _goBackIssue,
+              onSelect: (index) {
+                if (index < 0 || index >= _issueStack.length - 1) {
+                  return;
+                }
+                setState(() {
+                  _issueStack.removeRange(index + 1, _issueStack.length);
+                  _setCurrentIssue(_issueStack.last, listen: true);
+                });
+              },
+            ),
+            const SizedBox(height: 14),
+          ],
+          _TitleField(
+            controller: _titleController,
+            focusNode: _titleFocusNode,
+            decoration: _inputDecoration(
+              label: 'タイトル',
+              hint: '例: issueの同期ステータスを表示する',
+            ),
+          ),
+          const SizedBox(height: 14),
+          TextFormField(
+            controller: _bodyController,
+            minLines: 7,
+            maxLines: 12,
+            keyboardType: TextInputType.multiline,
+            textInputAction: TextInputAction.newline,
+            decoration: _inputDecoration(
+              label: '本文',
+              hint: '背景、やりたいこと、受け入れ条件などをMarkdownっぽく書けます。',
+            ),
+          ),
+          const SizedBox(height: 14),
+          _RepoField(
+            repositories: widget.repositoryOptions,
+            selectedRepository: _selectedRepo,
+            onRepositoryChanged: (value) {
+              setState(() => _selectedRepo = value);
+            },
+            decorationBuilder: _inputDecoration,
+          ),
+          if (isEditing) ...[
+            const SizedBox(height: 14),
+            _GitHubLinkField(
+              controller: _githubUrlController,
+              decoration: _inputDecoration(
+                label: 'GitHubリンク',
+                hint: 'https://github.com/openci/ima/issues/123',
+              ),
+              onOpen: _openGitHubUrl,
+              onCopy: _copyGitHubUrl,
+            ),
+            if (currentIssue.pullRequests.isNotEmpty) ...[
+              const SizedBox(height: 14),
+              PullRequestReviewPanel(
+                issue: currentIssue,
+                onOpenDiff: _openPullRequestDiff,
+                onMergePullRequest: (pullRequest) => unawaited(
+                  _mergePullRequest(
+                    issue: currentIssue,
+                    pullRequest: pullRequest,
+                  ),
+                ),
+                mergeConflictMessagesByPullRequest:
+                    _mergeConflictMessagesByPullRequest,
+              ),
+            ],
+            const SizedBox(height: 14),
+            CreateSubIssuePanel(
+              issue: currentIssue,
+              workspaceId: widget.workspaceId,
+              linkedSubIssues: subIssuesForParent(
+                currentIssue,
+                widget.allIssues,
+              ),
+              onOpenIssue: _openIssueFromSubIssue,
+              titleController: _subIssueTitleController,
+              bodyController: _subIssueBodyController,
+              isCreating: _isCreatingSubIssue,
+              onCreate: widget.onCreateGitHubSubIssue == null
+                  ? null
+                  : _createSubIssue,
+            ),
+          ],
+          const SizedBox(height: 14),
+          _StatusAndPriorityFields(
+            columns: widget.columns,
+            selectedColumnId: _selectedColumnId,
+            priority: _priority,
+            decorationBuilder: _inputDecoration,
+            priorityLabelBuilder: _priorityLabel,
+            onColumnChanged: (value) {
+              setState(() => _selectedColumnId = value);
+            },
+            onPriorityChanged: (value) {
+              setState(() => _priority = value);
+            },
+          ),
+          const SizedBox(height: 14),
+          DueDateField(
+            dueDate: _dueDate,
+            onPick: _pickDueDate,
+            onClear: () => setState(() => _dueDate = null),
+          ),
+          const SizedBox(height: 14),
+          TextFormField(
+            controller: _labelsController,
+            textInputAction: TextInputAction.done,
+            decoration: _inputDecoration(
+              label: 'ラベル',
+              hint: 'feature, github, mobile',
+            ),
+            onFieldSubmitted: (_) => _saveIssue(),
+          ),
+          if (isEditing) ...[
+            const SizedBox(height: 14),
+            IssueWeightPanel(
+              issue: currentIssue,
+              isEstimating: widget.isEstimatingWeight || _isEstimatingWeight,
+              isOverriding: _isOverridingWeight,
+              onEstimate: widget.onEstimateIssueWeight == null
+                  ? null
+                  : _estimateIssueWeight,
+              onOverride: widget.onOverrideIssueWeight == null
+                  ? null
+                  : _overrideIssueWeight,
+            ),
+            const SizedBox(height: 14),
+            CursorAgentPanel(
+              issue: currentIssue,
+              isStarting:
+                  widget.isStartingCursorAgent || _isStartingCursorAgent,
+              onStart: widget.onStartCursorAgent == null
+                  ? null
+                  : _startCursorAgent,
+            ),
+            SizedBox(height: 14),
+          ],
+        ],
+      ),
+    );
+    final pullRequestContent =
+        currentIssue == null || selectedPullRequest == null
+        ? null
+        : PullRequestDiffView(
+            key: ValueKey('${currentIssue.id}:${selectedPullRequest.number}'),
+            issue: currentIssue,
+            pullRequest: selectedPullRequest,
+            buildStatus:
+                widget.buildStatusesByPullRequest[buildStatusKey(
+                  currentIssue.repo,
+                  selectedPullRequest.number,
+                )],
+            mergeConflictMessage:
+                _mergeConflictMessagesByPullRequest[_pullRequestMergeConflictKey(
+                  currentIssue.repo,
+                  selectedPullRequest.number,
+                )],
+            loadDiff: () => _loadPullRequestDiff(
+              issue: currentIssue,
+              pullRequest: selectedPullRequest,
+            ),
+            onMerge:
+                selectedPullRequest.merged ||
+                    selectedPullRequest.state.toLowerCase() != 'open'
+                ? null
+                : () => _mergePullRequest(
+                    issue: currentIssue,
+                    pullRequest: selectedPullRequest,
+                  ),
+            onClose: _closePullRequestDiff,
+            closeIcon: Icons.arrow_back_rounded,
+            closeTooltip: 'Issue詳細に戻る',
+            showSheetHandle: widget.isBottomSheet,
+          );
+    final content = ClipRRect(
+      borderRadius: widget.isBottomSheet
+          ? const BorderRadius.vertical(top: Radius.circular(28))
+          : dialogBorderRadius,
+      child: Material(
+        color: Colors.white,
+        child:
+            pullRequestContent ??
+            (widget.isBottomSheet
+                ? Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      _BottomSheetHeader(
+                        title: title,
+                        issueDisplayId: isEditing
+                            ? currentIssue.displayId
+                            : null,
+                      ),
+                      Expanded(
+                        child: SingleChildScrollView(
+                          padding: const EdgeInsets.fromLTRB(20, 24, 20, 20),
+                          child: formContent,
+                        ),
+                      ),
+                      _BottomSheetActions(
+                        isEditing: isEditing,
+                        canCloseIssue: canCloseIssue,
+                        onCloseIssue: _closeIssue,
+                        onSaveIssue: _saveIssue,
+                      ),
+                    ],
+                  )
+                : Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Container(
+                        padding: dialogPadding.copyWith(bottom: 16),
+                        decoration: const BoxDecoration(
+                          color: Color(0xFFFAFBFC),
+                          border: Border(
+                            bottom: BorderSide(color: Color(0xFFE2E8F0)),
+                          ),
+                        ),
+                        child: DialogHeader(
+                          title: title,
+                          description: description,
+                          issueDisplayId: isEditing
+                              ? currentIssue.displayId
+                              : null,
+                        ),
+                      ),
+                      Flexible(
+                        child: SingleChildScrollView(
+                          padding: dialogPadding.copyWith(top: 18, bottom: 2),
+                          child: formContent,
+                        ),
+                      ),
+                      Container(
+                        padding: dialogPadding.copyWith(top: 16),
+                        decoration: const BoxDecoration(
+                          border: Border(
+                            top: BorderSide(color: Color(0xFFE2E8F0)),
+                          ),
+                        ),
+                        child: _DialogActions(
+                          isEditing: isEditing,
+                          canCloseIssue: canCloseIssue,
+                          onCancel: () => Navigator.of(context).pop(),
+                          onCloseIssue: _closeIssue,
+                          onSaveIssue: _saveIssue,
+                        ),
+                      ),
+                    ],
+                  )),
+      ),
+    );
+    final framedContent = widget.isBottomSheet
+        ? SizedBox(width: double.infinity, height: maxHeight, child: content)
+        : isViewingPullRequest
+        ? SizedBox(
+            width: math.min(math.max(screenSize.width - 40, 320), 1120),
+            height: maxHeight,
+            child: content,
+          )
+        : ConstrainedBox(
+            constraints: BoxConstraints(maxWidth: 720, maxHeight: maxHeight),
+            child: content,
+          );
+
+    return CallbackShortcuts(
+      bindings: isViewingPullRequest
+          ? const <ShortcutActivator, VoidCallback>{}
+          : <ShortcutActivator, VoidCallback>{
+              const SingleActivator(
+                LogicalKeyboardKey.enter,
+                meta: true,
+              ): _saveIssue,
+            },
+      child: Focus(
+        autofocus: true,
+        child: widget.isBottomSheet
+            ? AnimatedPadding(
+                duration: const Duration(milliseconds: 180),
+                curve: Curves.easeOutCubic,
+                padding: EdgeInsets.only(
+                  bottom: MediaQuery.viewInsetsOf(context).bottom,
+                ),
+                child: Align(
+                  alignment: Alignment.bottomCenter,
+                  child: framedContent,
+                ),
+              )
+            : Dialog(
+                insetPadding: EdgeInsets.symmetric(
+                  horizontal: isCompactDialog ? 12 : 20,
+                  vertical: isCompactDialog ? 12 : 24,
+                ),
+                backgroundColor: Colors.white,
+                surfaceTintColor: Colors.transparent,
+                shape: RoundedRectangleBorder(borderRadius: dialogBorderRadius),
+                clipBehavior: Clip.antiAlias,
+                child: framedContent,
+              ),
+      ),
+    );
+  }
+
+  InputDecoration _inputDecoration({required String label, String? hint}) {
+    return InputDecoration(
+      labelText: label,
+      hintText: hint,
+      filled: true,
+      fillColor: const Color(0xFFF8FAFC),
+      border: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(16),
+        borderSide: const BorderSide(color: Color(0xFFE2E8F0)),
+      ),
+      enabledBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(16),
+        borderSide: const BorderSide(color: Color(0xFFE2E8F0)),
+      ),
+      focusedBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(16),
+        borderSide: const BorderSide(color: Color(0xFF1D4ED8), width: 1.5),
+      ),
+      floatingLabelStyle: const TextStyle(color: Color(0xFF1D4ED8)),
+      contentPadding: const EdgeInsets.fromLTRB(14, 15, 14, 15),
+    );
+  }
+
+  String _priorityLabel(Priority priority) {
+    switch (priority) {
+      case Priority.high:
+        return '高';
+      case Priority.medium:
+        return '中';
+      case Priority.low:
+        return '低';
+    }
+  }
+
+  IssuePullRequest? _selectedPullRequestForIssue(Issue issue) {
+    final selected = _selectedPullRequest;
+    if (selected == null) {
+      return null;
+    }
+    for (final pullRequest in issue.pullRequests) {
+      if (pullRequest.number == selected.number) {
+        return pullRequest;
+      }
+    }
+    return null;
+  }
+}
+
+class _DialogActions extends StatelessWidget {
+  const _DialogActions({
+    required this.isEditing,
+    required this.canCloseIssue,
+    required this.onCancel,
+    required this.onCloseIssue,
+    required this.onSaveIssue,
+  });
+
+  final bool isEditing;
+  final bool canCloseIssue;
+  final VoidCallback onCancel;
+  final VoidCallback onCloseIssue;
+  final VoidCallback onSaveIssue;
+
+  @override
+  Widget build(BuildContext context) {
+    final cancelButton = TextButton(
+      onPressed: onCancel,
+      style: TextButton.styleFrom(
+        foregroundColor: const Color(0xFF64748B),
+        minimumSize: const Size(0, 40),
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 10),
+        tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+      ),
+      child: const Text('キャンセル'),
+    );
+    final closeButton = _IssueEditorCompleteButton(
+      onPressed: onCloseIssue,
+      minWidth: 136,
+    );
+    final saveButton = _IssueEditorPrimaryButton(
+      onPressed: onSaveIssue,
+      icon: isEditing ? Icons.save_outlined : Icons.add_rounded,
+      label: isEditing ? '変更を保存' : 'issueを追加',
+      minWidth: 148,
+    );
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        if (constraints.maxWidth < 560) {
+          return Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Align(alignment: Alignment.centerLeft, child: cancelButton),
+              const SizedBox(height: 10),
+              if (canCloseIssue) ...[closeButton, const SizedBox(height: 10)],
+              saveButton,
+            ],
+          );
+        }
+
+        return Row(
+          children: [
+            cancelButton,
+            const Spacer(),
+            if (canCloseIssue) ...[closeButton, const SizedBox(width: 12)],
+            saveButton,
+          ],
+        );
+      },
+    );
+  }
+}
+
+class _IssueEditorPrimaryButton extends StatelessWidget {
+  const _IssueEditorPrimaryButton({
+    required this.onPressed,
+    required this.icon,
+    required this.label,
+    required this.minWidth,
+  });
+
+  final VoidCallback? onPressed;
+  final IconData icon;
+  final String label;
+  final double minWidth;
+
+  @override
+  Widget build(BuildContext context) {
+    return FilledButton.icon(
+      onPressed: onPressed,
+      icon: Icon(icon, size: 18),
+      label: Text(label, maxLines: 1, overflow: TextOverflow.ellipsis),
+      style: FilledButton.styleFrom(
+        backgroundColor: const Color(0xFF1D4ED8),
+        foregroundColor: Colors.white,
+        disabledBackgroundColor: const Color(0xFFCBD5E1),
+        disabledForegroundColor: const Color(0xFF64748B),
+        elevation: 0,
+        minimumSize: Size(minWidth, 48),
+        padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 14),
+        textStyle: const TextStyle(
+          fontSize: 14,
+          fontWeight: FontWeight.w900,
+          letterSpacing: 0,
+        ),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      ),
+    );
+  }
+}
+
+class _IssueEditorCompleteButton extends StatelessWidget {
+  const _IssueEditorCompleteButton({
+    required this.onPressed,
+    required this.minWidth,
+  });
+
+  final VoidCallback? onPressed;
+  final double minWidth;
+
+  @override
+  Widget build(BuildContext context) {
+    return FilledButton.icon(
+      onPressed: onPressed,
+      icon: const Icon(Icons.check_rounded, size: 18),
+      label: const Text(
+        'issueを完了',
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+      ),
+      style: FilledButton.styleFrom(
+        backgroundColor: const Color(0xFFECFDF5),
+        foregroundColor: const Color(0xFF047857),
+        disabledBackgroundColor: const Color(0xFFE2E8F0),
+        disabledForegroundColor: const Color(0xFF64748B),
+        elevation: 0,
+        minimumSize: Size(minWidth, 48),
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+        side: const BorderSide(color: Color(0xFFA7F3D0)),
+        textStyle: const TextStyle(
+          fontSize: 14,
+          fontWeight: FontWeight.w900,
+          letterSpacing: 0,
+        ),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      ),
+    );
+  }
+}
+
+class _BottomSheetHeader extends StatelessWidget {
+  const _BottomSheetHeader({required this.title, this.issueDisplayId});
+
+  final String title;
+  final String? issueDisplayId;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.fromLTRB(20, 12, 10, 16),
+      decoration: const BoxDecoration(
+        color: Color(0xFFFAFBFC),
+        border: Border(bottom: BorderSide(color: Color(0xFFE2E8F0))),
+      ),
+      child: Column(
+        children: [
+          Container(
+            width: 36,
+            height: 4,
+            decoration: BoxDecoration(
+              color: const Color(0xFFCBD5E1),
+              borderRadius: BorderRadius.circular(999),
+            ),
+          ),
+          const SizedBox(height: 10),
+          Row(
+            children: [
+              Expanded(
+                child: Row(
+                  children: [
+                    Flexible(
+                      child: Text(
+                        title,
+                        overflow: TextOverflow.ellipsis,
+                        style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                          fontWeight: FontWeight.w800,
+                        ),
+                      ),
+                    ),
+                    if (issueDisplayId != null) ...[
+                      const SizedBox(width: 8),
+                      _IssueIdChip(displayId: issueDisplayId!),
+                    ],
+                  ],
+                ),
+              ),
+              IconButton(
+                tooltip: '閉じる',
+                onPressed: () => Navigator.of(context).pop(),
+                icon: const Icon(Icons.close_rounded),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _BottomSheetActions extends StatelessWidget {
+  const _BottomSheetActions({
+    required this.isEditing,
+    required this.canCloseIssue,
+    required this.onCloseIssue,
+    required this.onSaveIssue,
+  });
+
+  final bool isEditing;
+  final bool canCloseIssue;
+  final VoidCallback onCloseIssue;
+  final VoidCallback onSaveIssue;
+
+  @override
+  Widget build(BuildContext context) {
+    final closeButton = _IssueEditorCompleteButton(
+      onPressed: onCloseIssue,
+      minWidth: 0,
+    );
+    final saveButton = _IssueEditorPrimaryButton(
+      onPressed: onSaveIssue,
+      icon: isEditing ? Icons.save_outlined : Icons.add_rounded,
+      label: isEditing ? '変更を保存' : 'issueを追加',
+      minWidth: 0,
+    );
+
+    return Container(
+      padding: const EdgeInsets.fromLTRB(18, 12, 18, 18),
+      decoration: const BoxDecoration(
+        color: Colors.white,
+        border: Border(top: BorderSide(color: Color(0xFFE2E8F0))),
+      ),
+      child: SafeArea(
+        top: false,
+        child: Row(
+          children: [
+            if (canCloseIssue) ...[
+              Expanded(child: closeButton),
+              const SizedBox(width: 10),
+            ],
+            Expanded(child: saveButton),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class DialogHeader extends StatelessWidget {
+  const DialogHeader({
+    super.key,
+    required this.title,
+    required this.description,
+    this.issueDisplayId,
+  });
+
+  final String title;
+  final String description;
+  final String? issueDisplayId;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Flexible(
+                    child: Text(
+                      title,
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                      style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                        fontWeight: FontWeight.w800,
+                      ),
+                    ),
+                  ),
+                  if (issueDisplayId != null) ...[
+                    const SizedBox(width: 8),
+                    _IssueIdChip(displayId: issueDisplayId!),
+                  ],
+                ],
+              ),
+              const SizedBox(height: 6),
+              Text(
+                description,
+                style: const TextStyle(color: Color(0xFF64748B)),
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(width: 8),
+        IconButton(
+          tooltip: '閉じる',
+          onPressed: () => Navigator.of(context).pop(),
+          icon: const Icon(Icons.close_rounded),
+        ),
+      ],
+    );
+  }
+}
+
+class IssueBreadcrumb extends StatelessWidget {
+  const IssueBreadcrumb({
+    super.key,
+    required this.issues,
+    required this.onBack,
+    required this.onSelect,
+  });
+
+  final List<Issue> issues;
+  final VoidCallback onBack;
+  final ValueChanged<int> onSelect;
+
+  @override
+  Widget build(BuildContext context) {
+    final parentIssue = issues.first;
+    final currentIssue = issues.last;
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: const Color(0xFFEFF6FF),
+        border: Border.all(color: const Color(0xFFBFDBFE)),
+        borderRadius: BorderRadius.circular(18),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const Row(
+                      children: [
+                        Icon(
+                          Icons.account_tree_outlined,
+                          size: 16,
+                          color: Color(0xFF2563EB),
+                        ),
+                        SizedBox(width: 6),
+                        Text(
+                          'sub-issueを表示中',
+                          style: TextStyle(
+                            color: Color(0xFF2563EB),
+                            fontSize: 12,
+                            fontWeight: FontWeight.w900,
+                          ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 6),
+                    Text(
+                      currentIssue.title,
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                      style: const TextStyle(
+                        color: Color(0xFF0F172A),
+                        fontSize: 15,
+                        height: 1.25,
+                        fontWeight: FontWeight.w900,
+                      ),
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      '親: ${parentIssue.displayId} · ${parentIssue.title}',
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: const TextStyle(
+                        color: Color(0xFF475569),
+                        fontSize: 12,
+                        fontWeight: FontWeight.w700,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(width: 10),
+              OutlinedButton.icon(
+                onPressed: onBack,
+                icon: const Icon(Icons.arrow_back_rounded, size: 17),
+                label: Text('${parentIssue.displayId}に戻る'),
+                style: OutlinedButton.styleFrom(
+                  foregroundColor: const Color(0xFF1D4ED8),
+                  backgroundColor: Colors.white,
+                  side: const BorderSide(color: Color(0xFF93C5FD)),
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 10,
+                    vertical: 10,
+                  ),
+                  textStyle: const TextStyle(fontWeight: FontWeight.w900),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 10),
+          SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            child: Row(
+              children: [
+                for (var index = 0; index < issues.length; index++) ...[
+                  if (index > 0)
+                    const Padding(
+                      padding: EdgeInsets.symmetric(horizontal: 4),
+                      child: Icon(
+                        Icons.chevron_right_rounded,
+                        size: 16,
+                        color: Color(0xFF64748B),
+                      ),
+                    ),
+                  ActionChip(
+                    avatar: Icon(
+                      index == 0
+                          ? Icons.flag_outlined
+                          : Icons.subdirectory_arrow_right_rounded,
+                      size: 15,
+                      color: index == issues.length - 1
+                          ? const Color(0xFF0F172A)
+                          : const Color(0xFF2563EB),
+                    ),
+                    label: Text(issues[index].displayId),
+                    onPressed: index == issues.length - 1
+                        ? null
+                        : () => onSelect(index),
+                    visualDensity: VisualDensity.compact,
+                    backgroundColor: index == issues.length - 1
+                        ? const Color(0xFFFFFFFF)
+                        : const Color(0xFFDBEAFE),
+                    side: BorderSide(
+                      color: index == issues.length - 1
+                          ? const Color(0xFF94A3B8)
+                          : const Color(0xFF93C5FD),
+                    ),
+                    labelStyle: TextStyle(
+                      color: index == issues.length - 1
+                          ? const Color(0xFF0F172A)
+                          : const Color(0xFF1D4ED8),
+                      fontWeight: FontWeight.w900,
+                    ),
+                  ),
+                ],
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _IssueIdChip extends StatefulWidget {
+  const _IssueIdChip({required this.displayId});
+
+  final String displayId;
+
+  @override
+  State<_IssueIdChip> createState() => _IssueIdChipState();
+}
+
+class _IssueIdChipState extends State<_IssueIdChip> {
+  bool _copied = false;
+
+  Future<void> _handleCopy() async {
+    final trimmed = widget.displayId.trim();
+    if (trimmed.isEmpty) return;
+    await Clipboard.setData(ClipboardData(text: trimmed));
+    if (!mounted) return;
+    showOverlaySnackBar(context, 'Issue IDがコピーされました');
+    setState(() => _copied = true);
+    await Future<void>.delayed(const Duration(milliseconds: 1500));
+    if (!mounted) return;
+    setState(() => _copied = false);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: _copied ? null : () => unawaited(_handleCopy()),
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+        decoration: BoxDecoration(
+          color: const Color(0xFFF1F5F9),
+          borderRadius: BorderRadius.circular(6),
+          border: Border.all(color: const Color(0xFFE2E8F0)),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              widget.displayId,
+              style: const TextStyle(
+                color: Color(0xFF64748B),
+                fontWeight: FontWeight.w700,
+                fontSize: 13,
+              ),
+            ),
+            const SizedBox(width: 4),
+            AnimatedSwitcher(
+              duration: const Duration(milliseconds: 200),
+              child: Icon(
+                _copied ? Icons.check_rounded : Icons.copy_rounded,
+                key: ValueKey(_copied),
+                size: 13,
+                color: _copied
+                    ? const Color(0xFF22C55E)
+                    : const Color(0xFF94A3B8),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _TitleField extends StatelessWidget {
+  const _TitleField({
+    required this.controller,
+    required this.focusNode,
+    required this.decoration,
+  });
+
+  final TextEditingController controller;
+  final FocusNode focusNode;
+  final InputDecoration decoration;
+
+  @override
+  Widget build(BuildContext context) {
+    return TextFormField(
+      controller: controller,
+      focusNode: focusNode,
+      autofocus: true,
+      textInputAction: TextInputAction.next,
+      decoration: decoration,
+      validator: (value) =>
+          value == null || value.trim().isEmpty ? 'タイトルを入力してください' : null,
+    );
+  }
+}
+
+class _GitHubLinkField extends StatelessWidget {
+  const _GitHubLinkField({
+    required this.controller,
+    required this.decoration,
+    required this.onCopy,
+    required this.onOpen,
+  });
+
+  final TextEditingController controller;
+  final InputDecoration decoration;
+  final VoidCallback onCopy;
+  final VoidCallback onOpen;
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final field = TextFormField(
+          controller: controller,
+          keyboardType: TextInputType.url,
+          textInputAction: TextInputAction.next,
+          decoration: decoration,
+          validator: validateOptionalHttpUrl,
+        );
+        final actions = ValueListenableBuilder<TextEditingValue>(
+          valueListenable: controller,
+          builder: (context, value, _) {
+            final hasUrl = value.text.trim().isNotEmpty;
+            final actionButtonStyle = OutlinedButton.styleFrom(
+              minimumSize: const Size(0, 56),
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+            );
+            return Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: [
+                OutlinedButton.icon(
+                  onPressed: hasUrl ? onCopy : null,
+                  icon: const Icon(Icons.copy_rounded, size: 18),
+                  label: const Text('コピー'),
+                  style: actionButtonStyle,
+                ),
+                OutlinedButton.icon(
+                  onPressed: hasUrl ? onOpen : null,
+                  icon: const Icon(Icons.open_in_new_rounded, size: 18),
+                  label: const Text('開く'),
+                  style: actionButtonStyle,
+                ),
+              ],
+            );
+          },
+        );
+
+        if (constraints.maxWidth < 560) {
+          return Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [field, const SizedBox(height: 10), actions],
+          );
+        }
+
+        return Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Expanded(child: field),
+            const SizedBox(width: 12),
+            actions,
+          ],
+        );
+      },
+    );
+  }
+}
+
+class PullRequestReviewPanel extends StatelessWidget {
+  const PullRequestReviewPanel({
+    super.key,
+    required this.issue,
+    required this.onOpenDiff,
+    required this.onMergePullRequest,
+    required this.mergeConflictMessagesByPullRequest,
+  });
+
+  final Issue issue;
+  final ValueChanged<IssuePullRequest> onOpenDiff;
+  final ValueChanged<IssuePullRequest> onMergePullRequest;
+  final Map<String, String> mergeConflictMessagesByPullRequest;
+
+  @override
+  Widget build(BuildContext context) {
+    final pullRequests = issue.pullRequests.reversed.toList();
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: const Color(0xFFF8FAFC),
+        border: Border.all(color: const Color(0xFFE2E8F0)),
+        borderRadius: BorderRadius.circular(18),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              const Icon(
+                Icons.alt_route_rounded,
+                size: 18,
+                color: Color(0xFF2563EB),
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  pullRequests.length == 1
+                      ? 'Pull request'
+                      : 'Pull requests ${pullRequests.length}',
+                  style: const TextStyle(
+                    color: Color(0xFF0F172A),
+                    fontWeight: FontWeight.w900,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 10),
+          for (final entry in pullRequests.indexed) ...[
+            PullRequestReviewTile(
+              repository: issue.repo,
+              pullRequest: entry.$2,
+              mergeConflictMessage:
+                  mergeConflictMessagesByPullRequest[_pullRequestMergeConflictKey(
+                    issue.repo,
+                    entry.$2.number,
+                  )],
+              onOpenDiff: () => onOpenDiff(entry.$2),
+              onMerge: entry.$2.merged || entry.$2.state.toLowerCase() != 'open'
+                  ? null
+                  : () => onMergePullRequest(entry.$2),
+            ),
+            if (entry.$1 != pullRequests.length - 1) const SizedBox(height: 8),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class PullRequestReviewTile extends StatelessWidget {
+  const PullRequestReviewTile({
+    super.key,
+    required this.repository,
+    required this.pullRequest,
+    this.mergeConflictMessage,
+    required this.onOpenDiff,
+    required this.onMerge,
+  });
+
+  final String repository;
+  final IssuePullRequest pullRequest;
+  final String? mergeConflictMessage;
+  final VoidCallback onOpenDiff;
+  final VoidCallback? onMerge;
+
+  @override
+  Widget build(BuildContext context) {
+    final branch = pullRequest.branch;
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        border: Border.all(color: const Color(0xFFE2E8F0)),
+        borderRadius: BorderRadius.circular(14),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Wrap(
+                      spacing: 6,
+                      runSpacing: 6,
+                      crossAxisAlignment: WrapCrossAlignment.center,
+                      children: [
+                        Text(
+                          '$repository #${pullRequest.number}',
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: const TextStyle(
+                            color: Color(0xFF475569),
+                            fontSize: 12,
+                            fontWeight: FontWeight.w900,
+                          ),
+                        ),
+                        PullRequestStatePill(pullRequest: pullRequest),
+                      ],
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      pullRequest.title,
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                      style: const TextStyle(
+                        color: Color(0xFF0F172A),
+                        fontWeight: FontWeight.w900,
+                        height: 1.25,
+                      ),
+                    ),
+                    if (branch.isNotEmpty) ...[
+                      const SizedBox(height: 6),
+                      Row(
+                        children: [
+                          const Icon(
+                            Icons.fork_right_rounded,
+                            size: 14,
+                            color: Color(0xFF64748B),
+                          ),
+                          const SizedBox(width: 4),
+                          Expanded(
+                            child: Text(
+                              branch,
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                              style: const TextStyle(
+                                color: Color(0xFF64748B),
+                                fontSize: 12,
+                                fontWeight: FontWeight.w700,
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+            ],
+          ),
+          if (mergeConflictMessage != null) ...[
+            const SizedBox(height: 10),
+            PullRequestMergeConflictBanner(message: mergeConflictMessage!),
+          ],
+          const SizedBox(height: 10),
+          LayoutBuilder(
+            builder: (context, constraints) {
+              final compact = constraints.maxWidth < 500;
+              final diffButton = FilledButton.icon(
+                onPressed: onOpenDiff,
+                icon: const Icon(Icons.rate_review_rounded, size: 17),
+                label: const Text('PR詳細'),
+                style: FilledButton.styleFrom(
+                  backgroundColor: const Color(0xFF1D4ED8),
+                  foregroundColor: Colors.white,
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 14,
+                    vertical: 12,
+                  ),
+                  textStyle: const TextStyle(fontWeight: FontWeight.w900),
+                ),
+              );
+              final githubButton = OutlinedButton.icon(
+                onPressed: pullRequest.url == null
+                    ? null
+                    : () => unawaited(launchUrlExternal(pullRequest.url!)),
+                icon: const Icon(Icons.open_in_new_rounded, size: 17),
+                label: const Text('GitHub'),
+                style: OutlinedButton.styleFrom(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 12,
+                    vertical: 12,
+                  ),
+                  textStyle: const TextStyle(fontWeight: FontWeight.w900),
+                ),
+              );
+              final mergeButton = OutlinedButton.icon(
+                onPressed: onMerge,
+                icon: const Icon(Icons.call_merge_rounded, size: 17),
+                label: const Text('マージ'),
+                style: OutlinedButton.styleFrom(
+                  foregroundColor: const Color(0xFF047857),
+                  side: const BorderSide(color: Color(0xFFA7F3D0)),
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 12,
+                    vertical: 12,
+                  ),
+                  textStyle: const TextStyle(fontWeight: FontWeight.w900),
+                ),
+              );
+              if (compact) {
+                return Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    diffButton,
+                    const SizedBox(height: 8),
+                    Row(
+                      children: [
+                        Expanded(child: githubButton),
+                        const SizedBox(width: 8),
+                        Expanded(child: mergeButton),
+                      ],
+                    ),
+                  ],
+                );
+              }
+
+              return Row(
+                children: [
+                  diffButton,
+                  const SizedBox(width: 8),
+                  githubButton,
+                  const Spacer(),
+                  mergeButton,
+                ],
+              );
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class PullRequestStatePill extends StatelessWidget {
+  const PullRequestStatePill({super.key, required this.pullRequest});
+
+  final IssuePullRequest pullRequest;
+
+  @override
+  Widget build(BuildContext context) {
+    final state = pullRequest.state.toLowerCase();
+    final label = pullRequest.merged
+        ? 'merged'
+        : state == 'closed'
+        ? 'closed'
+        : 'open';
+    final color = pullRequest.merged
+        ? const Color(0xFF7C3AED)
+        : state == 'closed'
+        ? const Color(0xFFB45309)
+        : const Color(0xFF15803D);
+    final icon = pullRequest.merged
+        ? Icons.call_merge_rounded
+        : state == 'closed'
+        ? Icons.circle_rounded
+        : Icons.radio_button_checked_rounded;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 7, vertical: 3),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.09),
+        border: Border.all(color: color.withValues(alpha: 0.22)),
+        borderRadius: BorderRadius.circular(999),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: 11, color: color),
+          const SizedBox(width: 4),
+          Text(
+            label,
+            style: TextStyle(
+              color: color,
+              fontSize: 11,
+              fontWeight: FontWeight.w900,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class PullRequestMergeConflictBanner extends StatelessWidget {
+  const PullRequestMergeConflictBanner({super.key, required this.message});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: const Color(0xFFFFF7ED),
+        border: Border.all(color: const Color(0xFFFED7AA)),
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Icon(
+            Icons.warning_amber_rounded,
+            color: Color(0xFFC2410C),
+            size: 20,
+          ),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const Text(
+                  'Conflictがあります',
+                  style: TextStyle(
+                    color: Color(0xFF9A3412),
+                    fontSize: 12,
+                    fontWeight: FontWeight.w900,
+                  ),
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  message,
+                  style: const TextStyle(
+                    color: Color(0xFF7C2D12),
+                    fontSize: 12,
+                    fontWeight: FontWeight.w700,
+                    height: 1.35,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class PullRequestDiffSheet extends StatelessWidget {
+  const PullRequestDiffSheet({
+    super.key,
+    required this.issue,
+    required this.pullRequest,
+    this.buildStatus,
+    this.mergeConflictMessage,
+    required this.loadDiff,
+    required this.onMerge,
+  });
+
+  final Issue issue;
+  final IssuePullRequest pullRequest;
+  final CardBuildStatus? buildStatus;
+  final String? mergeConflictMessage;
+  final Future<IssuePullRequestDiff> Function() loadDiff;
+  final Future<bool> Function()? onMerge;
+
+  @override
+  Widget build(BuildContext context) {
+    final height = MediaQuery.sizeOf(context).height * 0.9;
+    return SizedBox(
+      height: height,
+      child: Material(
+        color: Colors.white,
+        borderRadius: const BorderRadius.vertical(top: Radius.circular(28)),
+        clipBehavior: Clip.antiAlias,
+        child: SafeArea(
+          top: false,
+          child: PullRequestDiffView(
+            issue: issue,
+            pullRequest: pullRequest,
+            buildStatus: buildStatus,
+            mergeConflictMessage: mergeConflictMessage,
+            loadDiff: loadDiff,
+            onMerge: onMerge,
+            onClose: () => Navigator.of(context).pop(),
+            closeIcon: Icons.close_rounded,
+            closeTooltip: '閉じる',
+            showSheetHandle: true,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class PullRequestDiffView extends StatefulWidget {
+  const PullRequestDiffView({
+    super.key,
+    required this.issue,
+    required this.pullRequest,
+    this.buildStatus,
+    this.mergeConflictMessage,
+    required this.loadDiff,
+    required this.onMerge,
+    required this.onClose,
+    required this.closeIcon,
+    required this.closeTooltip,
+    this.showSheetHandle = false,
+  });
+
+  final Issue issue;
+  final IssuePullRequest pullRequest;
+  final CardBuildStatus? buildStatus;
+  final String? mergeConflictMessage;
+  final Future<IssuePullRequestDiff> Function() loadDiff;
+  final Future<bool> Function()? onMerge;
+  final VoidCallback onClose;
+  final IconData closeIcon;
+  final String closeTooltip;
+  final bool showSheetHandle;
+
+  @override
+  State<PullRequestDiffView> createState() => _PullRequestDiffViewState();
+}
+
+class _PullRequestDiffViewState extends State<PullRequestDiffView> {
+  late Future<IssuePullRequestDiff> _future;
+  var _isMerging = false;
+  var _merged = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _future = _loadDiff();
+    _merged = widget.pullRequest.merged;
+  }
+
+  @override
+  void didUpdateWidget(covariant PullRequestDiffView oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.issue.id != widget.issue.id ||
+        oldWidget.issue.repo != widget.issue.repo ||
+        oldWidget.pullRequest.number != widget.pullRequest.number) {
+      _future = _loadDiff();
+      _isMerging = false;
+      _merged = widget.pullRequest.merged;
+    }
+  }
+
+  Future<IssuePullRequestDiff> _loadDiff() {
+    final completer = Completer<IssuePullRequestDiff>();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) {
+        return;
+      }
+      try {
+        widget.loadDiff().then(
+          completer.complete,
+          onError: completer.completeError,
+        );
+      } catch (error, stackTrace) {
+        completer.completeError(error, stackTrace);
+      }
+    });
+    return completer.future;
+  }
+
+  void _retry() {
+    final nextFuture = _loadDiff();
+    setState(() {
+      _future = nextFuture;
+    });
+  }
+
+  Future<void> _merge() async {
+    final onMerge = widget.onMerge;
+    if (onMerge == null || _isMerging || _merged) {
+      return;
+    }
+    setState(() => _isMerging = true);
+    final merged = await onMerge();
+    if (!mounted) {
+      return;
+    }
+    final nextFuture = merged ? _loadDiff() : null;
+    setState(() {
+      _isMerging = false;
+      _merged = merged || _merged;
+      if (nextFuture != null) {
+        _future = nextFuture;
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<IssuePullRequestDiff>(
+      future: _future,
+      builder: (context, snapshot) {
+        final diff = snapshot.data;
+        return Column(
+          children: [
+            _PullRequestDiffHeader(
+              issue: widget.issue,
+              pullRequest: widget.pullRequest,
+              diff: diff,
+              buildStatus: widget.buildStatus,
+              mergeConflictMessage: widget.mergeConflictMessage,
+              isMerging: _isMerging,
+              merged: _merged || (diff?.merged ?? false),
+              onMerge: widget.onMerge == null || _merged ? null : _merge,
+              onClose: widget.onClose,
+              closeIcon: widget.closeIcon,
+              closeTooltip: widget.closeTooltip,
+              showSheetHandle: widget.showSheetHandle,
+            ),
+            Expanded(
+              child: switch (snapshot.connectionState) {
+                ConnectionState.waiting => const Center(
+                  child: CircularProgressIndicator(),
+                ),
+                _ when snapshot.hasError => _PullRequestDiffError(
+                  error: snapshot.error,
+                  onRetry: _retry,
+                ),
+                _ when diff != null => PullRequestDiffBody(diff: diff),
+                _ => const Center(child: Text('差分を読み込めませんでした')),
+              },
+            ),
+          ],
+        );
+      },
+    );
+  }
+}
+
+class _PullRequestDiffHeader extends StatelessWidget {
+  const _PullRequestDiffHeader({
+    required this.issue,
+    required this.pullRequest,
+    required this.diff,
+    required this.buildStatus,
+    required this.mergeConflictMessage,
+    required this.isMerging,
+    required this.merged,
+    required this.onMerge,
+    required this.onClose,
+    required this.closeIcon,
+    required this.closeTooltip,
+    required this.showSheetHandle,
+  });
+
+  final Issue issue;
+  final IssuePullRequest pullRequest;
+  final IssuePullRequestDiff? diff;
+  final CardBuildStatus? buildStatus;
+  final String? mergeConflictMessage;
+  final bool isMerging;
+  final bool merged;
+  final VoidCallback? onMerge;
+  final VoidCallback onClose;
+  final IconData closeIcon;
+  final String closeTooltip;
+  final bool showSheetHandle;
+
+  @override
+  Widget build(BuildContext context) {
+    final title = diff?.title ?? pullRequest.title;
+    final url = diff?.url.isNotEmpty == true ? diff!.url : pullRequest.url;
+    final headerCi = diff?.ci;
+    final headerBuildStatus = buildStatus;
+    final activeMergeConflictMessage =
+        mergeConflictMessage ?? _pullRequestMergeConflictMessageFromDiff(diff);
+    final hasMergeConflict = activeMergeConflictMessage != null;
+    return Container(
+      padding: EdgeInsets.fromLTRB(20, showSheetHandle ? 12 : 16, 12, 14),
+      decoration: const BoxDecoration(
+        color: Color(0xFFFAFBFC),
+        border: Border(bottom: BorderSide(color: Color(0xFFE2E8F0))),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          if (showSheetHandle) ...[
+            Center(
+              child: Container(
+                width: 36,
+                height: 4,
+                decoration: BoxDecoration(
+                  color: const Color(0xFFCBD5E1),
+                  borderRadius: BorderRadius.circular(999),
+                ),
+              ),
+            ),
+            const SizedBox(height: 12),
+          ],
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Wrap(
+                      spacing: 8,
+                      runSpacing: 6,
+                      crossAxisAlignment: WrapCrossAlignment.center,
+                      children: [
+                        Text(
+                          '${issue.repo} #${pullRequest.number}',
+                          style: const TextStyle(
+                            color: Color(0xFF475569),
+                            fontSize: 12,
+                            fontWeight: FontWeight.w900,
+                          ),
+                        ),
+                        PullRequestStatePill(
+                          pullRequest: pullRequest.copyWith(
+                            state: diff?.state,
+                            merged: merged || diff?.merged == true,
+                          ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      title,
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                      style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                        color: const Color(0xFF0F172A),
+                        fontWeight: FontWeight.w900,
+                        height: 1.2,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              IconButton(
+                tooltip: closeTooltip,
+                onPressed: onClose,
+                icon: Icon(closeIcon),
+              ),
+            ],
+          ),
+          if (headerBuildStatus != null || headerCi != null) ...[
+            const SizedBox(height: 12),
+            _PullRequestCiStatusCard(
+              ci: headerCi,
+              buildStatus: headerBuildStatus,
+            ),
+          ],
+          if (activeMergeConflictMessage != null) ...[
+            const SizedBox(height: 12),
+            PullRequestMergeConflictBanner(message: activeMergeConflictMessage),
+          ],
+          const SizedBox(height: 12),
+          LayoutBuilder(
+            builder: (context, constraints) {
+              final compact = constraints.maxWidth < 520;
+              final openButton = OutlinedButton.icon(
+                onPressed: url == null || url.isEmpty
+                    ? null
+                    : () => unawaited(launchUrlExternal(url)),
+                icon: const Icon(Icons.open_in_new_rounded, size: 17),
+                label: const Text('GitHub'),
+              );
+              final ci = diff?.ci;
+              final buildStatus = headerBuildStatus;
+              final ciPassed =
+                  buildStatus?.allChecksPassed == true ||
+                  (buildStatus == null && ci?.allPassed == true);
+              final mergeButton = FilledButton.icon(
+                onPressed: merged || isMerging || hasMergeConflict
+                    ? null
+                    : onMerge,
+                icon: isMerging
+                    ? const SizedBox.square(
+                        dimension: 17,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : Icon(
+                        hasMergeConflict
+                            ? Icons.warning_amber_rounded
+                            : _mergeButtonIcon(ci, buildStatus),
+                        size: 17,
+                      ),
+                label: Text(
+                  merged
+                      ? 'マージ済み'
+                      : hasMergeConflict
+                      ? 'Conflictあり'
+                      : ciPassed
+                      ? 'CI pass・マージ'
+                      : _mergeButtonLabel(ci, buildStatus),
+                ),
+                style: FilledButton.styleFrom(
+                  backgroundColor: hasMergeConflict
+                      ? const Color(0xFFD97706)
+                      : _mergeButtonColor(ci, buildStatus),
+                  foregroundColor: Colors.white,
+                  disabledBackgroundColor: const Color(0xFFE2E8F0),
+                  disabledForegroundColor: const Color(0xFF64748B),
+                ),
+              );
+              if (compact) {
+                return Row(
+                  children: [
+                    Expanded(child: openButton),
+                    const SizedBox(width: 8),
+                    Expanded(child: mergeButton),
+                  ],
+                );
+              }
+              return Row(
+                children: [
+                  openButton,
+                  const Spacer(),
+                  mergeButton,
+                ],
+              );
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _PullRequestCiStatusCard extends StatelessWidget {
+  const _PullRequestCiStatusCard({required this.ci, required this.buildStatus});
+
+  final PullRequestCiSummary? ci;
+  final CardBuildStatus? buildStatus;
+
+  @override
+  Widget build(BuildContext context) {
+    final dashboardStatus = buildStatus;
+    if (dashboardStatus != null) {
+      final allPassed = dashboardStatus.allChecksPassed;
+      final summary = allPassed
+          ? 'CIはすべてpassしています'
+          : dashboardStatus.label == 'fail'
+          ? '失敗しているCIがあります'
+          : dashboardStatus.isSpinning
+          ? 'CIがまだ完了していません'
+          : 'CIの状態を確認できます';
+      return _PullRequestCiStatusFrame(
+        color: dashboardStatus.color,
+        backgroundColor: dashboardStatus.color.withValues(alpha: 0.08),
+        borderColor: dashboardStatus.color.withValues(alpha: 0.22),
+        icon: dashboardStatus.icon,
+        isSpinning: dashboardStatus.isSpinning,
+        summary: summary,
+        detail: dashboardStatus.summaryLabel,
+        showReady: allPassed,
+        onTap: () => showDialog<void>(
+          context: context,
+          builder: (_) => BuildStatusJobsDialog(status: dashboardStatus),
+        ),
+      );
+    }
+
+    final ci = this.ci;
+    if (ci == null) {
+      return const SizedBox.shrink();
+    }
+    final style = _ciStatusStyle(ci.status);
+    final summary = switch (ci.status) {
+      PullRequestCiStatus.success => 'CIはすべてpassしています',
+      PullRequestCiStatus.failure => '失敗しているCIがあります',
+      PullRequestCiStatus.pending => 'CIがまだ完了していません',
+      PullRequestCiStatus.none => 'CIチェックはまだ見つかりません',
+      PullRequestCiStatus.unknown => 'CIの一部を確認できませんでした',
+    };
+    final detail = switch (ci.status) {
+      PullRequestCiStatus.success =>
+        '${ci.passed} checks passed${ci.skipped > 0 ? ' / ${ci.skipped} skipped' : ''}',
+      PullRequestCiStatus.failure =>
+        '${ci.failed} failed / ${ci.passed} passed / ${ci.pending} pending',
+      PullRequestCiStatus.pending =>
+        '${ci.pending} pending / ${ci.passed} passed',
+      PullRequestCiStatus.none => 'GitHub checks/statuses: 0',
+      PullRequestCiStatus.unknown =>
+        '${ci.total} checks found${ci.checksTruncated ? ' / truncated' : ''}',
+    };
+    return _PullRequestCiStatusFrame(
+      color: style.color,
+      backgroundColor: style.backgroundColor,
+      borderColor: style.borderColor,
+      textColor: style.textColor,
+      icon: style.icon,
+      summary: summary,
+      detail: detail,
+      showReady: ci.allPassed,
+    );
+  }
+}
+
+class _PullRequestCiStatusFrame extends StatelessWidget {
+  const _PullRequestCiStatusFrame({
+    required this.color,
+    required this.backgroundColor,
+    required this.borderColor,
+    required this.icon,
+    required this.summary,
+    required this.detail,
+    required this.showReady,
+    this.textColor,
+    this.isSpinning = false,
+    this.onTap,
+  });
+
+  final Color color;
+  final Color backgroundColor;
+  final Color borderColor;
+  final Color? textColor;
+  final IconData icon;
+  final String summary;
+  final String detail;
+  final bool showReady;
+  final bool isSpinning;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final resolvedTextColor = textColor ?? color;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+      decoration: BoxDecoration(
+        color: backgroundColor,
+        border: Border.all(color: borderColor),
+        borderRadius: BorderRadius.circular(14),
+      ),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(12),
+        child: Row(
+          children: [
+            Container(
+              width: 32,
+              height: 32,
+              decoration: BoxDecoration(
+                color: color.withValues(alpha: 0.12),
+                borderRadius: BorderRadius.circular(10),
+              ),
+              child: Center(
+                child: BuildStatusIndicator(
+                  icon: icon,
+                  color: color,
+                  isSpinning: isSpinning,
+                  size: 19,
+                ),
+              ),
+            ),
+            const SizedBox(width: 10),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    summary,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: TextStyle(
+                      color: resolvedTextColor,
+                      fontSize: 13,
+                      fontWeight: FontWeight.w900,
+                    ),
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    detail,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: TextStyle(
+                      color: resolvedTextColor.withValues(alpha: 0.72),
+                      fontSize: 11,
+                      fontWeight: FontWeight.w800,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            if (showReady)
+              Container(
+                padding: const EdgeInsets.symmetric(horizontal: 9, vertical: 5),
+                decoration: BoxDecoration(
+                  color: color,
+                  borderRadius: BorderRadius.circular(999),
+                ),
+                child: const Text(
+                  'READY',
+                  style: TextStyle(
+                    color: Colors.white,
+                    fontSize: 10,
+                    fontWeight: FontWeight.w900,
+                  ),
+                ),
+              ),
+            if (onTap != null) ...[
+              const SizedBox(width: 8),
+              Icon(
+                Icons.open_in_new_rounded,
+                color: color.withValues(alpha: 0.75),
+                size: 16,
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+({
+  Color color,
+  Color backgroundColor,
+  Color borderColor,
+  Color textColor,
+  IconData icon,
+})
+_ciStatusStyle(PullRequestCiStatus status) {
+  return switch (status) {
+    PullRequestCiStatus.success => (
+      color: const Color(0xFF047857),
+      backgroundColor: const Color(0xFFECFDF5),
+      borderColor: const Color(0xFFA7F3D0),
+      textColor: const Color(0xFF064E3B),
+      icon: Icons.check_circle_rounded,
+    ),
+    PullRequestCiStatus.failure => (
+      color: const Color(0xFFB91C1C),
+      backgroundColor: const Color(0xFFFFF1F2),
+      borderColor: const Color(0xFFFECACA),
+      textColor: const Color(0xFF7F1D1D),
+      icon: Icons.error_rounded,
+    ),
+    PullRequestCiStatus.pending => (
+      color: const Color(0xFF2563EB),
+      backgroundColor: const Color(0xFFEFF6FF),
+      borderColor: const Color(0xFFBFDBFE),
+      textColor: const Color(0xFF1E3A8A),
+      icon: Icons.pending_rounded,
+    ),
+    PullRequestCiStatus.none => (
+      color: const Color(0xFF64748B),
+      backgroundColor: const Color(0xFFF8FAFC),
+      borderColor: const Color(0xFFE2E8F0),
+      textColor: const Color(0xFF334155),
+      icon: Icons.radio_button_unchecked_rounded,
+    ),
+    PullRequestCiStatus.unknown => (
+      color: const Color(0xFFD97706),
+      backgroundColor: const Color(0xFFFFFBEB),
+      borderColor: const Color(0xFFFDE68A),
+      textColor: const Color(0xFF78350F),
+      icon: Icons.help_rounded,
+    ),
+  };
+}
+
+extension on CardBuildStatus {
+  bool get allChecksPassed {
+    return jobs.isNotEmpty &&
+        jobs.every((job) => job.status == BuildJobStatus.SUCCESS);
+  }
+}
+
+Color _mergeButtonColor(
+  PullRequestCiSummary? ci,
+  CardBuildStatus? buildStatus,
+) {
+  final dashboardStatus = buildStatus;
+  if (dashboardStatus != null) {
+    return dashboardStatus.color;
+  }
+  return switch (ci?.status) {
+    PullRequestCiStatus.success => const Color(0xFF047857),
+    PullRequestCiStatus.failure => const Color(0xFFB91C1C),
+    PullRequestCiStatus.pending => const Color(0xFF2563EB),
+    PullRequestCiStatus.unknown => const Color(0xFFD97706),
+    PullRequestCiStatus.none || null => const Color(0xFF475569),
+  };
+}
+
+IconData _mergeButtonIcon(
+  PullRequestCiSummary? ci,
+  CardBuildStatus? buildStatus,
+) {
+  final dashboardStatus = buildStatus;
+  if (dashboardStatus != null) {
+    return dashboardStatus.icon;
+  }
+  return switch (ci?.status) {
+    PullRequestCiStatus.success => Icons.check_circle_rounded,
+    PullRequestCiStatus.failure => Icons.error_rounded,
+    PullRequestCiStatus.pending => Icons.pending_rounded,
+    PullRequestCiStatus.unknown => Icons.help_rounded,
+    PullRequestCiStatus.none || null => Icons.call_merge_rounded,
+  };
+}
+
+String _mergeButtonLabel(
+  PullRequestCiSummary? ci,
+  CardBuildStatus? buildStatus,
+) {
+  final dashboardStatus = buildStatus;
+  if (dashboardStatus != null) {
+    if (dashboardStatus.allChecksPassed) return 'CI pass・マージ';
+    if (dashboardStatus.label == 'fail') return 'CI確認・マージ';
+    if (dashboardStatus.isSpinning) return 'CI待ち・マージ';
+    return 'CI確認・マージ';
+  }
+  return switch (ci?.status) {
+    PullRequestCiStatus.failure => 'CI確認・マージ',
+    PullRequestCiStatus.pending => 'CI待ち・マージ',
+    PullRequestCiStatus.unknown => 'CI不明・マージ',
+    PullRequestCiStatus.success => 'CI pass・マージ',
+    PullRequestCiStatus.none || null => 'マージ',
+  };
+}
+
+class PullRequestDiffBody extends StatelessWidget {
+  const PullRequestDiffBody({super.key, required this.diff});
+
+  final IssuePullRequestDiff diff;
+
+  @override
+  Widget build(BuildContext context) {
+    final commentsCount = diff.comments.length;
+    return DefaultTabController(
+      length: 2,
+      child: Column(
+        children: [
+          Container(
+            decoration: const BoxDecoration(
+              color: Colors.white,
+              border: Border(bottom: BorderSide(color: Color(0xFFE2E8F0))),
+            ),
+            child: TabBar(
+              labelColor: const Color(0xFF0F172A),
+              unselectedLabelColor: const Color(0xFF64748B),
+              indicatorColor: const Color(0xFF2563EB),
+              indicatorWeight: 3,
+              labelStyle: const TextStyle(
+                fontSize: 13,
+                fontWeight: FontWeight.w900,
+              ),
+              tabs: [
+                Tab(text: 'Diff (${diff.files.length})'),
+                Tab(text: 'Comments ($commentsCount)'),
+              ],
+            ),
+          ),
+          Expanded(
+            child: TabBarView(
+              children: [
+                _PullRequestDiffTab(diff: diff),
+                _PullRequestCommentsTab(diff: diff),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _PullRequestDiffTab extends StatelessWidget {
+  const _PullRequestDiffTab({required this.diff});
+
+  final IssuePullRequestDiff diff;
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      padding: const EdgeInsets.fromLTRB(18, 16, 18, 24),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          _PullRequestDiffStats(diff: diff),
+          if (diff.filesTruncated) ...[
+            const SizedBox(height: 10),
+            const _PullRequestDiffNotice(
+              message: '変更ファイルが多いため、先頭300ファイルまで表示しています。',
+            ),
+          ],
+          const SizedBox(height: 12),
+          for (final entry in diff.files.indexed) ...[
+            PullRequestDiffFileView(file: entry.$2),
+            if (entry.$1 != diff.files.length - 1) const SizedBox(height: 10),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _PullRequestCommentsTab extends StatelessWidget {
+  const _PullRequestCommentsTab({required this.diff});
+
+  final IssuePullRequestDiff diff;
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      padding: const EdgeInsets.fromLTRB(18, 16, 18, 24),
+      child: diff.comments.isEmpty && !diff.commentsTruncated
+          ? const _PullRequestEmptyComments()
+          : _PullRequestCommentsPanel(diff: diff),
+    );
+  }
+}
+
+class _PullRequestEmptyComments extends StatelessWidget {
+  const _PullRequestEmptyComments();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(18),
+      decoration: BoxDecoration(
+        color: const Color(0xFFF8FAFC),
+        border: Border.all(color: const Color(0xFFE2E8F0)),
+        borderRadius: BorderRadius.circular(14),
+      ),
+      child: const Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(
+            Icons.forum_outlined,
+            size: 28,
+            color: Color(0xFF94A3B8),
+          ),
+          SizedBox(height: 8),
+          Text(
+            'PRコメントはまだありません',
+            style: TextStyle(
+              color: Color(0xFF475569),
+              fontWeight: FontWeight.w900,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _PullRequestDiffStats extends StatelessWidget {
+  const _PullRequestDiffStats({required this.diff});
+
+  final IssuePullRequestDiff diff;
+
+  @override
+  Widget build(BuildContext context) {
+    return Wrap(
+      spacing: 8,
+      runSpacing: 8,
+      children: [
+        _PullRequestDiffStatPill(
+          icon: Icons.description_outlined,
+          label: '${diff.changedFiles} files',
+          color: const Color(0xFF2563EB),
+        ),
+        _PullRequestDiffStatPill(
+          icon: Icons.add_rounded,
+          label: '+${diff.additions}',
+          color: const Color(0xFF15803D),
+        ),
+        _PullRequestDiffStatPill(
+          icon: Icons.remove_rounded,
+          label: '-${diff.deletions}',
+          color: const Color(0xFFB91C1C),
+        ),
+        if (diff.branch.isNotEmpty)
+          _PullRequestDiffStatPill(
+            icon: Icons.fork_right_rounded,
+            label: diff.branch,
+            color: const Color(0xFF64748B),
+          ),
+      ],
+    );
+  }
+}
+
+class _PullRequestDiffStatPill extends StatelessWidget {
+  const _PullRequestDiffStatPill({
+    required this.icon,
+    required this.label,
+    required this.color,
+  });
+
+  final IconData icon;
+  final String label;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 9, vertical: 6),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.09),
+        border: Border.all(color: color.withValues(alpha: 0.2)),
+        borderRadius: BorderRadius.circular(999),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: 14, color: color),
+          const SizedBox(width: 5),
+          Text(
+            label,
+            style: TextStyle(
+              color: color,
+              fontSize: 12,
+              fontWeight: FontWeight.w900,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _PullRequestCommentsPanel extends StatelessWidget {
+  const _PullRequestCommentsPanel({required this.diff});
+
+  final IssuePullRequestDiff diff;
+
+  @override
+  Widget build(BuildContext context) {
+    final comments = diff.comments;
+    final reviewCount = comments
+        .where((comment) => comment.kind == IssuePullRequestCommentKind.review)
+        .length;
+    final conversationCount = comments.length - reviewCount;
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: const Color(0xFFF8FAFC),
+        border: Border.all(color: const Color(0xFFE2E8F0)),
+        borderRadius: BorderRadius.circular(14),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Row(
+            children: [
+              const Icon(
+                Icons.forum_rounded,
+                size: 18,
+                color: Color(0xFF2563EB),
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  'PR comments',
+                  style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                    color: const Color(0xFF0F172A),
+                    fontWeight: FontWeight.w900,
+                  ),
+                ),
+              ),
+              _DiffCountPill(
+                label: '$conversationCount conversation',
+                color: const Color(0xFF64748B),
+              ),
+              const SizedBox(width: 6),
+              _DiffCountPill(
+                label: '$reviewCount review',
+                color: const Color(0xFF2563EB),
+              ),
+            ],
+          ),
+          if (diff.commentsTruncated) ...[
+            const SizedBox(height: 10),
+            const _PullRequestDiffNotice(
+              message: 'コメントが多いため、先頭100件ずつを表示しています。',
+            ),
+          ],
+          const SizedBox(height: 10),
+          for (final entry in comments.indexed) ...[
+            _PullRequestCommentTile(comment: entry.$2),
+            if (entry.$1 != comments.length - 1) const SizedBox(height: 8),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _PullRequestCommentTile extends StatelessWidget {
+  const _PullRequestCommentTile({required this.comment});
+
+  final IssuePullRequestComment comment;
+
+  @override
+  Widget build(BuildContext context) {
+    final isReview = comment.kind == IssuePullRequestCommentKind.review;
+    final accentColor = isReview
+        ? const Color(0xFF2563EB)
+        : const Color(0xFF64748B);
+    final location = [
+      if (comment.path != null) comment.path!,
+      if (comment.line != null) 'L${comment.line}',
+    ].join(':');
+    return Material(
+      color: Colors.white,
+      borderRadius: BorderRadius.circular(12),
+      clipBehavior: Clip.antiAlias,
+      child: InkWell(
+        onTap: comment.url.isEmpty
+            ? null
+            : () => unawaited(launchUrlExternal(comment.url)),
+        child: Container(
+          padding: const EdgeInsets.all(11),
+          decoration: BoxDecoration(
+            border: Border.all(color: const Color(0xFFE2E8F0)),
+            borderRadius: BorderRadius.circular(12),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Wrap(
+                spacing: 8,
+                runSpacing: 6,
+                crossAxisAlignment: WrapCrossAlignment.center,
+                children: [
+                  Container(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 7,
+                      vertical: 3,
+                    ),
+                    decoration: BoxDecoration(
+                      color: accentColor.withValues(alpha: 0.09),
+                      borderRadius: BorderRadius.circular(999),
+                    ),
+                    child: Text(
+                      isReview ? 'review' : 'conversation',
+                      style: TextStyle(
+                        color: accentColor,
+                        fontSize: 11,
+                        fontWeight: FontWeight.w900,
+                      ),
+                    ),
+                  ),
+                  Text(
+                    comment.author,
+                    style: const TextStyle(
+                      color: Color(0xFF0F172A),
+                      fontSize: 12,
+                      fontWeight: FontWeight.w900,
+                    ),
+                  ),
+                  if (location.isNotEmpty)
+                    Text(
+                      location,
+                      style: const TextStyle(
+                        color: Color(0xFF64748B),
+                        fontSize: 11,
+                        fontWeight: FontWeight.w800,
+                      ),
+                    ),
+                ],
+              ),
+              const SizedBox(height: 8),
+              MarkdownBody(
+                data: _commentPreview(comment.body),
+                selectable: true,
+                onTapLink: (text, href, title) {
+                  if (href == null || href.isEmpty) {
+                    return;
+                  }
+                  unawaited(launchUrlExternal(href));
+                },
+                styleSheet: MarkdownStyleSheet(
+                  p: const TextStyle(
+                    color: Color(0xFF334155),
+                    fontSize: 12,
+                    height: 1.42,
+                    fontWeight: FontWeight.w600,
+                  ),
+                  strong: const TextStyle(
+                    color: Color(0xFF0F172A),
+                    fontWeight: FontWeight.w900,
+                  ),
+                  code: const TextStyle(
+                    color: Color(0xFF1D4ED8),
+                    backgroundColor: Color(0xFFEFF6FF),
+                    fontFamily: 'monospace',
+                    fontSize: 12,
+                  ),
+                  codeblockDecoration: BoxDecoration(
+                    color: const Color(0xFFF1F5F9),
+                    border: Border.all(color: const Color(0xFFE2E8F0)),
+                    borderRadius: BorderRadius.circular(10),
+                  ),
+                  blockquote: const TextStyle(
+                    color: Color(0xFF475569),
+                    fontSize: 12,
+                    height: 1.42,
+                    fontWeight: FontWeight.w600,
+                  ),
+                  blockquoteDecoration: BoxDecoration(
+                    color: const Color(0xFFF8FAFC),
+                    border: const Border(
+                      left: BorderSide(color: Color(0xFFCBD5E1), width: 4),
+                    ),
+                    borderRadius: BorderRadius.circular(6),
+                  ),
+                  listBullet: const TextStyle(
+                    color: Color(0xFF334155),
+                    fontSize: 12,
+                    height: 1.42,
+                  ),
+                  a: const TextStyle(
+                    color: Color(0xFF2563EB),
+                    fontSize: 12,
+                    fontWeight: FontWeight.w800,
+                    decoration: TextDecoration.underline,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+String _commentPreview(String body) {
+  final normalized = body.trim().replaceAll(RegExp(r'\n{3,}'), '\n\n');
+  if (normalized.length <= 1200) {
+    return normalized;
+  }
+  return '${normalized.substring(0, 1200).trimRight()}\n...';
+}
+
+class PullRequestDiffFileView extends StatelessWidget {
+  const PullRequestDiffFileView({super.key, required this.file});
+
+  final IssuePullRequestDiffFile file;
+
+  @override
+  Widget build(BuildContext context) {
+    final patch = file.patch;
+    return Container(
+      decoration: BoxDecoration(
+        color: Colors.white,
+        border: Border.all(color: const Color(0xFFE2E8F0)),
+        borderRadius: BorderRadius.circular(14),
+      ),
+      child: Theme(
+        data: Theme.of(context).copyWith(dividerColor: Colors.transparent),
+        child: ExpansionTile(
+          tilePadding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+          childrenPadding: const EdgeInsets.fromLTRB(12, 0, 12, 12),
+          initiallyExpanded: diffFileInitiallyExpanded(file),
+          title: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                file.filename,
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+                style: const TextStyle(
+                  color: Color(0xFF0F172A),
+                  fontSize: 13,
+                  fontWeight: FontWeight.w900,
+                ),
+              ),
+              if (file.previousFilename != null) ...[
+                const SizedBox(height: 3),
+                Text(
+                  'renamed from ${file.previousFilename}',
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: const TextStyle(
+                    color: Color(0xFF64748B),
+                    fontSize: 11,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+              ],
+            ],
+          ),
+          subtitle: Padding(
+            padding: const EdgeInsets.only(top: 7),
+            child: Wrap(
+              spacing: 6,
+              runSpacing: 6,
+              crossAxisAlignment: WrapCrossAlignment.center,
+              children: [
+                _DiffFileStatusPill(status: file.status),
+                _DiffCountPill(
+                  label: '+${file.additions}',
+                  color: const Color(0xFF15803D),
+                ),
+                _DiffCountPill(
+                  label: '-${file.deletions}',
+                  color: const Color(0xFFB91C1C),
+                ),
+                _DiffCountPill(
+                  label: '${file.changes} changes',
+                  color: const Color(0xFF64748B),
+                ),
+              ],
+            ),
+          ),
+          children: [
+            if (patch.isEmpty)
+              const _PullRequestDiffNotice(
+                message: 'このファイルのdiff previewはありません。',
+              )
+            else
+              _PatchBlock(
+                filename: file.filename,
+                patch: file.patchTruncated
+                    ? '$patch\n\n... patch truncated in OpenCI preview'
+                    : patch,
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+bool diffFileInitiallyExpanded(IssuePullRequestDiffFile file) {
+  return file.patch.isNotEmpty && file.changes <= 80;
+}
+
+class _DiffFileStatusPill extends StatelessWidget {
+  const _DiffFileStatusPill({required this.status});
+
+  final String status;
+
+  @override
+  Widget build(BuildContext context) {
+    final color = switch (status) {
+      'added' => const Color(0xFF15803D),
+      'removed' => const Color(0xFFB91C1C),
+      'renamed' => const Color(0xFF7C3AED),
+      _ => const Color(0xFF2563EB),
+    };
+    return _DiffCountPill(label: status, color: color);
+  }
+}
+
+class _DiffCountPill extends StatelessWidget {
+  const _DiffCountPill({required this.label, required this.color});
+
+  final String label;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 7, vertical: 3),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.08),
+        border: Border.all(color: color.withValues(alpha: 0.18)),
+        borderRadius: BorderRadius.circular(999),
+      ),
+      child: Text(
+        label,
+        style: TextStyle(
+          color: color,
+          fontSize: 11,
+          fontWeight: FontWeight.w900,
+        ),
+      ),
+    );
+  }
+}
+
+class _PatchBlock extends StatelessWidget {
+  const _PatchBlock({required this.filename, required this.patch});
+
+  final String filename;
+  final String patch;
+
+  @override
+  Widget build(BuildContext context) {
+    final lines = diffPatchLines(patch);
+    final language = diffLanguageForFilename(filename);
+    final lineCountDigits = lines.fold(
+      2,
+      (digits, line) => math.max(
+        digits,
+        math.max(
+          line.oldLineNumber?.toString().length ?? 0,
+          line.newLineNumber?.toString().length ?? 0,
+        ),
+      ),
+    );
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: const Color(0xFFF8FAFC),
+        border: Border.all(color: const Color(0xFFE2E8F0)),
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(11),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+              decoration: const BoxDecoration(
+                color: Color(0xFFF1F5F9),
+                border: Border(bottom: BorderSide(color: Color(0xFFE2E8F0))),
+              ),
+              child: Row(
+                children: [
+                  const Icon(
+                    Icons.data_object_rounded,
+                    size: 16,
+                    color: Color(0xFF475569),
+                  ),
+                  const SizedBox(width: 7),
+                  Text(
+                    language ?? 'plain text',
+                    style: const TextStyle(
+                      color: Color(0xFF475569),
+                      fontSize: 11,
+                      fontWeight: FontWeight.w900,
+                    ),
+                  ),
+                  const Spacer(),
+                  Text(
+                    '${lines.length} lines',
+                    style: const TextStyle(
+                      color: Color(0xFF64748B),
+                      fontSize: 11,
+                      fontWeight: FontWeight.w800,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            SingleChildScrollView(
+              scrollDirection: Axis.horizontal,
+              child: SelectionArea(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    for (final line in lines)
+                      _PatchLineView(
+                        line: line,
+                        language: language,
+                        lineNumberWidth: lineCountDigits * 8.0 + 18,
+                      ),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _PatchLineView extends StatelessWidget {
+  const _PatchLineView({
+    required this.line,
+    required this.language,
+    required this.lineNumberWidth,
+  });
+
+  final DiffPatchLine line;
+  final String? language;
+  final double lineNumberWidth;
+
+  @override
+  Widget build(BuildContext context) {
+    final backgroundColor = switch (line.kind) {
+      DiffPatchLineKind.added => const Color(0xFFEFFBF1),
+      DiffPatchLineKind.removed => const Color(0xFFFFF1F2),
+      DiffPatchLineKind.hunk => const Color(0xFFEFF6FF),
+      DiffPatchLineKind.meta => const Color(0xFFFFFBEB),
+      DiffPatchLineKind.context => Colors.white,
+    };
+    final markerColor = switch (line.kind) {
+      DiffPatchLineKind.added => const Color(0xFF15803D),
+      DiffPatchLineKind.removed => const Color(0xFFB91C1C),
+      DiffPatchLineKind.hunk => const Color(0xFF2563EB),
+      DiffPatchLineKind.meta => const Color(0xFF92400E),
+      DiffPatchLineKind.context => const Color(0xFF64748B),
+    };
+    final numberColor = switch (line.kind) {
+      DiffPatchLineKind.added => const Color(0xFF16A34A),
+      DiffPatchLineKind.removed => const Color(0xFFDC2626),
+      DiffPatchLineKind.hunk => const Color(0xFF2563EB),
+      DiffPatchLineKind.meta => const Color(0xFFD97706),
+      DiffPatchLineKind.context => const Color(0xFF94A3B8),
+    };
+    final codeStyle = const TextStyle(
+      color: Color(0xFF24292E),
+      fontFamily: 'monospace',
+      fontSize: 12,
+      height: 1.42,
+    );
+    final gutterStyle = codeStyle.copyWith(color: numberColor);
+    return Container(
+      constraints: const BoxConstraints(minWidth: 760),
+      color: backgroundColor,
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          _PatchLineNumber(
+            value: line.oldLineNumber,
+            width: lineNumberWidth,
+            style: gutterStyle,
+          ),
+          _PatchLineNumber(
+            value: line.newLineNumber,
+            width: lineNumberWidth,
+            style: gutterStyle,
+          ),
+          Container(
+            width: 24,
+            padding: const EdgeInsets.only(top: 3),
+            alignment: Alignment.topCenter,
+            child: Text(
+              line.marker,
+              style: codeStyle.copyWith(
+                color: markerColor,
+                fontWeight: FontWeight.w900,
+              ),
+            ),
+          ),
+          ConstrainedBox(
+            constraints: const BoxConstraints(minWidth: 520),
+            child: Padding(
+              padding: const EdgeInsets.fromLTRB(0, 3, 18, 3),
+              child: Text.rich(
+                _highlightDiffCode(
+                  line.content,
+                  language: line.kind.isCode ? language : null,
+                  baseStyle: line.kind == DiffPatchLineKind.hunk
+                      ? codeStyle.copyWith(
+                          color: const Color(0xFF1D4ED8),
+                          fontWeight: FontWeight.w800,
+                        )
+                      : codeStyle,
+                ),
+                softWrap: false,
+                overflow: TextOverflow.visible,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _PatchLineNumber extends StatelessWidget {
+  const _PatchLineNumber({
+    required this.value,
+    required this.width,
+    required this.style,
+  });
+
+  final int? value;
+  final double width;
+  final TextStyle style;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: width,
+      padding: const EdgeInsets.fromLTRB(8, 3, 8, 3),
+      alignment: Alignment.topRight,
+      decoration: const BoxDecoration(
+        color: Color(0xFFF8FAFC),
+        border: Border(right: BorderSide(color: Color(0xFFE2E8F0))),
+      ),
+      child: Text(value?.toString() ?? '', style: style),
+    );
+  }
+}
+
+TextSpan _highlightDiffCode(
+  String code, {
+  required String? language,
+  required TextStyle baseStyle,
+}) {
+  if (code.isEmpty || language == null || code.length > 1000) {
+    return TextSpan(text: code, style: baseStyle);
+  }
+  try {
+    final result = _pullRequestDiffHighlighter.highlight(
+      code: code,
+      language: language,
+    );
+    final renderer = TextSpanRenderer(baseStyle, githubTheme);
+    result.render(renderer);
+    return renderer.span ?? TextSpan(text: code, style: baseStyle);
+  } catch (_) {
+    return TextSpan(text: code, style: baseStyle);
+  }
+}
+
+final _pullRequestDiffHighlighter = Highlight()
+  ..registerLanguages({
+    'bash': langBash,
+    'c': langC,
+    'cpp': langCpp,
+    'csharp': langCsharp,
+    'css': langCss,
+    'dart': langDart,
+    'dockerfile': langDockerfile,
+    'go': langGo,
+    'java': langJava,
+    'javascript': langJavascript,
+    'json': langJson,
+    'kotlin': langKotlin,
+    'markdown': langMarkdown,
+    'php': langPhp,
+    'python': langPython,
+    'ruby': langRuby,
+    'rust': langRust,
+    'scss': langScss,
+    'shell': langShell,
+    'sql': langSql,
+    'swift': langSwift,
+    'typescript': langTypescript,
+    'xml': langXml,
+    'yaml': langYaml,
+  });
+
+enum DiffPatchLineKind { context, added, removed, hunk, meta }
+
+extension on DiffPatchLineKind {
+  bool get isCode {
+    return switch (this) {
+      DiffPatchLineKind.context ||
+      DiffPatchLineKind.added ||
+      DiffPatchLineKind.removed => true,
+      DiffPatchLineKind.hunk || DiffPatchLineKind.meta => false,
+    };
+  }
+}
+
+class DiffPatchLine {
+  const DiffPatchLine({
+    required this.kind,
+    required this.content,
+    required this.marker,
+    this.oldLineNumber,
+    this.newLineNumber,
+  });
+
+  final DiffPatchLineKind kind;
+  final String content;
+  final String marker;
+  final int? oldLineNumber;
+  final int? newLineNumber;
+}
+
+List<DiffPatchLine> diffPatchLines(String patch) {
+  final parsed = <DiffPatchLine>[];
+  var oldLineNumber = 0;
+  var newLineNumber = 0;
+  for (final rawLine in patch.split('\n')) {
+    if (rawLine.startsWith('@@')) {
+      final match = RegExp(
+        r'^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@',
+      ).firstMatch(rawLine);
+      if (match != null) {
+        oldLineNumber = int.tryParse(match.group(1) ?? '') ?? oldLineNumber;
+        newLineNumber = int.tryParse(match.group(2) ?? '') ?? newLineNumber;
+      }
+      parsed.add(
+        DiffPatchLine(
+          kind: DiffPatchLineKind.hunk,
+          content: rawLine,
+          marker: '',
+        ),
+      );
+      continue;
+    }
+    if (rawLine.startsWith(r'\ No newline') ||
+        rawLine == '... patch truncated in OpenCI preview') {
+      parsed.add(
+        DiffPatchLine(
+          kind: DiffPatchLineKind.meta,
+          content: rawLine,
+          marker: '',
+        ),
+      );
+      continue;
+    }
+    if (rawLine.startsWith('+') && !rawLine.startsWith('+++')) {
+      parsed.add(
+        DiffPatchLine(
+          kind: DiffPatchLineKind.added,
+          content: rawLine.substring(1),
+          marker: '+',
+          newLineNumber: newLineNumber,
+        ),
+      );
+      newLineNumber += 1;
+      continue;
+    }
+    if (rawLine.startsWith('-') && !rawLine.startsWith('---')) {
+      parsed.add(
+        DiffPatchLine(
+          kind: DiffPatchLineKind.removed,
+          content: rawLine.substring(1),
+          marker: '-',
+          oldLineNumber: oldLineNumber,
+        ),
+      );
+      oldLineNumber += 1;
+      continue;
+    }
+    final content = rawLine.startsWith(' ') ? rawLine.substring(1) : rawLine;
+    parsed.add(
+      DiffPatchLine(
+        kind: DiffPatchLineKind.context,
+        content: content,
+        marker: rawLine.startsWith(' ') ? ' ' : '',
+        oldLineNumber: oldLineNumber,
+        newLineNumber: newLineNumber,
+      ),
+    );
+    oldLineNumber += 1;
+    newLineNumber += 1;
+  }
+  return parsed;
+}
+
+String? diffLanguageForFilename(String filename) {
+  final path = filename.toLowerCase();
+  final basename = path.split('/').last;
+  if (basename == 'dockerfile' || basename.startsWith('dockerfile.')) {
+    return 'dockerfile';
+  }
+  if (basename == 'makefile') return 'bash';
+  if (basename == 'gemfile') return 'ruby';
+  if (basename == 'podfile') return 'ruby';
+  if (basename == 'pubspec.yaml' || basename == 'pubspec.yml') return 'yaml';
+  final extension = basename.contains('.') ? basename.split('.').last : '';
+  return switch (extension) {
+    'bash' || 'sh' || 'zsh' => 'bash',
+    'c' || 'h' => 'c',
+    'cc' || 'cpp' || 'cxx' || 'hpp' => 'cpp',
+    'cs' => 'csharp',
+    'css' => 'css',
+    'dart' => 'dart',
+    'go' => 'go',
+    'java' => 'java',
+    'js' || 'jsx' || 'mjs' || 'cjs' => 'javascript',
+    'json' || 'jsonc' => 'json',
+    'kt' || 'kts' => 'kotlin',
+    'md' || 'mdx' => 'markdown',
+    'php' => 'php',
+    'py' => 'python',
+    'rb' => 'ruby',
+    'rs' => 'rust',
+    'scss' => 'scss',
+    'sql' => 'sql',
+    'swift' => 'swift',
+    'ts' || 'tsx' => 'typescript',
+    'xml' || 'html' || 'htm' || 'svg' => 'xml',
+    'yaml' || 'yml' => 'yaml',
+    _ => null,
+  };
+}
+
+String _pullRequestMergeConflictKey(String repository, int number) {
+  return '$repository#$number';
+}
+
+String? _pullRequestMergeConflictMessage(Object error) {
+  if (error is! FirebaseFunctionsException) {
+    return null;
+  }
+  final message = error.message ?? '';
+  final normalized = message.toLowerCase();
+  if (error.code != 'failed-precondition' ||
+      !normalized.contains('merge conflict')) {
+    return null;
+  }
+  return 'このPRはbase branchとconflictしています。GitHubでconflictを解消してから、もう一度マージしてください。';
+}
+
+String? _pullRequestMergeConflictMessageFromDiff(IssuePullRequestDiff? diff) {
+  if (diff == null) {
+    return null;
+  }
+  final mergeableState = diff.mergeableState.toLowerCase();
+  if (mergeableState == 'dirty' ||
+      (diff.mergeable == false && mergeableState.contains('conflict'))) {
+    return 'このPRはbase branchとconflictしています。GitHubでconflictを解消してから、もう一度マージしてください。';
+  }
+  return null;
+}
+
+class _PullRequestDiffNotice extends StatelessWidget {
+  const _PullRequestDiffNotice({required this.message});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(10),
+      decoration: BoxDecoration(
+        color: const Color(0xFFFFFBEB),
+        border: Border.all(color: const Color(0xFFFDE68A)),
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Text(
+        message,
+        style: const TextStyle(
+          color: Color(0xFF92400E),
+          fontSize: 12,
+          fontWeight: FontWeight.w800,
+        ),
+      ),
+    );
+  }
+}
+
+class _PullRequestDiffError extends StatelessWidget {
+  const _PullRequestDiffError({required this.error, required this.onRetry});
+
+  final Object? error;
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(
+              Icons.error_outline_rounded,
+              color: Color(0xFFB91C1C),
+              size: 28,
+            ),
+            const SizedBox(height: 10),
+            Text(
+              friendlyError(error ?? '差分を読み込めませんでした'),
+              textAlign: TextAlign.center,
+              style: const TextStyle(
+                color: Color(0xFF475569),
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+            const SizedBox(height: 14),
+            OutlinedButton.icon(
+              onPressed: onRetry,
+              icon: const Icon(Icons.refresh_rounded, size: 18),
+              label: const Text('再読み込み'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _RepoField extends StatelessWidget {
+  const _RepoField({
+    required this.repositories,
+    required this.selectedRepository,
+    required this.onRepositoryChanged,
+    required this.decorationBuilder,
+  });
+
+  final List<String> repositories;
+  final String? selectedRepository;
+  final ValueChanged<String> onRepositoryChanged;
+  final InputDecoration Function({required String label, String? hint})
+  decorationBuilder;
+
+  @override
+  Widget build(BuildContext context) {
+    return DropdownButtonFormField<String>(
+      initialValue: selectedRepository,
+      decoration: decorationBuilder(
+        label: 'repo',
+        hint: '連携済みrepoから選択',
+      ),
+      items: [
+        for (final repository in repositories)
+          DropdownMenuItem(
+            value: repository,
+            child: Text(repository, overflow: TextOverflow.ellipsis),
+          ),
+      ],
+      onChanged: repositories.isEmpty
+          ? null
+          : (value) {
+              if (value == null) {
+                return;
+              }
+
+              onRepositoryChanged(value);
+            },
+      validator: (value) =>
+          value == null || value.trim().isEmpty ? '先にrepoを選択してください' : null,
+    );
+  }
+}
+
+class CreateSubIssuePanel extends StatelessWidget {
+  const CreateSubIssuePanel({
+    super.key,
+    required this.issue,
+    this.workspaceId,
+    this.linkedSubIssues = const [],
+    this.onOpenIssue,
+    required this.titleController,
+    required this.bodyController,
+    required this.isCreating,
+    required this.onCreate,
+  });
+
+  final Issue issue;
+  final String? workspaceId;
+  final List<Issue> linkedSubIssues;
+  final ValueChanged<String>? onOpenIssue;
+  final TextEditingController titleController;
+  final TextEditingController bodyController;
+  final bool isCreating;
+  final VoidCallback? onCreate;
+
+  @override
+  Widget build(BuildContext context) {
+    final isLinkedToGitHub = issue.githubUrl != null;
+    final canCreate = isLinkedToGitHub && !isCreating && onCreate != null;
+    final summary = issue.subIssuesSummary;
+    final referencedSubIssues = _mergedSubIssueReferences(
+      linkedSubIssues: linkedSubIssues,
+      storedSubIssues: issue.subIssues,
+    );
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: const Color(0xFFF8FAFC),
+        border: Border.all(color: const Color(0xFFE2E8F0)),
+        borderRadius: BorderRadius.circular(18),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              const Icon(
+                Icons.account_tree_outlined,
+                size: 18,
+                color: Color(0xFF2563EB),
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  summary == null
+                      ? 'Sub-issues'
+                      : 'Sub-issues ${summary.completed}/${summary.total}',
+                  style: const TextStyle(
+                    color: Color(0xFF0F172A),
+                    fontWeight: FontWeight.w900,
+                  ),
+                ),
+              ),
+              if (summary != null)
+                Text(
+                  '${summary.percentCompleted}%',
+                  style: const TextStyle(
+                    color: Color(0xFF2563EB),
+                    fontWeight: FontWeight.w900,
+                  ),
+                ),
+            ],
+          ),
+          if (summary != null) ...[
+            const SizedBox(height: 8),
+            ClipRRect(
+              borderRadius: BorderRadius.circular(999),
+              child: LinearProgressIndicator(
+                minHeight: 6,
+                value: summary.progress,
+                backgroundColor: const Color(0xFFE2E8F0),
+                valueColor: AlwaysStoppedAnimation<Color>(
+                  summary.completed == summary.total
+                      ? const Color(0xFF16A34A)
+                      : const Color(0xFF2563EB),
+                ),
+              ),
+            ),
+          ],
+          if (linkedSubIssues.isNotEmpty || referencedSubIssues.isNotEmpty) ...[
+            const SizedBox(height: 10),
+            SubIssuesList(
+              workspaceId: workspaceId,
+              subIssues: linkedSubIssues,
+              referenceSubIssues: referencedSubIssues,
+              onIssueTap: onOpenIssue,
+            ),
+          ],
+          const SizedBox(height: 12),
+          CallbackShortcuts(
+            bindings: <ShortcutActivator, VoidCallback>{
+              SingleActivator(LogicalKeyboardKey.enter, meta: true): () {
+                if (canCreate) {
+                  onCreate!();
+                }
+              },
+            },
+            child: Focus(
+              child: Column(
+                children: [
+                  TextField(
+                    controller: titleController,
+                    enabled: canCreate,
+                    textInputAction: TextInputAction.next,
+                    decoration: const InputDecoration(
+                      labelText: '新しいsub-issueのタイトル',
+                      hintText: '例: APIでsub-issueを同期する',
+                    ),
+                  ),
+                  const SizedBox(height: 10),
+                  TextField(
+                    controller: bodyController,
+                    enabled: canCreate,
+                    minLines: 2,
+                    maxLines: 5,
+                    keyboardType: TextInputType.multiline,
+                    decoration: const InputDecoration(
+                      labelText: '本文',
+                      hintText: '任意: sub-issueの説明',
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+          const SizedBox(height: 12),
+          _SubIssueCreateActionBar(
+            isLinkedToGitHub: isLinkedToGitHub,
+            isCreating: isCreating,
+            canCreate: canCreate,
+            onCreate: onCreate,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SubIssueCreateActionBar extends StatelessWidget {
+  const _SubIssueCreateActionBar({
+    required this.isLinkedToGitHub,
+    required this.isCreating,
+    required this.canCreate,
+    required this.onCreate,
+  });
+
+  final bool isLinkedToGitHub;
+  final bool isCreating;
+  final bool canCreate;
+  final VoidCallback? onCreate;
+
+  @override
+  Widget build(BuildContext context) {
+    final message = isLinkedToGitHub
+        ? 'GitHubへ作成し、このissueのsub-issueに紐づけます。'
+        : 'GitHubに同期されたissueでのみ作成できます。';
+    final button = _SubIssueCreateButton(
+      isCreating: isCreating,
+      onPressed: canCreate ? onCreate : null,
+    );
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final isCompact = constraints.maxWidth < 480;
+        final messageText = Text(
+          message,
+          maxLines: isCompact ? 2 : 1,
+          overflow: TextOverflow.ellipsis,
+          style: const TextStyle(
+            color: Color(0xFF475569),
+            fontSize: 12,
+            height: 1.35,
+            fontWeight: FontWeight.w700,
+          ),
+        );
+
+        return Container(
+          padding: const EdgeInsets.all(10),
+          decoration: BoxDecoration(
+            color: Colors.white,
+            border: Border.all(color: const Color(0xFFE2E8F0)),
+            borderRadius: BorderRadius.circular(14),
+          ),
+          child: isCompact
+              ? Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    messageText,
+                    const SizedBox(height: 10),
+                    button,
+                  ],
+                )
+              : Row(
+                  children: [
+                    Container(
+                      width: 28,
+                      height: 28,
+                      decoration: BoxDecoration(
+                        color: const Color(0xFFEFF6FF),
+                        borderRadius: BorderRadius.circular(9),
+                      ),
+                      child: const Icon(
+                        Icons.account_tree_outlined,
+                        size: 16,
+                        color: Color(0xFF2563EB),
+                      ),
+                    ),
+                    const SizedBox(width: 10),
+                    Expanded(child: messageText),
+                    const SizedBox(width: 12),
+                    button,
+                  ],
+                ),
+        );
+      },
+    );
+  }
+}
+
+class _SubIssueCreateButton extends StatelessWidget {
+  const _SubIssueCreateButton({required this.isCreating, this.onPressed});
+
+  final bool isCreating;
+  final VoidCallback? onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return FilledButton.icon(
+      onPressed: onPressed,
+      icon: isCreating
+          ? const SizedBox.square(
+              dimension: 16,
+              child: CircularProgressIndicator(
+                strokeWidth: 2,
+                color: Colors.white,
+              ),
+            )
+          : const Icon(Icons.add_task_rounded, size: 18),
+      label: Text(isCreating ? '作成中...' : 'sub-issueを作成'),
+      style: FilledButton.styleFrom(
+        backgroundColor: const Color(0xFF0F766E),
+        foregroundColor: Colors.white,
+        disabledBackgroundColor: isCreating
+            ? const Color(0xFF0F766E)
+            : const Color(0xFFE2E8F0),
+        disabledForegroundColor: isCreating
+            ? Colors.white
+            : const Color(0xFF64748B),
+        elevation: 0,
+        minimumSize: const Size(148, 44),
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        textStyle: const TextStyle(
+          fontSize: 13,
+          fontWeight: FontWeight.w900,
+          letterSpacing: 0,
+        ),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      ),
+    );
+  }
+}
+
+List<IssueSubIssueReference> _mergedSubIssueReferences({
+  required List<Issue> linkedSubIssues,
+  required List<IssueSubIssueReference> storedSubIssues,
+}) {
+  final linkedIds = linkedSubIssues.map((issue) => issue.id).toSet();
+  final byKey = <String, IssueSubIssueReference>{};
+
+  for (final subIssue in storedSubIssues) {
+    if (subIssue.issueId.isNotEmpty && linkedIds.contains(subIssue.issueId)) {
+      continue;
+    }
+    final key = subIssue.issueId.isNotEmpty
+        ? subIssue.issueId
+        : subIssue.number.toString();
+    if (key.isNotEmpty) {
+      byKey[key] = subIssue;
+    }
+  }
+
+  return byKey.values.toList();
+}
+
+class _StatusAndPriorityFields extends StatelessWidget {
+  const _StatusAndPriorityFields({
+    required this.columns,
+    required this.selectedColumnId,
+    required this.priority,
+    required this.decorationBuilder,
+    required this.priorityLabelBuilder,
+    required this.onColumnChanged,
+    required this.onPriorityChanged,
+  });
+
+  final List<BoardColumn> columns;
+  final String selectedColumnId;
+  final Priority priority;
+  final InputDecoration Function({required String label, String? hint})
+  decorationBuilder;
+  final String Function(Priority priority) priorityLabelBuilder;
+  final ValueChanged<String> onColumnChanged;
+  final ValueChanged<Priority> onPriorityChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final statusField = DropdownButtonFormField<String>(
+          initialValue: selectedColumnId,
+          decoration: decorationBuilder(label: 'ステータス'),
+          items: [
+            for (final column in columns)
+              DropdownMenuItem(value: column.id, child: Text(column.title)),
+          ],
+          onChanged: (value) {
+            if (value == null) {
+              return;
+            }
+
+            onColumnChanged(value);
+          },
+        );
+        final priorityField = DropdownButtonFormField<Priority>(
+          initialValue: priority,
+          decoration: decorationBuilder(label: '優先度'),
+          items: [
+            for (final priority in Priority.values)
+              DropdownMenuItem(
+                value: priority,
+                child: Text(priorityLabelBuilder(priority)),
+              ),
+          ],
+          onChanged: (value) {
+            if (value == null) {
+              return;
+            }
+
+            onPriorityChanged(value);
+          },
+        );
+
+        if (constraints.maxWidth < 560) {
+          return Column(
+            children: [statusField, const SizedBox(height: 12), priorityField],
+          );
+        }
+
+        return Row(
+          children: [
+            Expanded(child: statusField),
+            const SizedBox(width: 12),
+            Expanded(child: priorityField),
+          ],
+        );
+      },
+    );
+  }
+}
+
+class DueDateField extends StatelessWidget {
+  const DueDateField({
+    super.key,
+    required this.dueDate,
+    required this.onPick,
+    required this.onClear,
+  });
+
+  final DateTime? dueDate;
+  final VoidCallback onPick;
+  final VoidCallback onClear;
+
+  @override
+  Widget build(BuildContext context) {
+    return InputDecorator(
+      decoration: InputDecoration(
+        labelText: '締切',
+        filled: true,
+        fillColor: const Color(0xFFF8FAFC),
+        border: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(16),
+          borderSide: const BorderSide(color: Color(0xFFE2E8F0)),
+        ),
+        enabledBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(16),
+          borderSide: const BorderSide(color: Color(0xFFE2E8F0)),
+        ),
+      ),
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          final dateLabel = Row(
+            children: [
+              const Icon(
+                Icons.calendar_today_outlined,
+                size: 18,
+                color: Color(0xFF64748B),
+              ),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Text(
+                  dueDate == null ? '締切なし' : formatDate(dueDate!),
+                  style: const TextStyle(
+                    color: Color(0xFF334155),
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+              ),
+            ],
+          );
+          final actions = Wrap(
+            spacing: 4,
+            crossAxisAlignment: WrapCrossAlignment.center,
+            children: [
+              TextButton(onPressed: onPick, child: const Text('日付を選択')),
+              if (dueDate != null)
+                IconButton(
+                  tooltip: '締切をクリア',
+                  onPressed: onClear,
+                  icon: const Icon(Icons.close_rounded, size: 18),
+                ),
+            ],
+          );
+
+          if (constraints.maxWidth < 360) {
+            return Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [dateLabel, const SizedBox(height: 8), actions],
+            );
+          }
+
+          return Row(
+            children: [
+              Expanded(child: dateLabel),
+              actions,
+            ],
+          );
+        },
+      ),
+    );
+  }
+}

--- a/apps/dashboard/lib/workspace/issue_board_ima_models.dart
+++ b/apps/dashboard/lib/workspace/issue_board_ima_models.dart
@@ -1,0 +1,886 @@
+import 'dart:async';
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'issue_board_ima_utils.dart';
+import 'issue_board_ima_app_shell.dart';
+
+typedef IssueDropCallback =
+    void Function({
+      required String issueId,
+      required String targetColumnId,
+      required int targetIndex,
+      bool clearPullRequests,
+    });
+
+typedef IssuePullRequestLinkCallback =
+    Future<void> Function({
+      required String issueId,
+      required String repository,
+      required IssuePullRequest pullRequest,
+    });
+
+typedef IssueWeightOverrideCallback =
+    Future<void> Function({
+      required String issueId,
+      required IssueWeightOverrideDraft draft,
+    });
+
+typedef IssuePullRequestCreateCallback =
+    Future<IssuePullRequest> Function({
+      required String issueId,
+      required String repository,
+      required String head,
+      required String base,
+      required String title,
+      required String body,
+    });
+
+typedef WorkspaceRecentBranchLoadCallback =
+    Future<WorkspaceRecentBranchList> Function();
+
+typedef WorkspaceRecentBranchCreatePullRequestCallback =
+    Future<IssuePullRequest> Function(WorkspaceRecentBranch branch);
+
+class IssueDragData {
+  const IssueDragData({required this.issueId, required this.sourceColumnId});
+
+  final String issueId;
+  final String sourceColumnId;
+}
+
+class CloseIssueDialogResult {
+  const CloseIssueDialogResult(this.issueId);
+
+  final String issueId;
+}
+
+class EditIssueDialogResult {
+  const EditIssueDialogResult({required this.issueId, required this.draft});
+
+  final String issueId;
+  final NewIssueDraft draft;
+}
+
+class IssueWeightOverrideDraft {
+  const IssueWeightOverrideDraft({
+    required this.estimateWeight,
+    this.actualWeight,
+  });
+
+  final int estimateWeight;
+  final int? actualWeight;
+}
+
+class NewIssueDraft {
+  const NewIssueDraft({
+    required this.title,
+    required this.body,
+    required this.repo,
+    required this.githubUrl,
+    required this.labels,
+    required this.columnId,
+    required this.priority,
+    required this.dueDate,
+  });
+
+  final String title;
+  final String body;
+  final String repo;
+  final String? githubUrl;
+  final List<String> labels;
+  final String columnId;
+  final Priority priority;
+  final DateTime? dueDate;
+}
+
+class BoardColumn {
+  const BoardColumn({
+    required this.id,
+    required this.title,
+    required this.description,
+    required this.color,
+    required this.issues,
+  });
+
+  final String id;
+  final String title;
+  final String description;
+  final Color color;
+  final List<Issue> issues;
+}
+
+class IssueResolution {
+  const IssueResolution({
+    this.actualWeight,
+    this.weightDelta,
+    this.cycleTimeMs,
+    this.leadTimeMs,
+    this.workStartSource = '',
+    this.actualWeightManualOverride = false,
+  });
+
+  static IssueResolution? fromMap(Map<String, dynamic> data) {
+    if (data.isEmpty) {
+      return null;
+    }
+    final hasActualWeight = data.containsKey('actualWeight');
+    final actualWeight = asInt(data['actualWeight']);
+    return IssueResolution(
+      actualWeight: hasActualWeight && actualWeight >= 0 ? actualWeight : null,
+      weightDelta: data['weightDelta'] is num
+          ? (data['weightDelta'] as num).toInt()
+          : null,
+      cycleTimeMs: data['cycleTimeMs'] is num
+          ? (data['cycleTimeMs'] as num).toInt()
+          : null,
+      leadTimeMs: data['leadTimeMs'] is num
+          ? (data['leadTimeMs'] as num).toInt()
+          : null,
+      workStartSource: asString(data['workStartSource']),
+      actualWeightManualOverride: data['actualWeightManualOverride'] == true,
+    );
+  }
+
+  final int? actualWeight;
+  final int? weightDelta;
+  final int? cycleTimeMs;
+  final int? leadTimeMs;
+  final String workStartSource;
+  final bool actualWeightManualOverride;
+}
+
+class IssueSubIssuesSummary {
+  const IssueSubIssuesSummary({
+    required this.total,
+    required this.completed,
+    required this.percentCompleted,
+  });
+
+  static IssueSubIssuesSummary? fromMap(Map<String, dynamic> data) {
+    final total = asInt(data['total']);
+    if (total <= 0) {
+      return null;
+    }
+    final completed = asInt(data['completed']).clamp(0, total).toInt();
+    final rawPercent = asInt(data['percentCompleted']);
+    final percentCompleted = rawPercent > 0
+        ? rawPercent.clamp(0, 100).toInt()
+        : ((completed / total) * 100).round();
+    return IssueSubIssuesSummary(
+      total: total,
+      completed: completed,
+      percentCompleted: percentCompleted,
+    );
+  }
+
+  double get progress => (percentCompleted / 100).clamp(0, 1).toDouble();
+
+  Map<String, Object> toFirestore() {
+    return {
+      'total': total,
+      'completed': completed,
+      'percentCompleted': percentCompleted,
+    };
+  }
+
+  final int total;
+  final int completed;
+  final int percentCompleted;
+}
+
+class IssueParentIssue {
+  const IssueParentIssue({
+    required this.issueId,
+    required this.nodeId,
+    required this.number,
+    this.url,
+  });
+
+  static IssueParentIssue? fromMap(Map<String, dynamic> data) {
+    if (data.isEmpty) {
+      return null;
+    }
+    final issueId = asString(data['issueId']);
+    final nodeId = asString(data['nodeId']);
+    final number = asInt(data['number']);
+    final url = normalizedOptionalUrl(asString(data['url']));
+    if (issueId.isEmpty && nodeId.isEmpty && number <= 0 && url == null) {
+      return null;
+    }
+    return IssueParentIssue(
+      issueId: issueId,
+      nodeId: nodeId,
+      number: number,
+      url: url,
+    );
+  }
+
+  final String issueId;
+  final String nodeId;
+  final int number;
+  final String? url;
+}
+
+class IssueSubIssueReference {
+  const IssueSubIssueReference({
+    required this.issueId,
+    required this.nodeId,
+    required this.number,
+    required this.title,
+    this.url,
+    required this.state,
+  });
+
+  static IssueSubIssueReference? fromMap(Map<String, dynamic> data) {
+    final title = asString(data['title']);
+    final number = asInt(data['number']);
+    if (title.isEmpty && number <= 0) {
+      return null;
+    }
+    return IssueSubIssueReference(
+      issueId: asString(data['issueId']),
+      nodeId: asString(data['nodeId']),
+      number: number,
+      title: title.isEmpty ? '#$number' : title,
+      url: normalizedOptionalUrl(asString(data['url'])),
+      state: asString(data['state'], 'open'),
+    );
+  }
+
+  final String issueId;
+  final String nodeId;
+  final int number;
+  final String title;
+  final String? url;
+  final String state;
+}
+
+class Issue {
+  const Issue({
+    required this.id,
+    String? displayId,
+    this.issueKey,
+    this.githubNumber = 0,
+    required this.repo,
+    required this.title,
+    this.body = '',
+    this.githubUrl,
+    required this.labels,
+    required this.comments,
+    required this.priority,
+    this.dueDate,
+    this.statusId = 'triage',
+    this.rank = 0,
+    this.closedAt,
+    this.weightEstimate,
+    this.resolution,
+    this.pullRequests = const [],
+    this.workBranch = '',
+    this.subIssuesSummary,
+    this.subIssues = const [],
+    this.parentIssue,
+    this.cursorAgent,
+  }) : displayId = displayId ?? issueKey ?? id;
+
+  factory Issue.fromDocument(DocumentSnapshot<Map<String, dynamic>> doc) {
+    final data = doc.data() ?? {};
+    final githubIssue = asMap(data['githubIssue']);
+    final number = asInt(githubIssue['number']);
+    final repo = asString(data['repo']);
+    final issueKey = asString(data['issueKey']);
+
+    return Issue(
+      id: doc.id,
+      issueKey: issueKey.isEmpty ? null : issueKey,
+      githubNumber: number,
+      displayId: issueKey.isNotEmpty
+          ? issueKey
+          : number > 0
+          ? '#$number'
+          : doc.id,
+      repo: repo,
+      title: asString(data['title'], '#$number'),
+      body: asString(data['body']),
+      githubUrl: normalizedOptionalUrl(asString(githubIssue['url'])),
+      labels: asStringList(data['labels']),
+      comments: asInt(data['comments']),
+      priority: priorityFromString(asString(data['priority'], 'medium')),
+      dueDate: asDate(data['dueDate']),
+      statusId: asString(data['statusId'], 'triage'),
+      rank: asDouble(data['rank']),
+      closedAt: asDate(data['closedAt']),
+      weightEstimate: IssueWeightEstimate.fromMap(
+        asMap(data['weightEstimate']),
+      ),
+      resolution: IssueResolution.fromMap(asMap(data['resolution'])),
+      pullRequests: asList(data['pullRequests'])
+          .map((value) => IssuePullRequest.fromMap(asMap(value)))
+          .where((pullRequest) => pullRequest.number > 0)
+          .toList(),
+      workBranch: asString(data['workBranch'] ?? data['branch']),
+      subIssuesSummary: IssueSubIssuesSummary.fromMap(
+        asMap(
+          githubIssue['subIssuesSummary'] ?? githubIssue['sub_issues_summary'],
+        ),
+      ),
+      subIssues: asList(githubIssue['subIssues'])
+          .map((value) => IssueSubIssueReference.fromMap(asMap(value)))
+          .whereType<IssueSubIssueReference>()
+          .toList(),
+      parentIssue: IssueParentIssue.fromMap(asMap(githubIssue['parentIssue'])),
+      cursorAgent: CursorAgentState.fromMap(asMap(data['cursorAgent'])),
+    );
+  }
+
+  Issue copyWith({
+    String? statusId,
+    double? rank,
+    DateTime? closedAt,
+    bool clearClosedAt = false,
+    List<IssuePullRequest>? pullRequests,
+  }) {
+    return Issue(
+      id: id,
+      displayId: displayId,
+      issueKey: issueKey,
+      githubNumber: githubNumber,
+      repo: repo,
+      title: title,
+      body: body,
+      githubUrl: githubUrl,
+      labels: labels,
+      comments: comments,
+      priority: priority,
+      dueDate: dueDate,
+      statusId: statusId ?? this.statusId,
+      rank: rank ?? this.rank,
+      closedAt: clearClosedAt ? null : closedAt ?? this.closedAt,
+      weightEstimate: weightEstimate,
+      resolution: resolution,
+      pullRequests: pullRequests ?? this.pullRequests,
+      workBranch: workBranch,
+      subIssuesSummary: subIssuesSummary,
+      subIssues: subIssues,
+      parentIssue: parentIssue,
+      cursorAgent: cursorAgent,
+    );
+  }
+
+  final String id;
+  final String displayId;
+  final String? issueKey;
+  final int githubNumber;
+  final String repo;
+  final String title;
+  final String body;
+  final String? githubUrl;
+  final List<String> labels;
+  final int comments;
+  final Priority priority;
+  final DateTime? dueDate;
+  final String statusId;
+  final double rank;
+  final DateTime? closedAt;
+  final IssueWeightEstimate? weightEstimate;
+  final IssueResolution? resolution;
+  final List<IssuePullRequest> pullRequests;
+  final String workBranch;
+  final IssueSubIssuesSummary? subIssuesSummary;
+  final List<IssueSubIssueReference> subIssues;
+  final IssueParentIssue? parentIssue;
+  final CursorAgentState? cursorAgent;
+}
+
+class CursorAgentState {
+  const CursorAgentState({
+    required this.status,
+    this.agentId = '',
+    this.runId = '',
+    this.errorMessage = '',
+  });
+
+  static CursorAgentState? fromMap(Map<String, dynamic> data) {
+    final status = asString(data['status']);
+    if (status.isEmpty) {
+      return null;
+    }
+
+    return CursorAgentState(
+      status: status,
+      agentId: asString(data['agentId']),
+      runId: asString(data['runId']),
+      errorMessage: asString(data['errorMessage']),
+    );
+  }
+
+  bool get isActive => status == 'starting' || status == 'running';
+
+  String get shortRunId {
+    if (runId.length <= 8) {
+      return runId;
+    }
+    return runId.substring(0, 8);
+  }
+
+  final String status;
+  final String agentId;
+  final String runId;
+  final String errorMessage;
+}
+
+class IssuePullRequest {
+  const IssuePullRequest({
+    required this.number,
+    required this.title,
+    this.url,
+    required this.state,
+    required this.merged,
+    required this.branch,
+    this.createdAt,
+    this.linkedIssues = const [],
+  });
+
+  factory IssuePullRequest.fromMap(Map<String, dynamic> data) {
+    return IssuePullRequest(
+      number: asInt(data['number']),
+      title: asString(data['title'], 'Pull request'),
+      url: normalizedOptionalUrl(asString(data['url'])),
+      state: asString(data['state'], 'open'),
+      merged: data['merged'] == true,
+      branch: asString(data['branch']),
+      createdAt: asDate(data['createdAt']),
+      linkedIssues: asList(data['linkedIssues'])
+          .map((value) => IssuePullRequestLinkedIssue.fromMap(asMap(value)))
+          .where((issue) => issue.number > 0)
+          .toList(),
+    );
+  }
+
+  Map<String, Object?> toFirestore({required String repository}) {
+    final parts = repository.split('/');
+    final owner = parts.isEmpty ? '' : parts.first;
+    final repo = parts.length > 1 ? parts[1] : '';
+    return {
+      'owner': owner,
+      'repo': repo,
+      'number': number,
+      'url': url,
+      'title': title,
+      'branch': branch,
+      'state': state,
+      'merged': merged,
+      if (createdAt != null) 'createdAt': Timestamp.fromDate(createdAt!),
+      'linkedIssues': [
+        for (final issue in linkedIssues) issue.toFirestore(),
+      ],
+    };
+  }
+
+  IssuePullRequest copyWith({String? state, bool? merged}) {
+    return IssuePullRequest(
+      number: number,
+      title: title,
+      url: url,
+      state: state ?? this.state,
+      merged: merged ?? this.merged,
+      branch: branch,
+      createdAt: createdAt,
+      linkedIssues: linkedIssues,
+    );
+  }
+
+  final int number;
+  final String title;
+  final String? url;
+  final String state;
+  final bool merged;
+  final String branch;
+  final DateTime? createdAt;
+  final List<IssuePullRequestLinkedIssue> linkedIssues;
+}
+
+class WorkspaceRecentBranchList {
+  const WorkspaceRecentBranchList({
+    required this.branches,
+    required this.repositories,
+  });
+
+  factory WorkspaceRecentBranchList.fromMap(Map<String, dynamic> data) {
+    return WorkspaceRecentBranchList(
+      branches: asList(data['branches'])
+          .map((value) => WorkspaceRecentBranch.fromMap(asMap(value)))
+          .where(
+            (branch) => branch.name.isNotEmpty && branch.repository.isNotEmpty,
+          )
+          .toList(),
+      repositories: asInt(data['repositories']),
+    );
+  }
+
+  final List<WorkspaceRecentBranch> branches;
+  final int repositories;
+}
+
+class WorkspaceRecentBranch {
+  const WorkspaceRecentBranch({
+    required this.repository,
+    required this.name,
+    this.sha = '',
+    this.base = 'main',
+    this.pushedAt,
+    this.issueId = '',
+    this.issueKey = '',
+    this.issueTitle = '',
+    this.issueStatusId = '',
+  });
+
+  factory WorkspaceRecentBranch.fromMap(Map<String, dynamic> data) {
+    final issue = asMap(data['issue']);
+    return WorkspaceRecentBranch(
+      repository: asString(data['repository']),
+      name: asString(data['name']),
+      sha: asString(data['sha']),
+      base: asString(data['base'], 'main'),
+      pushedAt: DateTime.tryParse(asString(data['pushedAt'])),
+      issueId: asString(issue['id']),
+      issueKey: asString(issue['issueKey'], asString(issue['displayId'])),
+      issueTitle: asString(issue['title']),
+      issueStatusId: asString(issue['statusId']),
+    );
+  }
+
+  String get key => '$repository:$name';
+
+  bool get hasIssue => issueId.isNotEmpty;
+
+  final String repository;
+  final String name;
+  final String sha;
+  final String base;
+  final DateTime? pushedAt;
+  final String issueId;
+  final String issueKey;
+  final String issueTitle;
+  final String issueStatusId;
+}
+
+class IssuePullRequestLinkedIssue {
+  const IssuePullRequestLinkedIssue({
+    required this.number,
+    required this.title,
+    this.url,
+    required this.state,
+  });
+
+  factory IssuePullRequestLinkedIssue.fromMap(Map<String, dynamic> data) {
+    final number = asInt(data['number']);
+    return IssuePullRequestLinkedIssue(
+      number: number,
+      title: asString(data['title'], '#$number'),
+      url: normalizedOptionalUrl(asString(data['url'])),
+      state: asString(data['state'], 'open').toLowerCase(),
+    );
+  }
+
+  Map<String, Object?> toFirestore() {
+    return {
+      'number': number,
+      'title': title,
+      'url': url,
+      'state': state,
+    };
+  }
+
+  final int number;
+  final String title;
+  final String? url;
+  final String state;
+}
+
+class IssuePullRequestDiff {
+  const IssuePullRequestDiff({
+    required this.repository,
+    required this.pullRequestNumber,
+    required this.title,
+    required this.url,
+    required this.state,
+    required this.merged,
+    this.mergeable,
+    this.mergeableState = '',
+    required this.branch,
+    required this.additions,
+    required this.deletions,
+    required this.changedFiles,
+    required this.ci,
+    required this.comments,
+    required this.commentsTruncated,
+    required this.filesTruncated,
+    required this.files,
+  });
+
+  factory IssuePullRequestDiff.fromMap(Map<String, dynamic> data) {
+    return IssuePullRequestDiff(
+      repository: asString(data['repository']),
+      pullRequestNumber: asInt(data['pullRequestNumber']),
+      title: asString(data['title'], 'Pull request'),
+      url: asString(data['url']),
+      state: asString(data['state'], 'open'),
+      merged: data['merged'] == true,
+      mergeable: data['mergeable'] is bool ? data['mergeable'] as bool : null,
+      mergeableState: asString(data['mergeableState']),
+      branch: asString(data['branch']),
+      additions: asInt(data['additions']),
+      deletions: asInt(data['deletions']),
+      changedFiles: asInt(data['changedFiles']),
+      ci: PullRequestCiSummary.fromMap(asMap(data['ci'])),
+      comments: asList(data['comments'])
+          .map((value) => IssuePullRequestComment.fromMap(asMap(value)))
+          .where((comment) => comment.body.isNotEmpty)
+          .toList(),
+      commentsTruncated: data['commentsTruncated'] == true,
+      filesTruncated: data['filesTruncated'] == true,
+      files: asList(data['files'])
+          .map((value) => IssuePullRequestDiffFile.fromMap(asMap(value)))
+          .where((file) => file.filename.isNotEmpty)
+          .toList(),
+    );
+  }
+
+  final String repository;
+  final int pullRequestNumber;
+  final String title;
+  final String url;
+  final String state;
+  final bool merged;
+  final bool? mergeable;
+  final String mergeableState;
+  final String branch;
+  final int additions;
+  final int deletions;
+  final int changedFiles;
+  final PullRequestCiSummary ci;
+  final List<IssuePullRequestComment> comments;
+  final bool commentsTruncated;
+  final bool filesTruncated;
+  final List<IssuePullRequestDiffFile> files;
+}
+
+enum IssuePullRequestCommentKind { conversation, review }
+
+class IssuePullRequestComment {
+  const IssuePullRequestComment({
+    required this.id,
+    required this.author,
+    required this.authorAssociation,
+    required this.body,
+    required this.url,
+    required this.createdAt,
+    required this.updatedAt,
+    required this.kind,
+    this.path,
+    this.line,
+    this.side,
+    this.inReplyToId,
+  });
+
+  factory IssuePullRequestComment.fromMap(Map<String, dynamic> data) {
+    final line = asInt(data['line']);
+    return IssuePullRequestComment(
+      id: asString(data['id']),
+      author: asString(data['author'], 'unknown'),
+      authorAssociation: asString(data['authorAssociation']),
+      body: asString(data['body']),
+      url: asString(data['url']),
+      createdAt: asString(data['createdAt']),
+      updatedAt: asString(data['updatedAt']),
+      kind: asString(data['kind']) == 'review'
+          ? IssuePullRequestCommentKind.review
+          : IssuePullRequestCommentKind.conversation,
+      path: emptyToNull(asString(data['path'])),
+      line: line > 0 ? line : null,
+      side: emptyToNull(asString(data['side'])),
+      inReplyToId: emptyToNull(asString(data['inReplyToId'])),
+    );
+  }
+
+  final String id;
+  final String author;
+  final String authorAssociation;
+  final String body;
+  final String url;
+  final String createdAt;
+  final String updatedAt;
+  final IssuePullRequestCommentKind kind;
+  final String? path;
+  final int? line;
+  final String? side;
+  final String? inReplyToId;
+}
+
+enum PullRequestCiStatus { success, failure, pending, none, unknown }
+
+class PullRequestCiSummary {
+  const PullRequestCiSummary({
+    required this.status,
+    required this.total,
+    required this.passed,
+    required this.failed,
+    required this.pending,
+    required this.skipped,
+    required this.checksTruncated,
+  });
+
+  factory PullRequestCiSummary.fromMap(Map<String, dynamic> data) {
+    return PullRequestCiSummary(
+      status: switch (asString(data['status'])) {
+        'success' => PullRequestCiStatus.success,
+        'failure' => PullRequestCiStatus.failure,
+        'pending' => PullRequestCiStatus.pending,
+        'unknown' => PullRequestCiStatus.unknown,
+        _ => PullRequestCiStatus.none,
+      },
+      total: asInt(data['total']),
+      passed: asInt(data['passed']),
+      failed: asInt(data['failed']),
+      pending: asInt(data['pending']),
+      skipped: asInt(data['skipped']),
+      checksTruncated: data['checksTruncated'] == true,
+    );
+  }
+
+  final PullRequestCiStatus status;
+  final int total;
+  final int passed;
+  final int failed;
+  final int pending;
+  final int skipped;
+  final bool checksTruncated;
+
+  bool get allPassed => status == PullRequestCiStatus.success && total > 0;
+}
+
+class IssuePullRequestDiffFile {
+  const IssuePullRequestDiffFile({
+    required this.filename,
+    required this.status,
+    required this.additions,
+    required this.deletions,
+    required this.changes,
+    required this.patch,
+    required this.patchTruncated,
+    required this.blobUrl,
+    required this.rawUrl,
+    this.previousFilename,
+  });
+
+  factory IssuePullRequestDiffFile.fromMap(Map<String, dynamic> data) {
+    final previousFilename = asString(data['previousFilename']);
+    return IssuePullRequestDiffFile(
+      filename: asString(data['filename']),
+      status: asString(data['status'], 'modified'),
+      additions: asInt(data['additions']),
+      deletions: asInt(data['deletions']),
+      changes: asInt(data['changes']),
+      patch: asString(data['patch']),
+      patchTruncated: data['patchTruncated'] == true,
+      blobUrl: asString(data['blobUrl']),
+      rawUrl: asString(data['rawUrl']),
+      previousFilename: previousFilename.isEmpty ? null : previousFilename,
+    );
+  }
+
+  final String filename;
+  final String status;
+  final int additions;
+  final int deletions;
+  final int changes;
+  final String patch;
+  final bool patchTruncated;
+  final String blobUrl;
+  final String rawUrl;
+  final String? previousFilename;
+}
+
+class IssueWeightEstimate {
+  const IssueWeightEstimate({
+    required this.status,
+    this.value,
+    this.confidence = 0,
+    this.reason = '',
+    this.model = '',
+    this.promptVersion = '',
+    this.inputHash = '',
+    this.source = '',
+    this.manualOverride = false,
+    this.estimatedAt,
+    this.error,
+  });
+
+  static IssueWeightEstimate? fromMap(Map<String, dynamic> data) {
+    if (data.isEmpty) {
+      return null;
+    }
+    final hasValue = data.containsKey('value');
+    final value = asInt(data['value']);
+    final normalizedValue = hasValue && value >= 0 ? value : null;
+    return IssueWeightEstimate(
+      status: asString(
+        data['status'],
+        normalizedValue == null ? 'unknown' : 'done',
+      ),
+      value: normalizedValue,
+      confidence: asDouble(data['confidence']),
+      reason: asString(data['reason']),
+      model: asString(data['model']),
+      promptVersion: asString(data['promptVersion']),
+      inputHash: asString(data['inputHash']),
+      source: asString(data['source']),
+      manualOverride: data['manualOverride'] == true,
+      estimatedAt: asDate(data['estimatedAt']),
+      error: asString(data['error']).isEmpty ? null : asString(data['error']),
+    );
+  }
+
+  final String status;
+  final int? value;
+  final double confidence;
+  final String reason;
+  final String model;
+  final String promptVersion;
+  final String inputHash;
+  final String source;
+  final bool manualOverride;
+  final DateTime? estimatedAt;
+  final String? error;
+}
+
+class GitHubRepository {
+  const GitHubRepository({
+    required this.fullName,
+    required this.name,
+    required this.owner,
+    required this.private,
+    required this.defaultBranch,
+  });
+
+  factory GitHubRepository.fromMap(Map<String, dynamic> data) {
+    final fullName = asString(data['fullName']);
+    final parts = fullName.split('/');
+
+    return GitHubRepository(
+      fullName: fullName,
+      name: asString(data['name'], parts.length > 1 ? parts[1] : fullName),
+      owner: asString(data['owner'], parts.isEmpty ? '' : parts.first),
+      private: data['private'] == true,
+      defaultBranch: asString(data['defaultBranch'], 'main'),
+    );
+  }
+
+  final String fullName;
+  final String name;
+  final String owner;
+  final bool private;
+  final String defaultBranch;
+}

--- a/apps/dashboard/lib/workspace/issue_board_ima_navigation.dart
+++ b/apps/dashboard/lib/workspace/issue_board_ima_navigation.dart
@@ -1,0 +1,470 @@
+import 'dart:async';
+
+import 'package:dashboard/build_info.dart';
+import 'package:dashboard/build_logs/build_logs_page.dart';
+import 'package:dashboard/store_release/store_release_page.dart';
+import 'package:dashboard/variables/variables_page.dart';
+import 'package:dashboard/workers/worker_status_page.dart';
+import 'package:dashboard/workflow/list/workflows_page.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'issue_board_ima_app_shell.dart';
+
+class CompactDestinationBody extends StatelessWidget {
+  const CompactDestinationBody({super.key, required this.destination});
+
+  final CompactBoardDestination destination;
+
+  @override
+  Widget build(BuildContext context) {
+    return switch (destination) {
+      CompactBoardDestination.issueBoard => const SizedBox.shrink(),
+      CompactBoardDestination.runs => const LogsBody(),
+      CompactBoardDestination.workers => const WorkerStatusBody(),
+      CompactBoardDestination.workflows => const WorkflowsBody(),
+      CompactBoardDestination.variables => const VariablesBody(),
+      CompactBoardDestination.storeRelease => const StoreReleaseBody(),
+    };
+  }
+}
+
+class DesktopBoardNavigationRail extends StatelessWidget {
+  const DesktopBoardNavigationRail({
+    super.key,
+    required this.selectedDestination,
+    required this.workspaceName,
+    required this.extended,
+    required this.onSignOut,
+    required this.onCollapsedChanged,
+    required this.onDestinationSelected,
+    this.onSwitchTeam,
+  });
+
+  final CompactBoardDestination selectedDestination;
+  final String workspaceName;
+  final bool extended;
+  final Future<void> Function() onSignOut;
+  final ValueChanged<bool> onCollapsedChanged;
+  final ValueChanged<CompactBoardDestination> onDestinationSelected;
+  final VoidCallback? onSwitchTeam;
+
+  @override
+  Widget build(BuildContext context) {
+    final selectedIndex = boardNavigationDestinations.indexOf(
+      selectedDestination,
+    );
+
+    return SizedBox(
+      width: extended ? 216 : 80,
+      child: NavigationRail(
+        backgroundColor: const Color(0xFFF8FAFC),
+        extended: extended,
+        minWidth: 80,
+        minExtendedWidth: 216,
+        groupAlignment: -1,
+        selectedIndex: selectedIndex < 0 ? 0 : selectedIndex,
+        labelType: extended ? null : NavigationRailLabelType.all,
+        leading: _DesktopRailHeader(
+          extended: extended,
+          onCollapsedChanged: onCollapsedChanged,
+        ),
+        trailing: _DesktopRailAccountSection(
+          extended: extended,
+          workspaceName: workspaceName,
+          onSwitchTeam: onSwitchTeam,
+          onSignOut: onSignOut,
+        ),
+        destinations: [
+          for (final destination in boardNavigationDestinations)
+            NavigationRailDestination(
+              icon: Icon(destination.icon),
+              selectedIcon: Icon(destination.selectedIcon),
+              label: Text(destination.label),
+            ),
+        ],
+        onDestinationSelected: (index) {
+          onDestinationSelected(boardNavigationDestinations[index]);
+        },
+      ),
+    );
+  }
+}
+
+class _DesktopRailHeader extends StatelessWidget {
+  const _DesktopRailHeader({
+    required this.extended,
+    required this.onCollapsedChanged,
+  });
+
+  final bool extended;
+  final ValueChanged<bool> onCollapsedChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    if (!extended) {
+      return Padding(
+        padding: const EdgeInsets.fromLTRB(8, 16, 8, 20),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const _OpenCiMark(),
+            const SizedBox(height: 12),
+            IconButton.filledTonal(
+              tooltip: 'ナビゲーションを展開',
+              onPressed: () => onCollapsedChanged(false),
+              icon: const Icon(Icons.chevron_right_rounded),
+            ),
+          ],
+        ),
+      );
+    }
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(20, 16, 12, 20),
+      child: Row(
+        children: [
+          const _OpenCiMark(),
+          const SizedBox(width: 12),
+          const Expanded(
+            child: Text(
+              'OpenCI',
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: TextStyle(
+                color: Color(0xFF0F172A),
+                fontSize: 18,
+                fontWeight: FontWeight.w900,
+              ),
+            ),
+          ),
+          const SizedBox(width: 4),
+          IconButton(
+            tooltip: 'ナビゲーションを折りたたむ',
+            onPressed: () => onCollapsedChanged(true),
+            icon: const Icon(Icons.chevron_left_rounded),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _OpenCiMark extends StatelessWidget {
+  const _OpenCiMark();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 40,
+      height: 40,
+      alignment: Alignment.center,
+      decoration: BoxDecoration(
+        color: const Color(0xFFEFF6FF),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: const Color(0xFFBFDBFE)),
+      ),
+      child: const Text(
+        'OC',
+        style: TextStyle(
+          color: Color(0xFF1D4ED8),
+          fontSize: 14,
+          fontWeight: FontWeight.w900,
+          letterSpacing: 0,
+        ),
+      ),
+    );
+  }
+}
+
+class _DesktopRailAccountSection extends StatelessWidget {
+  const _DesktopRailAccountSection({
+    required this.extended,
+    required this.workspaceName,
+    required this.onSignOut,
+    this.onSwitchTeam,
+  });
+
+  final bool extended;
+  final String workspaceName;
+  final Future<void> Function() onSignOut;
+  final VoidCallback? onSwitchTeam;
+
+  @override
+  Widget build(BuildContext context) {
+    if (!extended) {
+      return Padding(
+        padding: const EdgeInsets.fromLTRB(8, 18, 8, 16),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const _DesktopRailBuildInfo(extended: false),
+            if (_railBuildUpdatedAt != null) const SizedBox(height: 4),
+            if (onSwitchTeam != null) ...[
+              IconButton(
+                tooltip: workspaceName,
+                onPressed: onSwitchTeam,
+                icon: const Icon(Icons.groups_2_outlined),
+              ),
+              const SizedBox(height: 4),
+            ],
+            IconButton(
+              tooltip: 'サインアウト',
+              onPressed: () => unawaited(onSignOut()),
+              icon: const Icon(Icons.logout_rounded),
+            ),
+          ],
+        ),
+      );
+    }
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(12, 18, 12, 16),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          const _DesktopRailBuildInfo(extended: true),
+          if (_railBuildUpdatedAt != null) const SizedBox(height: 10),
+          if (onSwitchTeam != null) ...[
+            _DesktopRailActionTile(
+              icon: Icons.groups_2_outlined,
+              label: workspaceName,
+              onTap: onSwitchTeam!,
+            ),
+            const SizedBox(height: 8),
+          ],
+          _DesktopRailActionTile(
+            icon: Icons.logout_rounded,
+            label: 'サインアウト',
+            onTap: () => unawaited(onSignOut()),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _DesktopRailBuildInfo extends StatelessWidget {
+  const _DesktopRailBuildInfo({required this.extended});
+
+  final bool extended;
+
+  @override
+  Widget build(BuildContext context) {
+    final updatedAt = _railBuildUpdatedAt;
+    if (updatedAt == null) {
+      return const SizedBox.shrink();
+    }
+
+    final fullText = _formatRailBuildUpdatedText(updatedAt);
+    if (!extended) {
+      return Tooltip(
+        message: '最終更新: $fullText',
+        child: _AnimatedRailInk(
+          borderRadius: BorderRadius.circular(12),
+          onTap: () => unawaited(launchUrlExternal(openCiRepositoryUrl)),
+          child: Ink(
+            width: 40,
+            height: 40,
+            decoration: BoxDecoration(
+              color: const Color(0xFFEFF6FF),
+              borderRadius: BorderRadius.circular(12),
+              border: Border.all(color: const Color(0xFFBFDBFE)),
+            ),
+            child: const Icon(
+              Icons.update_rounded,
+              size: 20,
+              color: Color(0xFF2563EB),
+            ),
+          ),
+        ),
+      );
+    }
+
+    return _AnimatedRailInk(
+      borderRadius: BorderRadius.circular(16),
+      onTap: () => unawaited(launchUrlExternal(openCiRepositoryUrl)),
+      child: Ink(
+        padding: const EdgeInsets.all(12),
+        decoration: BoxDecoration(
+          color: const Color(0xFFFFFFFF),
+          borderRadius: BorderRadius.circular(16),
+          border: Border.all(color: const Color(0xFFE2E8F0)),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withValues(alpha: 0.03),
+              blurRadius: 12,
+              offset: const Offset(0, 6),
+            ),
+          ],
+        ),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Container(
+              width: 30,
+              height: 30,
+              decoration: BoxDecoration(
+                color: const Color(0xFFEFF6FF),
+                borderRadius: BorderRadius.circular(10),
+              ),
+              child: const Icon(
+                Icons.update_rounded,
+                size: 17,
+                color: Color(0xFF2563EB),
+              ),
+            ),
+            const SizedBox(width: 10),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const Text(
+                    '最終更新',
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: TextStyle(
+                      color: Color(0xFF64748B),
+                      fontSize: 11,
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    fullText,
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                    style: const TextStyle(
+                      color: Color(0xFF0F172A),
+                      fontSize: 12,
+                      fontWeight: FontWeight.w800,
+                      height: 1.25,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _AnimatedRailInk extends StatefulWidget {
+  const _AnimatedRailInk({
+    required this.borderRadius,
+    required this.onTap,
+    required this.child,
+  });
+
+  final BorderRadius borderRadius;
+  final VoidCallback onTap;
+  final Widget child;
+
+  @override
+  State<_AnimatedRailInk> createState() => _AnimatedRailInkState();
+}
+
+class _AnimatedRailInkState extends State<_AnimatedRailInk> {
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: Colors.transparent,
+      borderRadius: widget.borderRadius,
+      clipBehavior: Clip.antiAlias,
+      child: InkWell(
+        borderRadius: widget.borderRadius,
+        mouseCursor: SystemMouseCursors.click,
+        onTap: widget.onTap,
+        overlayColor: WidgetStateProperty.resolveWith((states) {
+          if (states.contains(WidgetState.pressed)) {
+            return const Color(0xFF2563EB).withValues(alpha: 0.14);
+          }
+          if (states.contains(WidgetState.hovered)) {
+            return const Color(0xFF2563EB).withValues(alpha: 0.08);
+          }
+          return null;
+        }),
+        child: widget.child,
+      ),
+    );
+  }
+}
+
+String _formatRailBuildUpdatedText(DateTime updatedAt) {
+  final formattedDate = DateFormat('MM/dd HH:mm').format(updatedAt);
+  final sha = _railBuildSha;
+  final shaSuffix = sha.isEmpty ? '' : ' ($sha)';
+  return '$formattedDate$shaSuffix';
+}
+
+DateTime? get _railBuildUpdatedAt {
+  final updatedAt = BuildInfo.updatedAt;
+  if (updatedAt != null) {
+    return updatedAt;
+  }
+
+  return kDebugMode
+      ? DateTime.now().subtract(const Duration(minutes: 42))
+      : null;
+}
+
+String get _railBuildSha {
+  if (BuildInfo.sha.isNotEmpty) {
+    return BuildInfo.sha;
+  }
+
+  return kDebugMode ? 'mock' : '';
+}
+
+class _DesktopRailActionTile extends StatelessWidget {
+  const _DesktopRailActionTile({
+    required this.icon,
+    required this.label,
+    required this.onTap,
+  });
+
+  final IconData icon;
+  final String label;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: Colors.white,
+      borderRadius: BorderRadius.circular(14),
+      clipBehavior: Clip.antiAlias,
+      child: InkWell(
+        onTap: onTap,
+        child: Container(
+          height: 44,
+          padding: const EdgeInsets.symmetric(horizontal: 12),
+          decoration: BoxDecoration(
+            border: Border.all(color: const Color(0xFFE2E8F0)),
+            borderRadius: BorderRadius.circular(14),
+          ),
+          child: Row(
+            children: [
+              Icon(icon, size: 18, color: const Color(0xFF475569)),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  label,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: const TextStyle(
+                    color: Color(0xFF334155),
+                    fontWeight: FontWeight.w700,
+                    fontSize: 13,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/apps/dashboard/lib/workspace/issue_board_ima_overview.dart
+++ b/apps/dashboard/lib/workspace/issue_board_ima_overview.dart
@@ -1,0 +1,2504 @@
+import 'dart:async';
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:dashboard/build_logs/build_logs_page.dart';
+import 'package:dashboard/build_logs/synced_spinner.dart';
+import 'package:dashboard/firebase/firestore.dart'
+    show
+        BuildJobStatus,
+        buildJobStatusFromFirestore,
+        dateTimeFromFirestore,
+        workerInstancesCollection;
+import 'package:dashboard/store_release/store_release_page.dart';
+import 'package:dashboard/variables/variables_page.dart';
+import 'package:dashboard/workflow/list/workflows_page.dart';
+import 'package:flutter/material.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+import 'package:go_router/go_router.dart';
+import 'issue_board_ima_utils.dart';
+import 'issue_board_ima_toolbar_search.dart';
+import 'issue_board_ima_issue_editor.dart';
+import 'issue_board_ima_models.dart';
+import 'issue_board_ima_app_shell.dart';
+
+class BoardHeader extends StatelessWidget {
+  const BoardHeader({
+    super.key,
+    required this.openIssues,
+    required this.closedIssues,
+    required this.dailyProgressStats,
+    required this.onChangeDailyWeightTarget,
+    required this.onWorkerOverviewTap,
+    this.recentBranches,
+  });
+
+  final int openIssues;
+  final List<Issue> closedIssues;
+  final DailyProgressStats dailyProgressStats;
+  final VoidCallback onChangeDailyWeightTarget;
+  final VoidCallback onWorkerOverviewTap;
+  final Widget? recentBranches;
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final isCompact = constraints.maxWidth < 520;
+        final title = Text(
+          'OpenCI',
+          style:
+              (isCompact ? textTheme.headlineSmall : textTheme.headlineMedium)
+                  ?.copyWith(fontWeight: FontWeight.w700, letterSpacing: 0),
+        );
+        if (isCompact) {
+          return Padding(
+            padding: const EdgeInsets.fromLTRB(16, 14, 16, 6),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                title,
+                const SizedBox(height: 10),
+                DailyProgressStrip(
+                  stats: dailyProgressStats,
+                  isCompact: true,
+                  onTap: onChangeDailyWeightTarget,
+                ),
+              ],
+            ),
+          );
+        }
+
+        return Padding(
+          padding: const EdgeInsets.fromLTRB(20, 14, 20, 8),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.center,
+                children: [Expanded(child: title)],
+              ),
+              const SizedBox(height: 10),
+              Align(
+                alignment: Alignment.centerLeft,
+                child: ConstrainedBox(
+                  constraints: BoxConstraints(
+                    maxWidth: recentBranches == null ? 820 : 940,
+                  ),
+                  child: BoardOverviewPanel(
+                    openIssues: openIssues,
+                    closedIssues: closedIssues,
+                    dailyProgressStats: dailyProgressStats,
+                    onDailyProgressTap: onChangeDailyWeightTarget,
+                    onWorkerOverviewTap: onWorkerOverviewTap,
+                    recentBranches: recentBranches,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}
+
+class TeamSwitcherButton extends StatelessWidget {
+  const TeamSwitcherButton({
+    super.key,
+    required this.workspaceName,
+    required this.onPressed,
+  });
+
+  final String workspaceName;
+  final VoidCallback? onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return Tooltip(
+      message: 'チーム切替',
+      child: OutlinedButton.icon(
+        onPressed: onPressed,
+        icon: const Icon(Icons.groups_2_outlined, size: 18),
+        label: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 180),
+          child: Text(
+            workspaceName,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          ),
+        ),
+        style: OutlinedButton.styleFrom(
+          foregroundColor: const Color(0xFF334155),
+          backgroundColor: Colors.white,
+          side: const BorderSide(color: Color(0xFFE2E8F0)),
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(14),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class IssueCountBadge extends StatelessWidget {
+  const IssueCountBadge({super.key, required this.openIssues});
+
+  final int openIssues;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        border: Border.all(color: const Color(0xFFE2E8F0)),
+        borderRadius: BorderRadius.circular(14),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.end,
+        children: [
+          Text(
+            '$openIssues',
+            style: Theme.of(
+              context,
+            ).textTheme.titleLarge?.copyWith(fontWeight: FontWeight.w700),
+          ),
+          const Text(
+            '未完了issue',
+            style: TextStyle(color: Color(0xFF64748B), fontSize: 12),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class EstimationAccuracyBadge extends StatelessWidget {
+  const EstimationAccuracyBadge({super.key, required this.closedIssues});
+
+  static const _validWeights = [1, 2, 4, 8, 16, 32];
+
+  static bool _isAdjacent(int a, int b) {
+    final idxA = _validWeights.indexOf(a);
+    final idxB = _validWeights.indexOf(b);
+    if (idxA < 0 || idxB < 0) return (a - b).abs() <= 1;
+    return (idxA - idxB).abs() <= 1;
+  }
+
+  final List<Issue> closedIssues;
+
+  @override
+  Widget build(BuildContext context) {
+    final pairs = closedIssues
+        .where(
+          (issue) =>
+              issue.resolution?.actualWeight != null &&
+              issue.weightEstimate?.value != null,
+        )
+        .toList();
+
+    if (pairs.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    final adjacentCount = pairs
+        .where(
+          (issue) => _isAdjacent(
+            issue.weightEstimate!.value!,
+            issue.resolution!.actualWeight!,
+          ),
+        )
+        .length;
+    final within1Rate = (adjacentCount / pairs.length * 100).round();
+    final deltas = pairs
+        .map(
+          (issue) =>
+              issue.weightEstimate!.value! - issue.resolution!.actualWeight!,
+        )
+        .toList();
+    final sumAbsError = deltas.fold<int>(0, (s, d) => s + d.abs());
+    final mae = (sumAbsError / deltas.length * 10).round() / 10;
+    final sumDelta = deltas.fold<int>(0, (s, d) => s + d);
+    final bias = (sumDelta / deltas.length * 10).round() / 10;
+
+    final biasLabel = bias == 0
+        ? 'バイアスなし'
+        : bias > 0
+        ? '過大推定 +$bias'
+        : '過小推定 $bias';
+    final accuracyColor = within1Rate >= 70
+        ? const Color(0xFF15803D)
+        : within1Rate >= 50
+        ? const Color(0xFFA16207)
+        : const Color(0xFFDC2626);
+
+    return Tooltip(
+      message: 'MAE $mae / $biasLabel / ${pairs.length}件',
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+        decoration: BoxDecoration(
+          color: Colors.white,
+          border: Border.all(color: const Color(0xFFE2E8F0)),
+          borderRadius: BorderRadius.circular(14),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.end,
+          children: [
+            Text(
+              '$within1Rate%',
+              style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                fontWeight: FontWeight.w700,
+                color: accuracyColor,
+              ),
+            ),
+            const Text(
+              '推定精度 (隣接値)',
+              style: TextStyle(color: Color(0xFF64748B), fontSize: 12),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class BoardOverviewPanel extends StatelessWidget {
+  const BoardOverviewPanel({
+    super.key,
+    required this.openIssues,
+    required this.closedIssues,
+    required this.dailyProgressStats,
+    required this.onDailyProgressTap,
+    required this.onWorkerOverviewTap,
+    this.recentBranches,
+  });
+
+  final int openIssues;
+  final List<Issue> closedIssues;
+  final DailyProgressStats dailyProgressStats;
+  final VoidCallback onDailyProgressTap;
+  final VoidCallback onWorkerOverviewTap;
+  final Widget? recentBranches;
+
+  @override
+  Widget build(BuildContext context) {
+    final accuracy = EstimationAccuracySummary.fromIssues(closedIssues);
+
+    return Material(
+      color: Colors.white,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(18),
+        side: const BorderSide(color: Color(0xFFE2E8F0)),
+      ),
+      clipBehavior: Clip.antiAlias,
+      child: IntrinsicHeight(
+        child: Row(
+          children: [
+            Expanded(
+              child: DailyProgressOverview(
+                stats: dailyProgressStats,
+                onTap: onDailyProgressTap,
+              ),
+            ),
+            const _OverviewDivider(),
+            Tooltip(
+              message:
+                  '${dailyProgressStats.prediction.advice} / 午後中央値 W${dailyProgressStats.prediction.historicalAfternoonMedian.toStringAsFixed(1)} / ${dailyProgressStats.prediction.sampleCount}日',
+              child: OverviewMetric(
+                label: '見込み',
+                value: '${dailyProgressStats.prediction.finishProbability}%',
+                valueColor: dailyProgressStats.prediction.color,
+                detail: dailyProgressStats.prediction.paceLabel,
+              ),
+            ),
+            const _OverviewDivider(),
+            OverviewMetric(
+              label: '未完了',
+              value: '$openIssues',
+              detail: 'issue',
+            ),
+            if (accuracy != null) ...[
+              const _OverviewDivider(),
+              Tooltip(
+                message:
+                    'MAE ${accuracy.mae} / ${accuracy.biasLabel} / ${accuracy.sampleCount}件',
+                child: OverviewMetric(
+                  label: '精度',
+                  value: '${accuracy.within1Rate}%',
+                  valueColor: accuracy.color,
+                  detail: '±1',
+                ),
+              ),
+            ],
+            const _OverviewDivider(),
+            WorkerOverviewMetric(onTap: onWorkerOverviewTap),
+            if (recentBranches != null) ...[
+              const _OverviewDivider(),
+              recentBranches!,
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class WorkerOverviewMetric extends StatelessWidget {
+  const WorkerOverviewMetric({super.key, required this.onTap});
+
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
+      stream: FirebaseFirestore.instance
+          .collection(workerInstancesCollection)
+          .snapshots(),
+      builder: (context, snapshot) {
+        if (snapshot.hasError) {
+          return _WorkerOverviewTapTarget(
+            onTap: onTap,
+            child: const OverviewMetric(
+              label: 'ワーカー',
+              value: '-',
+              detail: '読み込みエラー',
+              valueColor: Color(0xFFDC2626),
+              width: 112,
+            ),
+          );
+        }
+        if (!snapshot.hasData) {
+          return _WorkerOverviewTapTarget(
+            onTap: onTap,
+            child: const OverviewMetric(
+              label: 'ワーカー',
+              value: '-',
+              detail: '読み込み中',
+              width: 112,
+            ),
+          );
+        }
+
+        final summary = WorkerOverviewSummary.fromDocs(snapshot.data!.docs);
+        final valueColor = summary.offlineCount > 0
+            ? const Color(0xFFA16207)
+            : const Color(0xFF16A34A);
+        return Tooltip(
+          message:
+              'macOS ${summary.onlineMacos}/${summary.totalMacos} オンライン / '
+              'Linux ${summary.onlineLinux}/${summary.totalLinux} オンライン / '
+              'オフライン ${summary.offlineCount}',
+          child: _WorkerOverviewTapTarget(
+            onTap: onTap,
+            child: OverviewMetric(
+              label: 'ワーカー',
+              value: '${summary.onlineCount}/${summary.totalCount}',
+              valueColor: valueColor,
+              detail:
+                  'mac ${summary.onlineMacos} / linux ${summary.onlineLinux}',
+              width: 112,
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _WorkerOverviewTapTarget extends StatelessWidget {
+  const _WorkerOverviewTapTarget({required this.onTap, required this.child});
+
+  final VoidCallback onTap;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      child: child,
+    );
+  }
+}
+
+class WorkerOverviewSummary {
+  const WorkerOverviewSummary({
+    required this.totalMacos,
+    required this.onlineMacos,
+    required this.totalLinux,
+    required this.onlineLinux,
+    required this.totalOther,
+    required this.onlineOther,
+  });
+
+  static const offlineAfter = Duration(minutes: 2);
+
+  final int totalMacos;
+  final int onlineMacos;
+  final int totalLinux;
+  final int onlineLinux;
+  final int totalOther;
+  final int onlineOther;
+
+  int get totalCount => totalMacos + totalLinux + totalOther;
+  int get onlineCount => onlineMacos + onlineLinux + onlineOther;
+  int get offlineCount => totalCount - onlineCount;
+
+  static WorkerOverviewSummary fromDocs(
+    Iterable<QueryDocumentSnapshot<Map<String, dynamic>>> docs,
+  ) {
+    var totalMacos = 0;
+    var onlineMacos = 0;
+    var totalLinux = 0;
+    var onlineLinux = 0;
+    var totalOther = 0;
+    var onlineOther = 0;
+    final now = DateTime.now();
+
+    for (final doc in docs) {
+      final data = doc.data();
+      final platform = (data['platform'] as String? ?? '').toLowerCase();
+      final lastSeenAt = dateTimeFromFirestore(data['lastSeenAt']);
+      final isOnline = now.difference(lastSeenAt) < offlineAfter;
+
+      if (platform == 'darwin' || platform.contains('mac')) {
+        totalMacos += 1;
+        if (isOnline) onlineMacos += 1;
+      } else if (platform == 'linux') {
+        totalLinux += 1;
+        if (isOnline) onlineLinux += 1;
+      } else {
+        totalOther += 1;
+        if (isOnline) onlineOther += 1;
+      }
+    }
+
+    return WorkerOverviewSummary(
+      totalMacos: totalMacos,
+      onlineMacos: onlineMacos,
+      totalLinux: totalLinux,
+      onlineLinux: onlineLinux,
+      totalOther: totalOther,
+      onlineOther: onlineOther,
+    );
+  }
+}
+
+class BoardSidePanelDrawer extends StatelessWidget {
+  const BoardSidePanelDrawer({
+    super.key,
+    required this.panel,
+    required this.onDismiss,
+  });
+
+  final BoardSidePanel panel;
+  final VoidCallback onDismiss;
+
+  @override
+  Widget build(BuildContext context) {
+    return switch (panel) {
+      BoardSidePanel.workers => WorkerInspectorPanel(onDismiss: onDismiss),
+      BoardSidePanel.runs => _BoardSidePanelShell(
+        icon: Icons.history_rounded,
+        title: 'CI/CDログ',
+        onDismiss: onDismiss,
+        child: const LogsBody(),
+      ),
+      BoardSidePanel.workflows => _BoardSidePanelShell(
+        icon: Icons.schema_rounded,
+        title: 'CI/CD設定',
+        onDismiss: onDismiss,
+        child: const WorkflowsBody(),
+      ),
+      BoardSidePanel.variables => _BoardSidePanelShell(
+        icon: Icons.key_rounded,
+        title: '変数',
+        onDismiss: onDismiss,
+        child: const VariablesBody(),
+      ),
+      BoardSidePanel.storeRelease => _BoardSidePanelShell(
+        icon: Icons.rocket_launch_outlined,
+        title: 'ストアリリース',
+        onDismiss: onDismiss,
+        child: const StoreReleaseBody(),
+      ),
+    };
+  }
+}
+
+class _BoardSidePanelShell extends StatelessWidget {
+  const _BoardSidePanelShell({
+    required this.icon,
+    required this.title,
+    required this.onDismiss,
+    required this.child,
+  });
+
+  final IconData icon;
+  final String title;
+  final VoidCallback onDismiss;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(18, 16, 10, 12),
+          child: Row(
+            children: [
+              Icon(icon, color: const Color(0xFF2563EB)),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      title,
+                      style: const TextStyle(
+                        color: Color(0xFF0F172A),
+                        fontSize: 18,
+                        fontWeight: FontWeight.w900,
+                      ),
+                    ),
+                    const Text(
+                      'Esc で閉じる',
+                      style: TextStyle(color: Color(0xFF64748B), fontSize: 12),
+                    ),
+                  ],
+                ),
+              ),
+              IconButton(
+                tooltip: '閉じる',
+                onPressed: onDismiss,
+                icon: const Icon(Icons.close_rounded),
+              ),
+            ],
+          ),
+        ),
+        const Divider(height: 1, color: Color(0xFFE2E8F0)),
+        Expanded(child: child),
+      ],
+    );
+  }
+}
+
+class WorkerInspectorPanel extends StatelessWidget {
+  const WorkerInspectorPanel({super.key, required this.onDismiss});
+
+  final VoidCallback onDismiss;
+
+  @override
+  Widget build(BuildContext context) {
+    return StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
+      stream: FirebaseFirestore.instance
+          .collection(workerInstancesCollection)
+          .orderBy('lastSeenAt', descending: true)
+          .snapshots(),
+      builder: (context, snapshot) {
+        if (snapshot.hasError) {
+          return _WorkerInspectorShell(
+            onDismiss: onDismiss,
+            child: const Center(child: Text('Worker status を読み込めませんでした')),
+          );
+        }
+        if (!snapshot.hasData) {
+          return _WorkerInspectorShell(
+            onDismiss: onDismiss,
+            child: const Center(child: CircularProgressIndicator.adaptive()),
+          );
+        }
+
+        final workers = snapshot.data!.docs
+            .map(WorkerInspectorItem.fromDoc)
+            .toList();
+        workers.sort(_compareWorkerInspectorItems);
+        final macosWorkers = workers
+            .where(
+              (worker) => worker.platformGroup == WorkerPlatformGroup.macos,
+            )
+            .toList();
+        final linuxWorkers = workers
+            .where(
+              (worker) => worker.platformGroup == WorkerPlatformGroup.linux,
+            )
+            .toList();
+        final otherWorkers = workers
+            .where(
+              (worker) => worker.platformGroup == WorkerPlatformGroup.other,
+            )
+            .toList();
+
+        return _WorkerInspectorShell(
+          onDismiss: onDismiss,
+          child: workers.isEmpty
+              ? const _WorkerInspectorEmpty()
+              : ListView(
+                  padding: const EdgeInsets.fromLTRB(18, 0, 18, 18),
+                  children: [
+                    SizedBox(height: 14),
+                    _WorkerInspectorSummary(workers: workers),
+                    const SizedBox(height: 14),
+                    _WorkerInspectorSection(
+                      title: 'macOS',
+                      workers: macosWorkers,
+                      icon: const FaIcon(FontAwesomeIcons.apple),
+                    ),
+                    const SizedBox(height: 14),
+                    _WorkerInspectorSection(
+                      title: 'Linux',
+                      workers: linuxWorkers,
+                      icon: const FaIcon(FontAwesomeIcons.linux),
+                    ),
+                    if (otherWorkers.isNotEmpty) ...[
+                      const SizedBox(height: 14),
+                      _WorkerInspectorSection(
+                        title: 'その他',
+                        workers: otherWorkers,
+                        icon: const Icon(Icons.device_unknown_rounded),
+                      ),
+                    ],
+                  ],
+                ),
+        );
+      },
+    );
+  }
+}
+
+class _WorkerInspectorShell extends StatelessWidget {
+  const _WorkerInspectorShell({
+    required this.onDismiss,
+    required this.child,
+  });
+
+  final VoidCallback onDismiss;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(18, 16, 10, 12),
+          child: Row(
+            children: [
+              const Icon(Icons.dns_outlined, color: Color(0xFF2563EB)),
+              const SizedBox(width: 10),
+              const Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'ワーカー',
+                      style: TextStyle(
+                        color: Color(0xFF0F172A),
+                        fontSize: 18,
+                        fontWeight: FontWeight.w900,
+                      ),
+                    ),
+                    Text(
+                      'Esc で閉じる',
+                      style: TextStyle(color: Color(0xFF64748B), fontSize: 12),
+                    ),
+                  ],
+                ),
+              ),
+              IconButton(
+                tooltip: '閉じる',
+                onPressed: onDismiss,
+                icon: const Icon(Icons.close_rounded),
+              ),
+            ],
+          ),
+        ),
+        const Divider(height: 1, color: Color(0xFFE2E8F0)),
+        Expanded(child: child),
+      ],
+    );
+  }
+}
+
+class _WorkerInspectorSummary extends StatelessWidget {
+  const _WorkerInspectorSummary({required this.workers});
+
+  final List<WorkerInspectorItem> workers;
+
+  @override
+  Widget build(BuildContext context) {
+    final online = workers.where((worker) => worker.isOnline).length;
+    final busy = workers.where((worker) => worker.isBusy).length;
+    final error = workers
+        .where((worker) => worker.hasError && worker.isOnline)
+        .length;
+    final offline = workers.length - online;
+
+    return Wrap(
+      spacing: 8,
+      runSpacing: 8,
+      children: [
+        _WorkerInspectorSummaryChip(
+          label: 'オンライン',
+          value: online,
+          color: const Color(0xFF16A34A),
+        ),
+        _WorkerInspectorSummaryChip(
+          label: '実行中',
+          value: busy,
+          color: const Color(0xFF2563EB),
+        ),
+        _WorkerInspectorSummaryChip(
+          label: 'エラー',
+          value: error,
+          color: const Color(0xFFDC2626),
+        ),
+        _WorkerInspectorSummaryChip(
+          label: 'オフライン',
+          value: offline,
+          color: const Color(0xFF64748B),
+        ),
+      ],
+    );
+  }
+}
+
+class _WorkerInspectorSummaryChip extends StatelessWidget {
+  const _WorkerInspectorSummaryChip({
+    required this.label,
+    required this.value,
+    required this.color,
+  });
+
+  final String label;
+  final int value;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 84,
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 9),
+      decoration: BoxDecoration(
+        color: const Color(0xFFF8FAFC),
+        border: Border.all(color: const Color(0xFFE2E8F0)),
+        borderRadius: BorderRadius.circular(14),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            label,
+            style: const TextStyle(
+              color: Color(0xFF64748B),
+              fontSize: 11,
+              fontWeight: FontWeight.w700,
+            ),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            '$value',
+            style: TextStyle(
+              color: color,
+              fontSize: 20,
+              fontWeight: FontWeight.w900,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _WorkerInspectorSection extends StatelessWidget {
+  const _WorkerInspectorSection({
+    required this.title,
+    required this.workers,
+    required this.icon,
+  });
+
+  final String title;
+  final List<WorkerInspectorItem> workers;
+  final Widget icon;
+
+  @override
+  Widget build(BuildContext context) {
+    final online = workers.where((worker) => worker.isOnline).length;
+    return Container(
+      decoration: BoxDecoration(
+        color: Colors.white,
+        border: Border.all(color: const Color(0xFFE2E8F0)),
+        borderRadius: BorderRadius.circular(16),
+      ),
+      child: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(14, 12, 14, 10),
+            child: Row(
+              children: [
+                IconTheme(
+                  data: const IconThemeData(
+                    color: Color(0xFF2563EB),
+                    size: 18,
+                  ),
+                  child: icon,
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    title,
+                    style: const TextStyle(
+                      color: Color(0xFF0F172A),
+                      fontSize: 14,
+                      fontWeight: FontWeight.w900,
+                    ),
+                  ),
+                ),
+                Text(
+                  '$online/${workers.length} オンライン',
+                  style: const TextStyle(
+                    color: Color(0xFF64748B),
+                    fontSize: 12,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const Divider(height: 1, color: Color(0xFFE2E8F0)),
+          if (workers.isEmpty)
+            const Padding(
+              padding: EdgeInsets.all(14),
+              child: Align(
+                alignment: Alignment.centerLeft,
+                child: Text(
+                  '登録された worker はありません',
+                  style: TextStyle(color: Color(0xFF64748B), fontSize: 12),
+                ),
+              ),
+            )
+          else
+            for (final worker in workers) _WorkerInspectorRow(worker: worker),
+        ],
+      ),
+    );
+  }
+}
+
+class _WorkerInspectorRow extends StatelessWidget {
+  const _WorkerInspectorRow({required this.worker});
+
+  final WorkerInspectorItem worker;
+
+  @override
+  Widget build(BuildContext context) {
+    final statusColor = worker.statusColor;
+    return Container(
+      padding: const EdgeInsets.fromLTRB(14, 12, 14, 12),
+      decoration: const BoxDecoration(
+        border: Border(top: BorderSide(color: Color(0xFFE2E8F0))),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Container(
+                width: 9,
+                height: 9,
+                margin: const EdgeInsets.only(top: 5),
+                decoration: BoxDecoration(
+                  color: statusColor,
+                  shape: BoxShape.circle,
+                ),
+              ),
+              const SizedBox(width: 9),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      worker.workerId,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: const TextStyle(
+                        color: Color(0xFF0F172A),
+                        fontSize: 13,
+                        fontWeight: FontWeight.w900,
+                      ),
+                    ),
+                    const SizedBox(height: 3),
+                    Text(
+                      [
+                        worker.statusLabel,
+                        'v${worker.version}',
+                        if (worker.hostname.isNotEmpty) worker.hostname,
+                        if (worker.pid != null) 'pid ${worker.pid}',
+                      ].join(' · '),
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                      style: const TextStyle(
+                        color: Color(0xFF64748B),
+                        fontSize: 12,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(width: 8),
+              Text(
+                formatWorkerLastSeen(worker.lastSeenAt),
+                style: TextStyle(
+                  color: worker.isOnline
+                      ? const Color(0xFF64748B)
+                      : const Color(0xFFDC2626),
+                  fontSize: 11,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+            ],
+          ),
+          if (worker.currentBuildJobId != null) ...[
+            const SizedBox(height: 8),
+            _WorkerInspectorDetail(
+              icon: Icons.play_circle_outline_rounded,
+              text: worker.currentRunId == null
+                  ? '実行中のジョブ: ${worker.currentBuildJobId}'
+                  : '実行中のジョブ: ${worker.currentBuildJobId} / run ${worker.currentRunId}',
+            ),
+          ],
+          if (worker.lastError != null && worker.lastError!.isNotEmpty) ...[
+            const SizedBox(height: 8),
+            _WorkerInspectorDetail(
+              icon: Icons.error_outline_rounded,
+              text: worker.lastError!,
+              color: const Color(0xFFDC2626),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _WorkerInspectorDetail extends StatelessWidget {
+  const _WorkerInspectorDetail({
+    required this.icon,
+    required this.text,
+    this.color = const Color(0xFF64748B),
+  });
+
+  final IconData icon;
+  final String text;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Icon(icon, color: color, size: 15),
+        const SizedBox(width: 7),
+        Expanded(
+          child: Text(
+            text,
+            maxLines: 3,
+            overflow: TextOverflow.ellipsis,
+            style: TextStyle(color: color, fontSize: 12, height: 1.35),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _WorkerInspectorEmpty extends StatelessWidget {
+  const _WorkerInspectorEmpty();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Center(
+      child: Padding(
+        padding: EdgeInsets.all(24),
+        child: Text(
+          'Worker heartbeat がまだありません\n0.1.27 以降の worker が起動すると表示されます',
+          textAlign: TextAlign.center,
+          style: TextStyle(color: Color(0xFF64748B), height: 1.5),
+        ),
+      ),
+    );
+  }
+}
+
+enum WorkerPlatformGroup { macos, linux, other }
+
+int _compareWorkerInspectorItems(
+  WorkerInspectorItem a,
+  WorkerInspectorItem b,
+) {
+  final platformCompare = a.platformGroup.index.compareTo(
+    b.platformGroup.index,
+  );
+  if (platformCompare != 0) return platformCompare;
+  return a.workerId.toLowerCase().compareTo(b.workerId.toLowerCase());
+}
+
+class WorkerInspectorItem {
+  const WorkerInspectorItem({
+    required this.workerId,
+    required this.version,
+    required this.platform,
+    required this.hostname,
+    required this.status,
+    required this.lastSeenAt,
+    this.pid,
+    this.currentBuildJobId,
+    this.currentRunId,
+    this.consecutiveFailures = 0,
+    this.lastError,
+  });
+
+  static const offlineAfter = Duration(minutes: 2);
+
+  final String workerId;
+  final String version;
+  final String platform;
+  final String hostname;
+  final String status;
+  final DateTime lastSeenAt;
+  final int? pid;
+  final String? currentBuildJobId;
+  final String? currentRunId;
+  final int consecutiveFailures;
+  final String? lastError;
+
+  factory WorkerInspectorItem.fromDoc(
+    QueryDocumentSnapshot<Map<String, dynamic>> doc,
+  ) {
+    final data = doc.data();
+    return WorkerInspectorItem(
+      workerId: data['workerId'] as String? ?? doc.id,
+      version: data['version'] as String? ?? 'unknown',
+      platform: data['platform'] as String? ?? 'unknown',
+      hostname: data['hostname'] as String? ?? '',
+      status: data['status'] as String? ?? 'unknown',
+      lastSeenAt: dateTimeFromFirestore(data['lastSeenAt']),
+      pid: data['pid'] is int ? data['pid'] as int : null,
+      currentBuildJobId: data['currentBuildJobId'] as String?,
+      currentRunId: data['currentRunId'] as String?,
+      consecutiveFailures: data['consecutiveFailures'] is int
+          ? data['consecutiveFailures'] as int
+          : 0,
+      lastError: data['lastError'] as String?,
+    );
+  }
+
+  bool get isOnline => DateTime.now().difference(lastSeenAt) < offlineAfter;
+  bool get isBusy => isOnline && status == 'busy';
+  bool get hasError => status == 'error' || consecutiveFailures > 0;
+
+  WorkerPlatformGroup get platformGroup {
+    final normalized = platform.toLowerCase();
+    if (normalized == 'darwin' || normalized.contains('mac')) {
+      return WorkerPlatformGroup.macos;
+    }
+    if (normalized == 'linux') {
+      return WorkerPlatformGroup.linux;
+    }
+    return WorkerPlatformGroup.other;
+  }
+
+  String get statusLabel {
+    if (!isOnline) return 'オフライン';
+    return switch (status) {
+      'busy' => '実行中',
+      'error' => 'エラー',
+      'idle' => '待機中',
+      'starting' => '起動中',
+      'stopping' => '停止中',
+      _ => '不明',
+    };
+  }
+
+  Color get statusColor {
+    if (!isOnline) return const Color(0xFF94A3B8);
+    return switch (status) {
+      'busy' => const Color(0xFF2563EB),
+      'error' => const Color(0xFFDC2626),
+      'idle' => const Color(0xFF16A34A),
+      'starting' => const Color(0xFFA16207),
+      'stopping' => const Color(0xFFA16207),
+      _ => const Color(0xFF94A3B8),
+    };
+  }
+}
+
+String formatWorkerLastSeen(DateTime lastSeenAt) {
+  final diff = DateTime.now().difference(lastSeenAt);
+  if (diff.inSeconds < 10) return 'たった今';
+  if (diff.inSeconds < 60) return '${diff.inSeconds}秒前';
+  if (diff.inMinutes < 60) return '${diff.inMinutes}分前';
+  if (diff.inHours < 24) return '${diff.inHours}時間前';
+  return '${diff.inDays}日前';
+}
+
+class DailyProgressOverview extends StatelessWidget {
+  const DailyProgressOverview({
+    super.key,
+    required this.stats,
+    required this.onTap,
+  });
+
+  final DailyProgressStats stats;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final progressColor = stats.isAchieved
+        ? const Color(0xFF16A34A)
+        : Theme.of(context).colorScheme.primary;
+    final percent = (stats.progress * 100).round();
+    final adviceLabel = stats.prediction.advice;
+
+    return InkWell(
+      onTap: onTap,
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(16, 12, 16, 12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Row(
+              children: [
+                const Text(
+                  '今日',
+                  style: TextStyle(
+                    color: Color(0xFF64748B),
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+                const SizedBox(width: 10),
+                Text(
+                  'W${stats.completedWeight} / W${stats.targetWeight}',
+                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                    color: const Color(0xFF0F172A),
+                    fontWeight: FontWeight.w900,
+                    letterSpacing: 0,
+                  ),
+                ),
+                const SizedBox(width: 10),
+                Expanded(
+                  child: Text(
+                    '${stats.completedCount}件完了 · $adviceLabel',
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: TextStyle(
+                      color: stats.isAchieved
+                          ? const Color(0xFF15803D)
+                          : const Color(0xFF475569),
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                ),
+                Text(
+                  '$percent%',
+                  style: TextStyle(
+                    color: progressColor,
+                    fontWeight: FontWeight.w900,
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            ClipRRect(
+              borderRadius: BorderRadius.circular(999),
+              child: LinearProgressIndicator(
+                minHeight: 6,
+                value: stats.cappedProgress,
+                backgroundColor: const Color(0xFFE2E8F0),
+                valueColor: AlwaysStoppedAnimation<Color>(progressColor),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class OverviewMetric extends StatelessWidget {
+  const OverviewMetric({
+    super.key,
+    required this.label,
+    required this.value,
+    required this.detail,
+    this.valueColor = const Color(0xFF0F172A),
+    this.width = 92,
+  });
+
+  final String label;
+  final String value;
+  final String detail;
+  final Color valueColor;
+  final double width;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: width,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          crossAxisAlignment: CrossAxisAlignment.end,
+          children: [
+            Text(
+              label,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: const TextStyle(
+                color: Color(0xFF64748B),
+                fontSize: 12,
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+            const SizedBox(height: 2),
+            Text(
+              value,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                color: valueColor,
+                fontWeight: FontWeight.w900,
+              ),
+            ),
+            Text(
+              detail,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: const TextStyle(color: Color(0xFF94A3B8), fontSize: 11),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _OverviewDivider extends StatelessWidget {
+  const _OverviewDivider();
+
+  @override
+  Widget build(BuildContext context) {
+    return const VerticalDivider(
+      width: 1,
+      thickness: 1,
+      color: Color(0xFFE2E8F0),
+    );
+  }
+}
+
+class EstimationAccuracySummary {
+  const EstimationAccuracySummary({
+    required this.within1Rate,
+    required this.mae,
+    required this.bias,
+    required this.sampleCount,
+  });
+
+  final int within1Rate;
+  final double mae;
+  final double bias;
+  final int sampleCount;
+
+  static EstimationAccuracySummary? fromIssues(List<Issue> closedIssues) {
+    final pairs = closedIssues
+        .where(
+          (issue) =>
+              issue.resolution?.actualWeight != null &&
+              issue.weightEstimate?.value != null,
+        )
+        .toList();
+
+    if (pairs.isEmpty) {
+      return null;
+    }
+
+    final deltas = pairs
+        .map(
+          (issue) =>
+              issue.weightEstimate!.value! - issue.resolution!.actualWeight!,
+        )
+        .toList();
+    final within1 = deltas.where((d) => d.abs() <= 1).length;
+    final sumAbsError = deltas.fold<int>(
+      0,
+      (total, delta) => total + delta.abs(),
+    );
+    final sumDelta = deltas.fold<int>(0, (total, delta) => total + delta);
+
+    return EstimationAccuracySummary(
+      within1Rate: (within1 / deltas.length * 100).round(),
+      mae: (sumAbsError / deltas.length * 10).round() / 10,
+      bias: (sumDelta / deltas.length * 10).round() / 10,
+      sampleCount: pairs.length,
+    );
+  }
+
+  String get biasLabel {
+    if (bias == 0) {
+      return 'バイアスなし';
+    }
+    return bias > 0 ? '過大推定 +$bias' : '過小推定 $bias';
+  }
+
+  Color get color {
+    if (within1Rate >= 70) {
+      return const Color(0xFF15803D);
+    }
+    if (within1Rate >= 50) {
+      return const Color(0xFFA16207);
+    }
+    return const Color(0xFFDC2626);
+  }
+}
+
+class DailyProgressStats {
+  const DailyProgressStats({
+    required this.targetWeight,
+    required this.completedWeight,
+    required this.completedCount,
+    required this.recentAverageWeight,
+    required this.history,
+    required this.prediction,
+  });
+
+  final int targetWeight;
+  final int completedWeight;
+  final int completedCount;
+  final double recentAverageWeight;
+  final List<DailyProgressHistoryDay> history;
+  final DailyProgressPrediction prediction;
+
+  double get progress {
+    if (targetWeight <= 0) {
+      return 0;
+    }
+    return completedWeight / targetWeight;
+  }
+
+  double get cappedProgress {
+    final value = progress;
+    if (value.isNaN || value.isInfinite || value <= 0) {
+      return 0;
+    }
+    if (value >= 1) {
+      return 1;
+    }
+    return value;
+  }
+
+  int get remainingWeight {
+    final remaining = targetWeight - completedWeight;
+    return remaining > 0 ? remaining : 0;
+  }
+
+  int get overWeight {
+    final over = completedWeight - targetWeight;
+    return over > 0 ? over : 0;
+  }
+
+  bool get isAchieved => targetWeight > 0 && completedWeight >= targetWeight;
+}
+
+class DailyProgressHistoryDay {
+  const DailyProgressHistoryDay({
+    required this.date,
+    required this.completedWeight,
+    required this.completedCount,
+    required this.morningWeight,
+    required this.afternoonWeight,
+  });
+
+  final DateTime date;
+  final int completedWeight;
+  final int completedCount;
+  final int morningWeight;
+  final int afternoonWeight;
+}
+
+class DailyProgressPrediction {
+  const DailyProgressPrediction({
+    required this.finishProbability,
+    required this.paceLabel,
+    required this.advice,
+    required this.color,
+    required this.requiredAfternoonWeight,
+    required this.historicalAfternoonMedian,
+    required this.sampleCount,
+    required this.usesFallback,
+  });
+
+  final int finishProbability;
+  final String paceLabel;
+  final String advice;
+  final Color color;
+  final int requiredAfternoonWeight;
+  final double historicalAfternoonMedian;
+  final int sampleCount;
+  final bool usesFallback;
+}
+
+class DailyPaceBucket {
+  int totalWeight = 0;
+  int completedCount = 0;
+  int morningWeight = 0;
+  int afternoonWeight = 0;
+  int weightAtCurrentTime = 0;
+
+  void add({
+    required DateTime closedAt,
+    required int weight,
+    required DateTime now,
+  }) {
+    totalWeight += weight;
+    completedCount += 1;
+
+    if (closedAt.hour < 12) {
+      morningWeight += weight;
+    } else {
+      afternoonWeight += weight;
+    }
+
+    if (isAtOrBeforeTimeOfDay(closedAt, now)) {
+      weightAtCurrentTime += weight;
+    }
+  }
+}
+
+class DailyProgressStrip extends StatelessWidget {
+  const DailyProgressStrip({
+    super.key,
+    required this.stats,
+    required this.onTap,
+    this.isCompact = false,
+  });
+
+  final DailyProgressStats stats;
+  final VoidCallback onTap;
+  final bool isCompact;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final progressColor = stats.isAchieved
+        ? const Color(0xFF16A34A)
+        : colorScheme.primary;
+    final percent = (stats.progress * 100).round();
+    final remainingLabel = stats.isAchieved
+        ? stats.overWeight > 0
+              ? '+W${stats.overWeight}'
+              : '達成'
+        : '残り W${stats.remainingWeight}';
+    final progressLabel = 'W${stats.completedWeight} / W${stats.targetWeight}';
+
+    return Padding(
+      padding: EdgeInsets.fromLTRB(
+        isCompact ? 16 : 0,
+        isCompact ? 8 : 0,
+        isCompact ? 16 : 0,
+        isCompact ? 10 : 0,
+      ),
+      child: Material(
+        color: Colors.white,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(18),
+          side: const BorderSide(color: Color(0xFFE2E8F0)),
+        ),
+        clipBehavior: Clip.antiAlias,
+        child: InkWell(
+          onTap: onTap,
+          child: Padding(
+            padding: EdgeInsets.fromLTRB(
+              isCompact ? 14 : 16,
+              isCompact ? 12 : 14,
+              isCompact ? 14 : 16,
+              isCompact ? 12 : 14,
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                LayoutBuilder(
+                  builder: (context, constraints) {
+                    final useCompactContent =
+                        isCompact || constraints.maxWidth < 520;
+                    if (useCompactContent) {
+                      return Row(
+                        children: [
+                          Expanded(
+                            child: Text(
+                              progressLabel,
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                              style: Theme.of(context).textTheme.titleMedium
+                                  ?.copyWith(
+                                    color: const Color(0xFF0F172A),
+                                    fontWeight: FontWeight.w800,
+                                    letterSpacing: 0,
+                                  ),
+                            ),
+                          ),
+                          const SizedBox(width: 10),
+                          Text(
+                            '${stats.completedCount}件',
+                            style: const TextStyle(
+                              color: Color(0xFF64748B),
+                              fontWeight: FontWeight.w700,
+                            ),
+                          ),
+                          const SizedBox(width: 10),
+                          Text(
+                            remainingLabel,
+                            style: TextStyle(
+                              color: stats.isAchieved
+                                  ? const Color(0xFF15803D)
+                                  : const Color(0xFF334155),
+                              fontWeight: FontWeight.w800,
+                            ),
+                          ),
+                        ],
+                      );
+                    }
+
+                    return Row(
+                      children: [
+                        Expanded(
+                          child: Wrap(
+                            spacing: 12,
+                            runSpacing: 6,
+                            crossAxisAlignment: WrapCrossAlignment.center,
+                            children: [
+                              const Text(
+                                '今日の目標',
+                                style: TextStyle(
+                                  color: Color(0xFF64748B),
+                                  fontWeight: FontWeight.w700,
+                                ),
+                              ),
+                              Text(
+                                progressLabel,
+                                style: Theme.of(context).textTheme.titleLarge
+                                    ?.copyWith(
+                                      color: const Color(0xFF0F172A),
+                                      fontWeight: FontWeight.w800,
+                                      letterSpacing: 0,
+                                    ),
+                              ),
+                              Text(
+                                '${stats.completedCount}件完了',
+                                style: const TextStyle(
+                                  color: Color(0xFF475569),
+                                  fontWeight: FontWeight.w700,
+                                ),
+                              ),
+                              Text(
+                                remainingLabel,
+                                style: TextStyle(
+                                  color: stats.isAchieved
+                                      ? const Color(0xFF15803D)
+                                      : const Color(0xFF334155),
+                                  fontWeight: FontWeight.w800,
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                        const SizedBox(width: 12),
+                        Text(
+                          '$percent%',
+                          style: Theme.of(context).textTheme.titleMedium
+                              ?.copyWith(
+                                color: progressColor,
+                                fontWeight: FontWeight.w900,
+                              ),
+                        ),
+                      ],
+                    );
+                  },
+                ),
+                const SizedBox(height: 10),
+                ClipRRect(
+                  borderRadius: BorderRadius.circular(999),
+                  child: LinearProgressIndicator(
+                    minHeight: isCompact ? 7 : 8,
+                    value: stats.cappedProgress,
+                    backgroundColor: const Color(0xFFE2E8F0),
+                    valueColor: AlwaysStoppedAnimation<Color>(progressColor),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class DailyProgressSheet extends StatefulWidget {
+  const DailyProgressSheet({
+    super.key,
+    required this.currentTarget,
+    required this.stats,
+    this.onRecomputeWeights,
+  });
+
+  final int currentTarget;
+  final DailyProgressStats stats;
+  final Future<void> Function()? onRecomputeWeights;
+
+  @override
+  State<DailyProgressSheet> createState() => _DailyProgressSheetState();
+}
+
+class _DailyProgressSheetState extends State<DailyProgressSheet> {
+  late int _target = _clampTarget(widget.currentTarget);
+
+  int _clampTarget(int value) {
+    if (value < 1) {
+      return 1;
+    }
+    if (value > 99) {
+      return 99;
+    }
+    return value;
+  }
+
+  void _changeTarget(int delta) {
+    setState(() => _target = _clampTarget(_target + delta));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final screenSize = MediaQuery.sizeOf(context);
+    final averageLabel = widget.stats.recentAverageWeight > 0
+        ? '過去30日の平均: W${widget.stats.recentAverageWeight.toStringAsFixed(1)}/日'
+        : '過去30日の平均はまだありません';
+
+    return SafeArea(
+      top: false,
+      child: Align(
+        alignment: Alignment.bottomCenter,
+        child: ConstrainedBox(
+          constraints: BoxConstraints(
+            maxWidth: 560,
+            maxHeight: screenSize.height * 0.88,
+          ),
+          child: Material(
+            color: Colors.white,
+            borderRadius: const BorderRadius.vertical(top: Radius.circular(28)),
+            clipBehavior: Clip.antiAlias,
+            child: Padding(
+              padding: const EdgeInsets.fromLTRB(20, 10, 20, 16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  Center(
+                    child: Container(
+                      width: 42,
+                      height: 4,
+                      decoration: BoxDecoration(
+                        color: const Color(0xFFCBD5E1),
+                        borderRadius: BorderRadius.circular(999),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 16),
+                  Row(
+                    children: [
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              '1日の目標 Weight',
+                              style: Theme.of(context).textTheme.titleLarge
+                                  ?.copyWith(
+                                    fontWeight: FontWeight.w900,
+                                    letterSpacing: 0,
+                                  ),
+                            ),
+                            const SizedBox(height: 4),
+                            const Text(
+                              '泳ぐ距離を決めるように、毎日の目標を決めます。',
+                              style: TextStyle(color: Color(0xFF64748B)),
+                            ),
+                          ],
+                        ),
+                      ),
+                      IconButton(
+                        onPressed: () => Navigator.of(context).pop(),
+                        icon: const Icon(Icons.close_rounded),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 16),
+                  Container(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 12,
+                      vertical: 14,
+                    ),
+                    decoration: BoxDecoration(
+                      color: const Color(0xFFF8FAFC),
+                      borderRadius: BorderRadius.circular(18),
+                      border: Border.all(color: const Color(0xFFE2E8F0)),
+                    ),
+                    child: Column(
+                      children: [
+                        Row(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: [
+                            IconButton.filledTonal(
+                              onPressed: () => _changeTarget(-1),
+                              icon: const Icon(Icons.remove_rounded),
+                            ),
+                            SizedBox(
+                              width: 112,
+                              child: Column(
+                                children: [
+                                  Text(
+                                    'W$_target',
+                                    style: Theme.of(context)
+                                        .textTheme
+                                        .headlineMedium
+                                        ?.copyWith(
+                                          fontWeight: FontWeight.w900,
+                                          letterSpacing: 0,
+                                        ),
+                                  ),
+                                  const Text(
+                                    '毎日の目標',
+                                    style: TextStyle(
+                                      color: Color(0xFF64748B),
+                                      fontSize: 12,
+                                      fontWeight: FontWeight.w700,
+                                    ),
+                                  ),
+                                ],
+                              ),
+                            ),
+                            IconButton.filled(
+                              onPressed: () => _changeTarget(1),
+                              icon: const Icon(Icons.add_rounded),
+                            ),
+                          ],
+                        ),
+                        const SizedBox(height: 10),
+                        Wrap(
+                          spacing: 8,
+                          alignment: WrapAlignment.center,
+                          children: [
+                            OutlinedButton(
+                              onPressed: () => _changeTarget(-5),
+                              child: const Text('-5'),
+                            ),
+                            OutlinedButton(
+                              onPressed: () => _changeTarget(5),
+                              child: const Text('+5'),
+                            ),
+                          ],
+                        ),
+                      ],
+                    ),
+                  ),
+                  const SizedBox(height: 12),
+                  Text(
+                    averageLabel,
+                    textAlign: TextAlign.center,
+                    style: const TextStyle(
+                      color: Color(0xFF64748B),
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                  const SizedBox(height: 18),
+                  Row(
+                    children: [
+                      Text(
+                        '過去30日の履歴',
+                        style: Theme.of(context).textTheme.titleMedium
+                            ?.copyWith(fontWeight: FontWeight.w900),
+                      ),
+                      const Spacer(),
+                      const Text(
+                        'Weight / 目標',
+                        style: TextStyle(
+                          color: Color(0xFF64748B),
+                          fontSize: 12,
+                          fontWeight: FontWeight.w700,
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 8),
+                  Expanded(
+                    child: Container(
+                      decoration: BoxDecoration(
+                        border: Border.all(color: const Color(0xFFE2E8F0)),
+                        borderRadius: BorderRadius.circular(18),
+                      ),
+                      clipBehavior: Clip.antiAlias,
+                      child: ListView.separated(
+                        padding: EdgeInsets.zero,
+                        itemCount: widget.stats.history.length,
+                        separatorBuilder: (_, _) =>
+                            const Divider(height: 1, color: Color(0xFFE2E8F0)),
+                        itemBuilder: (context, index) =>
+                            DailyProgressHistoryRow(
+                              day: widget.stats.history[index],
+                              targetWeight: _target,
+                            ),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 14),
+                  Row(
+                    children: [
+                      if (widget.onRecomputeWeights != null)
+                        TextButton.icon(
+                          onPressed: () {
+                            widget.onRecomputeWeights!();
+                            Navigator.of(context).pop();
+                          },
+                          icon: const Icon(Icons.refresh_rounded, size: 18),
+                          label: const Text('Weight再計算'),
+                        ),
+                      const Spacer(),
+                      TextButton(
+                        onPressed: () => Navigator.of(context).pop(),
+                        child: const Text('キャンセル'),
+                      ),
+                      const SizedBox(width: 8),
+                      FilledButton(
+                        onPressed: () => Navigator.of(context).pop(_target),
+                        child: const Text('保存'),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class BuildStatusBadge extends StatelessWidget {
+  const BuildStatusBadge({super.key, required this.status});
+
+  final CardBuildStatus? status;
+
+  @override
+  Widget build(BuildContext context) {
+    final currentStatus = status;
+    if (currentStatus == null) {
+      return const SizedBox.shrink();
+    }
+
+    final color = currentStatus.color;
+    return Tooltip(
+      message: currentStatus.tooltip,
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: () => showDialog<void>(
+          context: context,
+          builder: (_) => BuildStatusJobsDialog(status: currentStatus),
+        ),
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 7, vertical: 4),
+          decoration: BoxDecoration(
+            color: color.withValues(alpha: 0.1),
+            border: Border.all(color: color.withValues(alpha: 0.28)),
+            borderRadius: BorderRadius.circular(999),
+          ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              BuildStatusIndicator(
+                icon: currentStatus.icon,
+                color: color,
+                isSpinning: currentStatus.isSpinning,
+                size: 13,
+              ),
+              if (currentStatus.label.isNotEmpty) ...[
+                const SizedBox(width: 4),
+                Text(
+                  currentStatus.label,
+                  style: TextStyle(
+                    color: color,
+                    fontSize: 12,
+                    fontWeight: FontWeight.w900,
+                  ),
+                ),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class BuildStatusJobsDialog extends StatelessWidget {
+  const BuildStatusJobsDialog({super.key, required this.status});
+
+  final CardBuildStatus status;
+
+  @override
+  Widget build(BuildContext context) {
+    final screenSize = MediaQuery.sizeOf(context);
+    final isCompactDialog = screenSize.width < 560;
+    final dialogPadding = EdgeInsets.all(isCompactDialog ? 18 : 24);
+    final maxHeight = screenSize.height * (isCompactDialog ? 0.9 : 0.82);
+    final dialogBorderRadius = BorderRadius.circular(28);
+
+    return Dialog(
+      insetPadding: EdgeInsets.symmetric(
+        horizontal: isCompactDialog ? 12 : 20,
+        vertical: isCompactDialog ? 12 : 24,
+      ),
+      backgroundColor: Colors.white,
+      surfaceTintColor: Colors.transparent,
+      shape: RoundedRectangleBorder(borderRadius: dialogBorderRadius),
+      clipBehavior: Clip.antiAlias,
+      child: ConstrainedBox(
+        constraints: BoxConstraints(maxWidth: 720, maxHeight: maxHeight),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Container(
+              padding: dialogPadding.copyWith(bottom: 16),
+              decoration: const BoxDecoration(
+                border: Border(
+                  bottom: BorderSide(color: Color(0xFFE2E8F0)),
+                ),
+              ),
+              child: DialogHeader(
+                title: 'CI checks',
+                description: status.summaryLabel,
+              ),
+            ),
+            Flexible(
+              child: SingleChildScrollView(
+                padding: dialogPadding.copyWith(top: 16, bottom: 16),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    Container(
+                      padding: const EdgeInsets.all(12),
+                      decoration: BoxDecoration(
+                        color: status.color.withValues(alpha: 0.08),
+                        border: Border.all(
+                          color: status.color.withValues(alpha: 0.18),
+                        ),
+                        borderRadius: BorderRadius.circular(18),
+                      ),
+                      child: Row(
+                        children: [
+                          Container(
+                            width: 34,
+                            height: 34,
+                            decoration: BoxDecoration(
+                              color: status.color.withValues(alpha: 0.1),
+                              borderRadius: BorderRadius.circular(12),
+                            ),
+                            child: Center(
+                              child: BuildStatusIndicator(
+                                icon: status.icon,
+                                color: status.color,
+                                isSpinning: status.isSpinning,
+                                size: 20,
+                              ),
+                            ),
+                          ),
+                          const SizedBox(width: 10),
+                          Expanded(
+                            child: Text(
+                              status.tooltip,
+                              maxLines: 2,
+                              overflow: TextOverflow.ellipsis,
+                              style: TextStyle(
+                                color: status.color,
+                                fontWeight: FontWeight.w800,
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                    const SizedBox(height: 14),
+                    for (final entry in status.jobs.indexed) ...[
+                      BuildStatusJobRow(job: entry.$2),
+                      if (entry.$1 != status.jobs.length - 1)
+                        const SizedBox(height: 8),
+                    ],
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class BuildStatusJobRow extends StatelessWidget {
+  const BuildStatusJobRow({super.key, required this.job});
+
+  final BuildStatusJob job;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: const Color(0xFFF8FAFC),
+      borderRadius: BorderRadius.circular(16),
+      clipBehavior: Clip.antiAlias,
+      child: InkWell(
+        onTap: () {
+          Navigator.of(context).pop();
+          context.push('/runs/${Uri.encodeComponent(job.id)}');
+        },
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 11),
+          decoration: BoxDecoration(
+            border: Border.all(color: const Color(0xFFE2E8F0)),
+            borderRadius: BorderRadius.circular(16),
+          ),
+          child: Row(
+            children: [
+              Container(
+                width: 32,
+                height: 32,
+                decoration: BoxDecoration(
+                  color: job.color.withValues(alpha: 0.1),
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                child: Center(
+                  child: BuildStatusIndicator(
+                    icon: job.icon,
+                    color: job.color,
+                    isSpinning: job.isSpinning,
+                    size: 18,
+                  ),
+                ),
+              ),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      job.title,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: const TextStyle(
+                        color: Color(0xFF0F172A),
+                        fontWeight: FontWeight.w900,
+                      ),
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      job.subtitle,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: const TextStyle(
+                        color: Color(0xFF64748B),
+                        fontSize: 12,
+                        fontWeight: FontWeight.w700,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(width: 10),
+              Text(
+                job.statusLabel,
+                style: TextStyle(
+                  color: job.color,
+                  fontSize: 12,
+                  fontWeight: FontWeight.w900,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class BuildStatusIndicator extends StatelessWidget {
+  const BuildStatusIndicator({
+    super.key,
+    required this.icon,
+    required this.color,
+    required this.isSpinning,
+    required this.size,
+  });
+
+  final IconData icon;
+  final Color color;
+  final bool isSpinning;
+  final double size;
+
+  @override
+  Widget build(BuildContext context) {
+    if (isSpinning) {
+      return SyncedSpinner(color: color, size: size, strokeWidth: 2);
+    }
+
+    return Icon(icon, size: size, color: color);
+  }
+}
+
+class RecentRunSummary {
+  const RecentRunSummary({
+    required this.id,
+    required this.status,
+    required this.owner,
+    required this.repo,
+    required this.createdAt,
+    required this.workflowName,
+    required this.workflowFileName,
+    required this.jobKey,
+    required this.branch,
+    required this.workflowRunId,
+    required this.pullRequestNumber,
+  });
+
+  final String id;
+  final BuildJobStatus status;
+  final String owner;
+  final String repo;
+  final DateTime createdAt;
+  final String workflowName;
+  final String workflowFileName;
+  final String jobKey;
+  final String branch;
+  final String workflowRunId;
+  final int pullRequestNumber;
+
+  String get repository => '$owner/$repo';
+
+  String get workflowTitle => workflowName.isEmpty ? repository : workflowName;
+
+  String get workflowRunGroupKey =>
+      '${workflowRunId.isEmpty ? id : workflowRunId}:$workflowFileName';
+
+  static RecentRunSummary? fromDoc(
+    QueryDocumentSnapshot<Map<String, dynamic>> doc,
+  ) {
+    final data = doc.data();
+    try {
+      return RecentRunSummary(
+        id: doc.id,
+        status: buildJobStatusFromFirestore(data['status']),
+        owner: asString(data['owner']),
+        repo: asString(data['repo']),
+        createdAt:
+            asDate(data['createdAt']) ?? DateTime.fromMillisecondsSinceEpoch(0),
+        workflowName: asString(data['workflowName']),
+        workflowFileName: asString(data['workflowFileName']),
+        jobKey: asString(data['jobKey']),
+        branch: asString(data['branch']),
+        workflowRunId: asString(data['workflowRunId']),
+        pullRequestNumber: asInt(data['pullRequestNumber']),
+      );
+    } catch (_) {
+      return null;
+    }
+  }
+}
+
+class CardBuildStatus {
+  const CardBuildStatus({
+    required this.label,
+    required this.tooltip,
+    required this.color,
+    required this.icon,
+    required this.signature,
+    required this.isSpinning,
+    required this.workflowTitle,
+    required this.summaryLabel,
+    required this.jobs,
+  });
+
+  final String label;
+  final String tooltip;
+  final Color color;
+  final IconData icon;
+  final String signature;
+  final bool isSpinning;
+  final String workflowTitle;
+  final String summaryLabel;
+  final List<BuildStatusJob> jobs;
+
+  static CardBuildStatus? fromRuns(List<RecentRunSummary> runs) {
+    if (runs.isEmpty) {
+      return null;
+    }
+
+    final sortedRuns = runs.toList()
+      ..sort((a, b) => b.createdAt.compareTo(a.createdAt));
+    final selectedWorkflowKeys = <String>{};
+    final selectedRunIds = <String>{};
+    for (final run in sortedRuns) {
+      final workflowKey = '${run.workflowTitle}:${run.workflowFileName}';
+      if (!selectedWorkflowKeys.add(workflowKey)) {
+        continue;
+      }
+      selectedRunIds.add(run.workflowRunGroupKey);
+    }
+    final currentRuns =
+        [
+          for (final run in sortedRuns)
+            if (selectedRunIds.contains(run.workflowRunGroupKey)) run,
+        ]..sort((a, b) {
+          final workflowCompare = a.workflowTitle.compareTo(b.workflowTitle);
+          if (workflowCompare != 0) {
+            return workflowCompare;
+          }
+          return a.jobKey.compareTo(b.jobKey);
+        });
+
+    var passed = 0;
+    var failed = 0;
+    var active = 0;
+    var other = 0;
+    var queuedOnly = true;
+
+    for (final run in currentRuns) {
+      switch (run.status) {
+        case BuildJobStatus.SUCCESS:
+          passed++;
+          queuedOnly = false;
+        case BuildJobStatus.FAILURE || BuildJobStatus.TIMED_OUT:
+          failed++;
+          queuedOnly = false;
+        case BuildJobStatus.IN_PROGRESS || BuildJobStatus.WAITING:
+          active++;
+          queuedOnly = false;
+        case BuildJobStatus.QUEUED:
+          active++;
+        case BuildJobStatus.CANCELLED || BuildJobStatus.SKIPPED:
+          other++;
+          queuedOnly = false;
+      }
+    }
+
+    final total = currentRuns.length;
+    final jobs = [
+      for (final run in currentRuns)
+        BuildStatusJob(
+          id: run.id,
+          title: run.jobKey.isEmpty ? run.workflowTitle : run.jobKey,
+          subtitle: [
+            run.workflowTitle,
+            if (run.branch.isNotEmpty) run.branch,
+            relativeTimeLabel(run.createdAt),
+          ].join(' / '),
+          status: run.status,
+          createdAt: run.createdAt,
+        ),
+    ];
+    final summaryLabel =
+        '$passed passed / $failed failed / $active running / $other other';
+
+    final label = failed > 0
+        ? 'fail'
+        : active > 0
+        ? queuedOnly
+              ? 'queued'
+              : '$passed/$total CI pass'
+        : passed == total
+        ? total == 1
+              ? 'CI pass'
+              : '$passed CI pass'
+        : '$passed/$total CI pass';
+    final color = failed > 0
+        ? const Color(0xFFB91C1C)
+        : active > 0
+        ? const Color(0xFF2563EB)
+        : passed == total
+        ? const Color(0xFF15803D)
+        : const Color(0xFFB45309);
+    final icon = failed > 0
+        ? Icons.cancel_rounded
+        : active > 0
+        ? queuedOnly
+              ? Icons.schedule_rounded
+              : Icons.sync_rounded
+        : passed == total
+        ? Icons.check_circle_rounded
+        : Icons.adjust_rounded;
+
+    return CardBuildStatus(
+      label: label,
+      color: color,
+      icon: icon,
+      isSpinning: shouldSpinCardBuildStatus(
+        failed: failed,
+        active: active,
+        queuedOnly: queuedOnly,
+      ),
+      signature: jobs.map((job) => '${job.id}:${job.status.name}').join(','),
+      workflowTitle: 'PR checks',
+      summaryLabel: summaryLabel,
+      jobs: jobs,
+      tooltip: 'PR checks: $summaryLabel',
+    );
+  }
+}
+
+@visibleForTesting
+bool shouldSpinCardBuildStatus({
+  required int failed,
+  required int active,
+  required bool queuedOnly,
+}) {
+  return failed == 0 && active > 0 && !queuedOnly;
+}
+
+class BuildStatusJob {
+  const BuildStatusJob({
+    required this.id,
+    required this.title,
+    required this.subtitle,
+    required this.status,
+    required this.createdAt,
+  });
+
+  final String id;
+  final String title;
+  final String subtitle;
+  final BuildJobStatus status;
+  final DateTime createdAt;
+
+  Color get color => switch (status) {
+    BuildJobStatus.SUCCESS => const Color(0xFF15803D),
+    BuildJobStatus.FAILURE ||
+    BuildJobStatus.TIMED_OUT => const Color(0xFFB91C1C),
+    BuildJobStatus.IN_PROGRESS => const Color(0xFF2563EB),
+    BuildJobStatus.QUEUED => const Color(0xFF7C3AED),
+    BuildJobStatus.WAITING ||
+    BuildJobStatus.CANCELLED => const Color(0xFFB45309),
+    BuildJobStatus.SKIPPED => const Color(0xFF64748B),
+  };
+
+  IconData get icon => switch (status) {
+    BuildJobStatus.SUCCESS => Icons.check_circle_rounded,
+    BuildJobStatus.FAILURE => Icons.cancel_rounded,
+    BuildJobStatus.IN_PROGRESS => Icons.sync_rounded,
+    BuildJobStatus.QUEUED => Icons.schedule_rounded,
+    BuildJobStatus.WAITING => Icons.adjust_rounded,
+    BuildJobStatus.CANCELLED => Icons.block_rounded,
+    BuildJobStatus.SKIPPED => Icons.skip_next_rounded,
+    BuildJobStatus.TIMED_OUT => Icons.timer_off_rounded,
+  };
+
+  bool get isSpinning => status == BuildJobStatus.IN_PROGRESS;
+
+  String get statusLabel => switch (status) {
+    BuildJobStatus.SUCCESS => 'passed',
+    BuildJobStatus.FAILURE => 'failed',
+    BuildJobStatus.IN_PROGRESS => 'running',
+    BuildJobStatus.QUEUED => 'queued',
+    BuildJobStatus.WAITING => 'waiting',
+    BuildJobStatus.CANCELLED => 'cancelled',
+    BuildJobStatus.SKIPPED => 'skipped',
+    BuildJobStatus.TIMED_OUT => 'timed out',
+  };
+}
+
+CardBuildStatus? _buildStatusForIssue(
+  Issue issue,
+  Map<String, CardBuildStatus> statusesByPullRequest,
+) {
+  for (final pullRequest in issue.pullRequests.reversed) {
+    final status =
+        statusesByPullRequest[buildStatusKey(
+          issue.repo,
+          pullRequest.number,
+        )];
+    if (status != null) {
+      return status;
+    }
+  }
+  return null;
+}
+
+Map<String, CardBuildStatus> buildStatusesByIssueId(
+  List<Issue> issues,
+  Map<String, CardBuildStatus> statusesByPullRequest,
+) {
+  final statuses = <String, CardBuildStatus>{};
+  for (final issue in issues) {
+    final status = _buildStatusForIssue(issue, statusesByPullRequest);
+    if (status != null) {
+      statuses[issue.id] = status;
+    }
+  }
+  return statuses;
+}
+
+String buildStatusKey(String repository, int pullRequestNumber) {
+  return '$repository#$pullRequestNumber';
+}
+
+String issueRepositoryNumberKey(String repository, int number) {
+  return '$repository#$number';
+}
+
+Map<String, Issue> issuesByRepositoryNumber(List<Issue> issues) {
+  final issuesByNumber = <String, Issue>{};
+  for (final issue in issues) {
+    if (issue.repo.isEmpty || issue.githubNumber <= 0) {
+      continue;
+    }
+    issuesByNumber[issueRepositoryNumberKey(issue.repo, issue.githubNumber)] =
+        issue;
+  }
+  return issuesByNumber;
+}
+
+String buildStatusMapSignature(Map<String, CardBuildStatus> statuses) {
+  final keys = statuses.keys.toList()..sort();
+  return [
+    for (final key in keys) '$key:${statuses[key]!.signature}',
+  ].join('|');
+}
+
+String relativeTimeLabel(DateTime value) {
+  final difference = DateTime.now().difference(value);
+  if (difference.inMinutes < 1) {
+    return 'たった今';
+  }
+  if (difference.inHours < 1) {
+    return '${difference.inMinutes}分前';
+  }
+  if (difference.inDays < 1) {
+    return '${difference.inHours}時間前';
+  }
+  if (difference.inDays < 30) {
+    return '${difference.inDays}日前';
+  }
+  final months = (difference.inDays / 30).floor();
+  return '$monthsヶ月前';
+}

--- a/apps/dashboard/lib/workspace/issue_board_ima_page.dart
+++ b/apps/dashboard/lib/workspace/issue_board_ima_page.dart
@@ -1,0 +1,10 @@
+export 'issue_board_ima_app_shell.dart';
+export 'issue_board_ima_board_columns.dart';
+export 'issue_board_ima_board_page.dart';
+export 'issue_board_ima_issue_cards.dart';
+export 'issue_board_ima_issue_editor.dart';
+export 'issue_board_ima_models.dart';
+export 'issue_board_ima_navigation.dart';
+export 'issue_board_ima_overview.dart';
+export 'issue_board_ima_toolbar_search.dart';
+export 'issue_board_ima_utils.dart';

--- a/apps/dashboard/lib/workspace/issue_board_ima_toolbar_search.dart
+++ b/apps/dashboard/lib/workspace/issue_board_ima_toolbar_search.dart
@@ -1,0 +1,1688 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'issue_board_ima_utils.dart';
+import 'issue_board_ima_board_columns.dart';
+import 'issue_board_ima_models.dart';
+import 'issue_board_ima_app_shell.dart';
+import 'issue_board_ima_overview.dart';
+
+class DailyProgressHistoryRow extends StatelessWidget {
+  const DailyProgressHistoryRow({
+    super.key,
+    required this.day,
+    required this.targetWeight,
+  });
+
+  final DailyProgressHistoryDay day;
+  final int targetWeight;
+
+  @override
+  Widget build(BuildContext context) {
+    final progress = targetWeight <= 0
+        ? 0.0
+        : day.completedWeight / targetWeight;
+    final cappedProgress = progress.clamp(0.0, 1.0).toDouble();
+    final percent = (progress * 100).round();
+    final achieved = day.completedWeight >= targetWeight && targetWeight > 0;
+    final remainingWeight = targetWeight - day.completedWeight;
+    final statusLabel = achieved
+        ? day.completedWeight > targetWeight
+              ? '+W${day.completedWeight - targetWeight}'
+              : '達成'
+        : day.completedWeight == 0
+        ? '未着手'
+        : '残り W$remainingWeight';
+    final accentColor = achieved
+        ? const Color(0xFF15803D)
+        : day.completedWeight == 0
+        ? const Color(0xFF94A3B8)
+        : const Color(0xFF2563EB);
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 11),
+      child: Column(
+        children: [
+          Row(
+            children: [
+              SizedBox(
+                width: 72,
+                child: Text(
+                  dailyHistoryDateLabel(day.date),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: const TextStyle(
+                    color: Color(0xFF0F172A),
+                    fontWeight: FontWeight.w800,
+                  ),
+                ),
+              ),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Text(
+                  'W${day.completedWeight} / W$targetWeight',
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: const TextStyle(
+                    color: Color(0xFF0F172A),
+                    fontWeight: FontWeight.w800,
+                  ),
+                ),
+              ),
+              Text(
+                '$percent%',
+                style: TextStyle(
+                  color: accentColor,
+                  fontWeight: FontWeight.w900,
+                ),
+              ),
+              const SizedBox(width: 12),
+              SizedBox(
+                width: 64,
+                child: Text(
+                  '${day.completedCount}件',
+                  textAlign: TextAlign.right,
+                  style: const TextStyle(
+                    color: Color(0xFF64748B),
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+              ),
+              SizedBox(
+                width: 72,
+                child: Text(
+                  statusLabel,
+                  textAlign: TextAlign.right,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(
+                    color: accentColor,
+                    fontWeight: FontWeight.w800,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 6),
+          Row(
+            children: [
+              const SizedBox(width: 82),
+              Expanded(
+                child: Text(
+                  '午前 W${day.morningWeight} · 午後 W${day.afternoonWeight}',
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: const TextStyle(
+                    color: Color(0xFF94A3B8),
+                    fontSize: 12,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          ClipRRect(
+            borderRadius: BorderRadius.circular(999),
+            child: LinearProgressIndicator(
+              minHeight: 6,
+              value: cappedProgress,
+              backgroundColor: const Color(0xFFE2E8F0),
+              valueColor: AlwaysStoppedAnimation<Color>(accentColor),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class BoardToolbar extends StatelessWidget {
+  const BoardToolbar({
+    super.key,
+    required this.onConnectGitHub,
+    required this.onSelectRepositories,
+    required this.onImportIssues,
+    required this.onSyncIssues,
+    required this.onSearchIssues,
+    required this.boardViewMode,
+    required this.onBoardViewModeChanged,
+    required this.githubLogin,
+    required this.repoCount,
+    required this.isBusy,
+    required this.onRunsTap,
+    required this.onWorkersTap,
+    required this.onWorkflowsTap,
+    required this.onVariablesTap,
+    required this.onStoreReleaseTap,
+    this.showNavigationActions = true,
+  });
+
+  final VoidCallback onConnectGitHub;
+  final VoidCallback onSelectRepositories;
+  final VoidCallback onImportIssues;
+  final VoidCallback onSyncIssues;
+  final VoidCallback onSearchIssues;
+  final BoardViewMode boardViewMode;
+  final ValueChanged<BoardViewMode> onBoardViewModeChanged;
+  final String? githubLogin;
+  final int repoCount;
+  final bool isBusy;
+  final VoidCallback onRunsTap;
+  final VoidCallback onWorkersTap;
+  final VoidCallback onWorkflowsTap;
+  final VoidCallback onVariablesTap;
+  final VoidCallback onStoreReleaseTap;
+  final bool showNavigationActions;
+
+  @override
+  Widget build(BuildContext context) {
+    final isConnected = githubLogin != null && githubLogin!.isNotEmpty;
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        if (constraints.maxWidth < compactBoardBreakpoint) {
+          return const SizedBox.shrink();
+        }
+
+        return Padding(
+          padding: const EdgeInsets.fromLTRB(20, 0, 20, 10),
+          child: Align(
+            alignment: Alignment.centerLeft,
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 1120),
+              child: Wrap(
+                spacing: 8,
+                runSpacing: 8,
+                crossAxisAlignment: WrapCrossAlignment.center,
+                children: [
+                  if (!isConnected)
+                    FilledButton.icon(
+                      onPressed: isBusy ? null : onConnectGitHub,
+                      icon: const Icon(Icons.link_rounded, size: 16),
+                      label: const Text('GitHub App接続'),
+                    ),
+                  if (isConnected) ...[
+                    ToolbarChip(
+                      icon: Icons.account_tree_outlined,
+                      label: '$repoCount repo',
+                      tooltip: 'GitHub repoを選択',
+                      onPressed: isBusy ? null : onSelectRepositories,
+                    ),
+                    ToolbarChip(
+                      icon: Icons.download_rounded,
+                      label: '取り込み',
+                      tooltip: 'GitHub issueを取り込む',
+                      onPressed: isBusy ? null : onImportIssues,
+                    ),
+                    ToolbarChip(
+                      icon: Icons.sync_outlined,
+                      label: '同期',
+                      tooltip: '未同期issueを同期',
+                      onPressed: isBusy ? null : onSyncIssues,
+                    ),
+                  ],
+                  ToolbarChip(
+                    icon: Icons.search_outlined,
+                    label: '検索',
+                    tooltip: 'issueを検索 (⌘K)',
+                    onPressed: onSearchIssues,
+                  ),
+                  BoardViewModeToggle(
+                    value: boardViewMode,
+                    onChanged: onBoardViewModeChanged,
+                  ),
+                  if (showNavigationActions) ...[
+                    ToolbarChip(
+                      icon: Icons.history_rounded,
+                      label: 'CI/CDログ',
+                      tooltip: 'CI/CD の実行ログを開く',
+                      onPressed: onRunsTap,
+                    ),
+                    ToolbarChip(
+                      icon: Icons.dns_outlined,
+                      label: 'ワーカー',
+                      tooltip: 'OpenCI worker の稼動状況を開く',
+                      onPressed: onWorkersTap,
+                    ),
+                    ToolbarChip(
+                      icon: Icons.schema_rounded,
+                      label: 'CI/CD設定',
+                      tooltip: 'CI/CD設定を開く',
+                      onPressed: onWorkflowsTap,
+                    ),
+                    ToolbarChip(
+                      icon: Icons.key_rounded,
+                      label: '変数',
+                      tooltip: '変数 / シークレットを開く',
+                      onPressed: onVariablesTap,
+                    ),
+                    ToolbarChip(
+                      icon: Icons.rocket_launch_outlined,
+                      label: 'ストアリリース',
+                      tooltip: 'ストアリリースを開く',
+                      onPressed: onStoreReleaseTap,
+                    ),
+                  ],
+                ],
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class BoardViewModeToggle extends StatelessWidget {
+  const BoardViewModeToggle({
+    super.key,
+    required this.value,
+    required this.onChanged,
+  });
+
+  final BoardViewMode value;
+  final ValueChanged<BoardViewMode> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final isOverview = value == BoardViewMode.overview;
+
+    return Container(
+      height: 34,
+      padding: const EdgeInsets.only(left: 10, right: 4),
+      decoration: BoxDecoration(
+        color: isOverview ? const Color(0xFFEFF6FF) : Colors.white,
+        border: Border.all(
+          color: isOverview ? const Color(0xFFBFDBFE) : const Color(0xFFE2E8F0),
+        ),
+        borderRadius: BorderRadius.circular(999),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(
+            Icons.grid_view_rounded,
+            size: 15,
+            color: isOverview
+                ? const Color(0xFF2563EB)
+                : const Color(0xFF64748B),
+          ),
+          const SizedBox(width: 6),
+          Text(
+            '全体ボード',
+            style: TextStyle(
+              color: isOverview
+                  ? const Color(0xFF1D4ED8)
+                  : const Color(0xFF475569),
+              fontSize: 12,
+              fontWeight: FontWeight.w900,
+            ),
+          ),
+          Transform.scale(
+            scale: 0.76,
+            child: Switch(
+              value: isOverview,
+              onChanged: (enabled) => onChanged(
+                enabled ? BoardViewMode.overview : BoardViewMode.standard,
+              ),
+              materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class CompactBoardViewModeButton extends StatelessWidget {
+  const CompactBoardViewModeButton({
+    super.key,
+    required this.value,
+    required this.onChanged,
+  });
+
+  final BoardViewMode value;
+  final ValueChanged<BoardViewMode> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final isOverview = value == BoardViewMode.overview;
+    return Tooltip(
+      message: '表示を切り替え',
+      child: Semantics(
+        label: '表示切り替え',
+        value: isOverview ? '全体ボード' : '一覧表示',
+        child: Container(
+          height: 40,
+          padding: const EdgeInsets.all(3),
+          decoration: BoxDecoration(
+            color: Colors.white,
+            border: Border.all(color: const Color(0xFFE2E8F0)),
+            borderRadius: BorderRadius.circular(999),
+          ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              _CompactBoardViewModeSegment(
+                icon: Icons.view_list_rounded,
+                label: '一覧',
+                selected: !isOverview,
+                onTap: () => onChanged(BoardViewMode.standard),
+              ),
+              _CompactBoardViewModeSegment(
+                icon: Icons.grid_view_rounded,
+                label: '全体',
+                selected: isOverview,
+                onTap: () => onChanged(BoardViewMode.overview),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _CompactBoardViewModeSegment extends StatelessWidget {
+  const _CompactBoardViewModeSegment({
+    required this.icon,
+    required this.label,
+    required this.selected,
+    required this.onTap,
+  });
+
+  final IconData icon;
+  final String label;
+  final bool selected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final foregroundColor = selected
+        ? const Color(0xFF1D4ED8)
+        : const Color(0xFF64748B);
+
+    return Material(
+      color: selected ? const Color(0xFFEFF6FF) : Colors.transparent,
+      borderRadius: BorderRadius.circular(999),
+      child: InkWell(
+        borderRadius: BorderRadius.circular(999),
+        onTap: selected ? null : onTap,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(icon, size: 15, color: foregroundColor),
+              const SizedBox(width: 3),
+              Text(
+                label,
+                style: TextStyle(
+                  color: foregroundColor,
+                  fontSize: 12,
+                  fontWeight: selected ? FontWeight.w900 : FontWeight.w800,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class CompactBoardDrawer extends StatelessWidget {
+  const CompactBoardDrawer({
+    super.key,
+    required this.isConnected,
+    required this.isBusy,
+    required this.repoCount,
+    required this.onConnectGitHub,
+    required this.onSelectRepositories,
+    required this.onImportIssues,
+    required this.onSyncIssues,
+    required this.onSearchIssues,
+    required this.onSignOut,
+    required this.workspaceName,
+    required this.selectedDestination,
+    required this.onIssueBoardTap,
+    required this.onRunsTap,
+    required this.onWorkersTap,
+    required this.onWorkflowsTap,
+    required this.onVariablesTap,
+    required this.onStoreReleaseTap,
+    this.onSwitchTeam,
+  });
+
+  final bool isConnected;
+  final bool isBusy;
+  final int repoCount;
+  final VoidCallback onConnectGitHub;
+  final VoidCallback onSelectRepositories;
+  final VoidCallback onImportIssues;
+  final VoidCallback onSyncIssues;
+  final VoidCallback onSearchIssues;
+  final Future<void> Function() onSignOut;
+  final String workspaceName;
+  final CompactBoardDestination selectedDestination;
+  final VoidCallback onIssueBoardTap;
+  final VoidCallback onRunsTap;
+  final VoidCallback onWorkersTap;
+  final VoidCallback onWorkflowsTap;
+  final VoidCallback onVariablesTap;
+  final VoidCallback onStoreReleaseTap;
+  final VoidCallback? onSwitchTeam;
+
+  @override
+  Widget build(BuildContext context) {
+    void closeDrawer() => Navigator.of(context).pop();
+    void runAfterClose(VoidCallback action) {
+      closeDrawer();
+      action();
+    }
+
+    return Drawer(
+      backgroundColor: const Color(0xFFF8FAFC),
+      child: SafeArea(
+        child: ListView(
+          padding: EdgeInsets.zero,
+          children: [
+            Padding(
+              padding: const EdgeInsets.fromLTRB(20, 20, 20, 18),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const Text(
+                    'OpenCI',
+                    style: TextStyle(
+                      color: Color(0xFF0F172A),
+                      fontSize: 24,
+                      fontWeight: FontWeight.w900,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    workspaceName,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: const TextStyle(
+                      color: Color(0xFF475569),
+                      fontWeight: FontWeight.w800,
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    isConnected ? '$repoCount repo connected' : 'GitHub未接続',
+                    style: const TextStyle(
+                      color: Color(0xFF64748B),
+                      fontSize: 12,
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const Divider(height: 1),
+            const _CompactDrawerSectionLabel('ナビゲーション'),
+            _CompactDrawerTile(
+              icon: Icons.view_kanban_outlined,
+              label: 'ワークスペース',
+              selected:
+                  selectedDestination == CompactBoardDestination.issueBoard,
+              onTap: () => runAfterClose(onIssueBoardTap),
+            ),
+            _CompactDrawerTile(
+              icon: Icons.history_rounded,
+              label: 'CI/CDログ',
+              selected: selectedDestination == CompactBoardDestination.runs,
+              onTap: () => runAfterClose(onRunsTap),
+            ),
+            _CompactDrawerTile(
+              icon: Icons.dns_outlined,
+              label: 'ワーカー',
+              selected: selectedDestination == CompactBoardDestination.workers,
+              onTap: () => runAfterClose(onWorkersTap),
+            ),
+            _CompactDrawerTile(
+              icon: Icons.schema_rounded,
+              label: 'CI/CD設定',
+              selected:
+                  selectedDestination == CompactBoardDestination.workflows,
+              onTap: () => runAfterClose(onWorkflowsTap),
+            ),
+            _CompactDrawerTile(
+              icon: Icons.key_rounded,
+              label: '変数',
+              selected:
+                  selectedDestination == CompactBoardDestination.variables,
+              onTap: () => runAfterClose(onVariablesTap),
+            ),
+            _CompactDrawerTile(
+              icon: Icons.rocket_launch_outlined,
+              label: 'ストアリリース',
+              selected:
+                  selectedDestination == CompactBoardDestination.storeRelease,
+              onTap: () => runAfterClose(onStoreReleaseTap),
+            ),
+            const Divider(height: 24),
+            const _CompactDrawerSectionLabel('GitHub'),
+            if (!isConnected)
+              _CompactDrawerTile(
+                icon: Icons.link_rounded,
+                label: 'GitHub App接続',
+                enabled: !isBusy,
+                onTap: () => runAfterClose(onConnectGitHub),
+              ),
+            _CompactDrawerTile(
+              icon: Icons.account_tree_outlined,
+              label: '$repoCount repo',
+              enabled: !isBusy && isConnected,
+              onTap: () => runAfterClose(onSelectRepositories),
+            ),
+            _CompactDrawerTile(
+              icon: Icons.download_rounded,
+              label: 'issue取り込み',
+              enabled: !isBusy && isConnected,
+              onTap: () => runAfterClose(onImportIssues),
+            ),
+            _CompactDrawerTile(
+              icon: Icons.sync_outlined,
+              label: '未同期を同期',
+              enabled: !isBusy && isConnected,
+              onTap: () => runAfterClose(onSyncIssues),
+            ),
+            const Divider(height: 24),
+            const _CompactDrawerSectionLabel('アカウント'),
+            _CompactDrawerTile(
+              icon: Icons.search_outlined,
+              label: 'issue検索',
+              onTap: () => runAfterClose(onSearchIssues),
+            ),
+            if (onSwitchTeam != null)
+              _CompactDrawerTile(
+                icon: Icons.groups_2_outlined,
+                label: 'チームを切り替え',
+                onTap: () => runAfterClose(onSwitchTeam!),
+              ),
+            _CompactDrawerTile(
+              icon: Icons.logout_rounded,
+              label: 'サインアウト',
+              onTap: () {
+                closeDrawer();
+                unawaited(onSignOut());
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _CompactDrawerSectionLabel extends StatelessWidget {
+  const _CompactDrawerSectionLabel(this.label);
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(20, 16, 20, 6),
+      child: Text(
+        label,
+        style: const TextStyle(
+          color: Color(0xFF94A3B8),
+          fontSize: 12,
+          fontWeight: FontWeight.w700,
+          letterSpacing: 0,
+        ),
+      ),
+    );
+  }
+}
+
+class _CompactDrawerTile extends StatelessWidget {
+  const _CompactDrawerTile({
+    required this.icon,
+    required this.label,
+    required this.onTap,
+    this.enabled = true,
+    this.selected = false,
+  });
+
+  final IconData icon;
+  final String label;
+  final VoidCallback onTap;
+  final bool enabled;
+  final bool selected;
+
+  @override
+  Widget build(BuildContext context) {
+    final color = selected
+        ? const Color(0xFF2563EB)
+        : enabled
+        ? const Color(0xFF0F172A)
+        : const Color(0xFFCBD5E1);
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 8),
+      child: ListTile(
+        enabled: enabled,
+        selected: selected,
+        selectedTileColor: const Color(0xFFEFF6FF),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
+        leading: Icon(icon, color: color),
+        title: Text(
+          label,
+          overflow: TextOverflow.ellipsis,
+          style: TextStyle(
+            color: color,
+            fontWeight: selected ? FontWeight.w700 : FontWeight.w500,
+          ),
+        ),
+        onTap: enabled ? onTap : null,
+      ),
+    );
+  }
+}
+
+class ToolbarChip extends StatelessWidget {
+  const ToolbarChip({
+    super.key,
+    required this.icon,
+    required this.label,
+    this.tooltip,
+    this.onPressed,
+  });
+
+  final IconData icon;
+  final String label;
+  final String? tooltip;
+  final VoidCallback? onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    final borderRadius = BorderRadius.circular(999);
+    final chip = Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 7),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        border: Border.all(color: const Color(0xFFE2E8F0)),
+        borderRadius: borderRadius,
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: 15, color: const Color(0xFF475569)),
+          const SizedBox(width: 6),
+          Text(
+            label,
+            style: const TextStyle(
+              color: Color(0xFF334155),
+              fontSize: 12,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ],
+      ),
+    );
+
+    if (onPressed == null) {
+      return chip;
+    }
+
+    return Tooltip(
+      message: tooltip ?? label,
+      child: Material(
+        type: MaterialType.transparency,
+        child: InkWell(
+          borderRadius: borderRadius,
+          onTap: onPressed,
+          child: chip,
+        ),
+      ),
+    );
+  }
+}
+
+class IssueSearchDialog extends StatefulWidget {
+  const IssueSearchDialog({
+    super.key,
+    required this.columns,
+    this.initialQuery = '',
+  });
+
+  final List<BoardColumn> columns;
+  final String initialQuery;
+
+  @override
+  State<IssueSearchDialog> createState() => _IssueSearchDialogState();
+}
+
+class _IssueSearchDialogState extends State<IssueSearchDialog> {
+  final _queryController = TextEditingController();
+  String? _selectedIssueId;
+
+  @override
+  void initState() {
+    super.initState();
+    _queryController.text = widget.initialQuery;
+  }
+
+  @override
+  void dispose() {
+    _queryController.dispose();
+    super.dispose();
+  }
+
+  List<_IssueSearchEntry> get _entries => [
+    for (final column in widget.columns)
+      for (final issue in visibleIssuesForColumn(column))
+        _IssueSearchEntry(issue: issue, column: column),
+  ];
+
+  List<_IssueSearchEntry> get _filteredEntries {
+    final tokens = _queryController.text
+        .trim()
+        .toLowerCase()
+        .split(RegExp(r'\s+'))
+        .where((token) => token.isNotEmpty)
+        .toList();
+    if (tokens.isEmpty) {
+      return _entries;
+    }
+
+    return [
+      for (final entry in _entries)
+        if (entry.matches(tokens)) entry,
+    ];
+  }
+
+  _IssueSearchEntry? _selectedEntryFor(List<_IssueSearchEntry> entries) {
+    if (entries.isEmpty) {
+      return null;
+    }
+
+    final selectedIssueId = _selectedIssueId;
+    if (selectedIssueId != null) {
+      for (final entry in entries) {
+        if (entry.issue.id == selectedIssueId) {
+          return entry;
+        }
+      }
+    }
+
+    return entries.first;
+  }
+
+  void _select(_IssueSearchEntry entry) {
+    setState(() => _selectedIssueId = entry.issue.id);
+  }
+
+  void _open(_IssueSearchEntry entry) {
+    Navigator.of(context).pop(
+      IssueSearchDialogResult(
+        issueId: entry.issue.id,
+        query: _queryController.text,
+      ),
+    );
+  }
+
+  void _selectFirstMatch() {
+    final entries = _filteredEntries;
+    if (entries.isEmpty) {
+      return;
+    }
+
+    _open(_selectedEntryFor(entries) ?? entries.first);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final screenSize = MediaQuery.sizeOf(context);
+    final isCompactDialog = screenSize.width < 560;
+    final maxHeight = screenSize.height * (isCompactDialog ? 0.92 : 0.86);
+    final dialogPadding = EdgeInsets.all(isCompactDialog ? 18 : 24);
+    final dialogBorderRadius = BorderRadius.circular(isCompactDialog ? 22 : 28);
+    final query = _queryController.text;
+    final entries = _filteredEntries;
+    final selectedEntry = _selectedEntryFor(entries);
+    final usesSplitNavigator = screenSize.width >= 820;
+
+    return Dialog(
+      insetPadding: EdgeInsets.symmetric(
+        horizontal: isCompactDialog ? 12 : 20,
+        vertical: isCompactDialog ? 12 : 24,
+      ),
+      backgroundColor: Colors.white,
+      surfaceTintColor: Colors.transparent,
+      shape: RoundedRectangleBorder(borderRadius: dialogBorderRadius),
+      clipBehavior: Clip.antiAlias,
+      child: ConstrainedBox(
+        constraints: BoxConstraints(
+          maxWidth: usesSplitNavigator ? 1040 : 720,
+          maxHeight: maxHeight,
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Container(
+              padding: dialogPadding.copyWith(bottom: 16),
+              decoration: const BoxDecoration(
+                border: Border(bottom: BorderSide(color: Color(0xFFE2E8F0))),
+              ),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          'Issueを検索',
+                          style: Theme.of(context).textTheme.titleLarge
+                              ?.copyWith(fontWeight: FontWeight.w800),
+                        ),
+                        const SizedBox(height: 4),
+                        const Text(
+                          'タイトル、repo、label、担当者で探せます。Enterで先頭のIssueを開きます。',
+                          style: TextStyle(color: Color(0xFF64748B)),
+                        ),
+                      ],
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  if (!isCompactDialog && query.isEmpty)
+                    const _IssueSearchShortcutPill(label: '⌘K'),
+                  IconButton(
+                    tooltip: '検索を閉じる',
+                    onPressed: () => Navigator.of(context).pop(),
+                    icon: const Icon(Icons.close_rounded),
+                  ),
+                ],
+              ),
+            ),
+            Padding(
+              padding: dialogPadding.copyWith(top: 18, bottom: 12),
+              child: Column(
+                children: [
+                  TextField(
+                    controller: _queryController,
+                    autofocus: true,
+                    textInputAction: TextInputAction.search,
+                    style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                      fontWeight: FontWeight.w700,
+                      letterSpacing: 0,
+                    ),
+                    onChanged: (_) => setState(() => _selectedIssueId = null),
+                    onSubmitted: (_) => _selectFirstMatch(),
+                    decoration: InputDecoration(
+                      hintText: 'issueを検索...',
+                      hintStyle: const TextStyle(
+                        color: Color(0xFF94A3B8),
+                        fontWeight: FontWeight.w600,
+                      ),
+                      prefixIcon: const Icon(
+                        Icons.search_rounded,
+                        color: Color(0xFF64748B),
+                      ),
+                      suffixIcon: query.isEmpty
+                          ? null
+                          : IconButton(
+                              tooltip: '検索をクリア',
+                              onPressed: () {
+                                _queryController.clear();
+                                setState(() {});
+                              },
+                              icon: const Icon(Icons.close_rounded),
+                            ),
+                      filled: true,
+                      fillColor: const Color(0xFFF8FAFC),
+                      border: OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(16),
+                        borderSide: const BorderSide(color: Color(0xFFE2E8F0)),
+                      ),
+                      enabledBorder: OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(16),
+                        borderSide: const BorderSide(color: Color(0xFFE2E8F0)),
+                      ),
+                      focusedBorder: OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(16),
+                        borderSide: const BorderSide(
+                          color: Color(0xFF1D4ED8),
+                          width: 1.5,
+                        ),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 10),
+                  Row(
+                    children: [
+                      Text(
+                        '${entries.length}件',
+                        style: const TextStyle(
+                          color: Color(0xFF64748B),
+                          fontSize: 12,
+                          fontWeight: FontWeight.w800,
+                          letterSpacing: 0,
+                        ),
+                      ),
+                      const Spacer(),
+                      const _IssueSearchShortcutPill(label: 'Enterで編集'),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+            Flexible(
+              child: entries.isEmpty
+                  ? _IssueSearchEmptyState(hasQuery: query.isNotEmpty)
+                  : usesSplitNavigator
+                  ? Padding(
+                      padding: EdgeInsets.fromLTRB(
+                        dialogPadding.left,
+                        0,
+                        dialogPadding.right,
+                        dialogPadding.bottom,
+                      ),
+                      child: Row(
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                        children: [
+                          SizedBox(
+                            width: 360,
+                            child: ListView.builder(
+                              shrinkWrap: true,
+                              itemCount: entries.length,
+                              itemBuilder: (context, index) {
+                                final entry = entries[index];
+                                return _IssueSearchResultTile(
+                                  entry: entry,
+                                  selected:
+                                      entry.issue.id == selectedEntry?.issue.id,
+                                  onTap: () => _select(entry),
+                                );
+                              },
+                            ),
+                          ),
+                          const SizedBox(width: 14),
+                          Expanded(
+                            child: _IssueSearchDetailPane(
+                              entry: selectedEntry,
+                              onOpen: selectedEntry == null
+                                  ? null
+                                  : () => _open(selectedEntry),
+                            ),
+                          ),
+                        ],
+                      ),
+                    )
+                  : ListView.builder(
+                      shrinkWrap: true,
+                      padding: EdgeInsets.fromLTRB(
+                        dialogPadding.left,
+                        0,
+                        dialogPadding.right,
+                        dialogPadding.bottom,
+                      ),
+                      itemCount: entries.length,
+                      itemBuilder: (context, index) {
+                        final entry = entries[index];
+                        return _IssueSearchResultTile(
+                          entry: entry,
+                          selected: false,
+                          onTap: () => _open(entry),
+                        );
+                      },
+                    ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _IssueSearchShortcutPill extends StatelessWidget {
+  const _IssueSearchShortcutPill({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      decoration: BoxDecoration(
+        color: const Color(0xFFF1F5F9),
+        border: Border.all(color: const Color(0xFFE2E8F0)),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Text(
+        label,
+        style: const TextStyle(
+          color: Color(0xFF64748B),
+          fontSize: 11,
+          fontWeight: FontWeight.w800,
+        ),
+      ),
+    );
+  }
+}
+
+class _IssueSearchEmptyState extends StatelessWidget {
+  const _IssueSearchEmptyState({required this.hasQuery});
+
+  final bool hasQuery;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 34),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Container(
+            width: 46,
+            height: 46,
+            decoration: BoxDecoration(
+              color: const Color(0xFFF8FAFC),
+              border: Border.all(color: const Color(0xFFE2E8F0)),
+              borderRadius: BorderRadius.circular(18),
+            ),
+            child: const Icon(
+              Icons.search_off_rounded,
+              color: Color(0xFF94A3B8),
+              size: 24,
+            ),
+          ),
+          const SizedBox(height: 12),
+          Text(
+            hasQuery ? '一致するIssueがありません' : '検索できるIssueがありません',
+            style: const TextStyle(
+              color: Color(0xFF334155),
+              fontWeight: FontWeight.w800,
+            ),
+          ),
+          const SizedBox(height: 4),
+          const Text(
+            'タイトル、repo、label、担当者で探せます',
+            style: TextStyle(color: Color(0xFF64748B), fontSize: 12),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _IssueSearchResultTile extends StatelessWidget {
+  const _IssueSearchResultTile({
+    required this.entry,
+    required this.selected,
+    required this.onTap,
+  });
+
+  final _IssueSearchEntry entry;
+  final bool selected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final issue = entry.issue;
+    final labels = issue.labels.take(3).toList();
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: Material(
+        color: selected ? const Color(0xFFEFF6FF) : const Color(0xFFF8FAFC),
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(16),
+          side: BorderSide(
+            color: selected ? const Color(0xFFBFDBFE) : const Color(0xFFE2E8F0),
+          ),
+        ),
+        child: InkWell(
+          customBorder: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(16),
+          ),
+          onTap: onTap,
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Container(
+                  width: 36,
+                  height: 36,
+                  alignment: Alignment.center,
+                  decoration: BoxDecoration(
+                    color: entry.column.color.withValues(alpha: 0.1),
+                    borderRadius: BorderRadius.circular(14),
+                  ),
+                  child: Icon(
+                    Icons.radio_button_unchecked_rounded,
+                    size: 16,
+                    color: entry.column.color,
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        issue.title,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                          color: const Color(0xFF0F172A),
+                          fontWeight: FontWeight.w800,
+                          height: 1.25,
+                        ),
+                      ),
+                      const SizedBox(height: 7),
+                      Wrap(
+                        spacing: 6,
+                        runSpacing: 6,
+                        children: [
+                          _IssueSearchMetaPill(label: issue.displayId),
+                          _IssueSearchMetaPill(label: issue.repo),
+                          _IssueSearchMetaPill(label: entry.column.title),
+                          for (final label in labels)
+                            _IssueSearchMetaPill(label: label),
+                        ],
+                      ),
+                    ],
+                  ),
+                ),
+                const SizedBox(width: 10),
+                const Padding(
+                  padding: EdgeInsets.only(top: 8),
+                  child: Icon(
+                    Icons.north_east_rounded,
+                    size: 16,
+                    color: Color(0xFFCBD5E1),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _IssueSearchDetailPane extends StatelessWidget {
+  const _IssueSearchDetailPane({required this.entry, required this.onOpen});
+
+  final _IssueSearchEntry? entry;
+  final VoidCallback? onOpen;
+
+  @override
+  Widget build(BuildContext context) {
+    final entry = this.entry;
+    if (entry == null) {
+      return const DecoratedBox(
+        decoration: BoxDecoration(
+          color: Color(0xFFF8FAFC),
+          borderRadius: BorderRadius.all(Radius.circular(18)),
+          border: Border.fromBorderSide(BorderSide(color: Color(0xFFE2E8F0))),
+        ),
+        child: Center(
+          child: Text(
+            'Issueを選択してください',
+            style: TextStyle(
+              color: Color(0xFF64748B),
+              fontWeight: FontWeight.w700,
+            ),
+          ),
+        ),
+      );
+    }
+
+    final issue = entry.issue;
+    final body = issue.body.trim();
+    final labels = issue.labels.take(8).toList();
+    final pullRequest = issue.pullRequests.isEmpty
+        ? null
+        : issue.pullRequests.last;
+
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: const Color(0xFFF8FAFC),
+        border: Border.all(color: const Color(0xFFE2E8F0)),
+        borderRadius: BorderRadius.circular(18),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(18, 18, 18, 14),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Wrap(
+                  spacing: 6,
+                  runSpacing: 6,
+                  children: [
+                    _IssueSearchMetaPill(label: issue.displayId),
+                    _IssueSearchMetaPill(label: issue.repo),
+                    _IssueSearchMetaPill(label: entry.column.title),
+                    _IssueSearchMetaPill(
+                      label: _issuePriorityLabel(issue.priority),
+                    ),
+                    if (issue.dueDate != null)
+                      _IssueSearchMetaPill(label: formatDate(issue.dueDate!)),
+                  ],
+                ),
+                const SizedBox(height: 14),
+                Text(
+                  issue.title,
+                  style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                    color: const Color(0xFF0F172A),
+                    fontWeight: FontWeight.w800,
+                    height: 1.2,
+                  ),
+                ),
+                if (labels.isNotEmpty) ...[
+                  const SizedBox(height: 12),
+                  Wrap(
+                    spacing: 6,
+                    runSpacing: 6,
+                    children: [
+                      for (final label in labels)
+                        _IssueSearchMetaPill(label: label),
+                    ],
+                  ),
+                ],
+              ],
+            ),
+          ),
+          const Divider(height: 1, color: Color(0xFFE2E8F0)),
+          Expanded(
+            child: SingleChildScrollView(
+              padding: const EdgeInsets.all(18),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    body.isEmpty ? '本文はありません' : body,
+                    style: TextStyle(
+                      color: body.isEmpty
+                          ? const Color(0xFF94A3B8)
+                          : const Color(0xFF334155),
+                      height: 1.5,
+                      fontWeight: body.isEmpty ? FontWeight.w700 : null,
+                    ),
+                  ),
+                  if (pullRequest != null) ...[
+                    const SizedBox(height: 18),
+                    _IssueSearchDetailCallout(
+                      icon: Icons.account_tree_outlined,
+                      title: 'Pull request',
+                      value: '#${pullRequest.number} ${pullRequest.title}',
+                    ),
+                  ],
+                  if (issue.subIssuesSummary != null) ...[
+                    const SizedBox(height: 10),
+                    _IssueSearchDetailCallout(
+                      icon: Icons.checklist_rounded,
+                      title: 'Sub-issues',
+                      value:
+                          '${issue.subIssuesSummary!.completed}/${issue.subIssuesSummary!.total} completed',
+                    ),
+                  ],
+                ],
+              ),
+            ),
+          ),
+          Container(
+            padding: const EdgeInsets.all(14),
+            decoration: const BoxDecoration(
+              color: Colors.white,
+              border: Border(top: BorderSide(color: Color(0xFFE2E8F0))),
+            ),
+            child: Row(
+              children: [
+                const Text(
+                  'カード選択で詳細を切り替え',
+                  style: TextStyle(
+                    color: Color(0xFF64748B),
+                    fontSize: 12,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+                const Spacer(),
+                FilledButton.icon(
+                  onPressed: onOpen,
+                  icon: const Icon(Icons.edit_outlined, size: 18),
+                  label: const Text('編集する'),
+                  style: FilledButton.styleFrom(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 16,
+                      vertical: 12,
+                    ),
+                    textStyle: const TextStyle(fontWeight: FontWeight.w800),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _IssueSearchDetailCallout extends StatelessWidget {
+  const _IssueSearchDetailCallout({
+    required this.icon,
+    required this.title,
+    required this.value,
+  });
+
+  final IconData icon;
+  final String title;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        border: Border.all(color: const Color(0xFFE2E8F0)),
+        borderRadius: BorderRadius.circular(14),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(icon, size: 18, color: const Color(0xFF2563EB)),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  title,
+                  style: const TextStyle(
+                    color: Color(0xFF64748B),
+                    fontSize: 12,
+                    fontWeight: FontWeight.w800,
+                  ),
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  value,
+                  style: const TextStyle(
+                    color: Color(0xFF334155),
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+String _issuePriorityLabel(Priority priority) {
+  switch (priority) {
+    case Priority.high:
+      return '優先度: 高';
+    case Priority.medium:
+      return '優先度: 中';
+    case Priority.low:
+      return '優先度: 低';
+  }
+}
+
+class _IssueSearchMetaPill extends StatelessWidget {
+  const _IssueSearchMetaPill({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 7, vertical: 3),
+      decoration: BoxDecoration(
+        color: const Color(0xFFF8FAFC),
+        border: Border.all(color: const Color(0xFFE2E8F0)),
+        borderRadius: BorderRadius.circular(999),
+      ),
+      child: Text(
+        label,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+        style: const TextStyle(
+          color: Color(0xFF64748B),
+          fontSize: 11,
+          fontWeight: FontWeight.w800,
+        ),
+      ),
+    );
+  }
+}
+
+class _IssueSearchEntry {
+  const _IssueSearchEntry({required this.issue, required this.column});
+
+  final Issue issue;
+  final BoardColumn column;
+
+  bool matches(List<String> tokens) {
+    final searchableText = [
+      issue.id,
+      issue.displayId,
+      issue.issueKey ?? '',
+      issue.repo,
+      issue.title,
+      issue.body,
+      issue.priority.name,
+      column.title,
+      ...issue.labels,
+      for (final pullRequest in issue.pullRequests) ...[
+        '${pullRequest.number}',
+        pullRequest.title,
+        pullRequest.branch,
+      ],
+    ].join(' ').toLowerCase();
+
+    return tokens.every(searchableText.contains);
+  }
+}
+
+class IssueSearchDialogResult {
+  const IssueSearchDialogResult({required this.issueId, required this.query});
+
+  final String issueId;
+  final String query;
+}
+
+class RepositoryPickerBottomSheet extends StatefulWidget {
+  const RepositoryPickerBottomSheet({
+    super.key,
+    required this.initiallySelected,
+    required this.loadRepositories,
+  });
+
+  final Set<String> initiallySelected;
+  final Future<List<GitHubRepository>> Function() loadRepositories;
+
+  @override
+  State<RepositoryPickerBottomSheet> createState() =>
+      _RepositoryPickerBottomSheetState();
+}
+
+class _RepositoryPickerBottomSheetState
+    extends State<RepositoryPickerBottomSheet> {
+  late final Set<String> _selected = {...widget.initiallySelected};
+  late Future<List<GitHubRepository>> _repositoriesFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _repositoriesFuture = widget.loadRepositories();
+  }
+
+  void _retry() {
+    final future = widget.loadRepositories();
+    setState(() {
+      _repositoriesFuture = future;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: MediaQuery.sizeOf(context).height * 0.78,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(24, 8, 24, 16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'GitHub repoを選択',
+                  style: Theme.of(context).textTheme.titleLarge,
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  '同期するrepoを選んでください。',
+                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    color: Theme.of(context).colorScheme.onSurfaceVariant,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          Expanded(
+            child: FutureBuilder<List<GitHubRepository>>(
+              future: _repositoriesFuture,
+              builder: (context, snapshot) {
+                if (snapshot.connectionState != ConnectionState.done) {
+                  return const _RepositoryPickerLoading();
+                }
+
+                if (snapshot.hasError) {
+                  return _RepositoryPickerError(onRetry: _retry);
+                }
+
+                final repositories = snapshot.data ?? const [];
+                if (repositories.isEmpty) {
+                  return const Center(child: Text('repoが見つかりませんでした。'));
+                }
+
+                return ListView.builder(
+                  padding: const EdgeInsets.symmetric(horizontal: 8),
+                  itemCount: repositories.length,
+                  itemBuilder: (context, index) {
+                    final repo = repositories[index];
+                    final selected = _selected.contains(repo.fullName);
+
+                    return CheckboxListTile(
+                      value: selected,
+                      title: Text(repo.fullName),
+                      subtitle: Text(
+                        '${repo.private ? '非公開' : '公開'} / ${repo.defaultBranch}',
+                      ),
+                      onChanged: (value) {
+                        setState(() {
+                          if (value == true) {
+                            _selected.add(repo.fullName);
+                          } else {
+                            _selected.remove(repo.fullName);
+                          }
+                        });
+                      },
+                    );
+                  },
+                );
+              },
+            ),
+          ),
+          SafeArea(
+            top: false,
+            child: Padding(
+              padding: const EdgeInsets.fromLTRB(16, 12, 16, 16),
+              child: Row(
+                children: [
+                  TextButton(
+                    onPressed: () => Navigator.of(context).pop(),
+                    child: const Text('キャンセル'),
+                  ),
+                  const Spacer(),
+                  TextButton(
+                    onPressed: () => setState(_selected.clear),
+                    child: const Text('クリア'),
+                  ),
+                  const SizedBox(width: 8),
+                  FilledButton(
+                    onPressed: () => Navigator.of(context).pop(_selected),
+                    child: Text('${_selected.length}件のrepoを保存'),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _RepositoryPickerLoading extends StatelessWidget {
+  const _RepositoryPickerLoading();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          CircularProgressIndicator(),
+          SizedBox(height: 16),
+          Text('repoを読み込んでいます...'),
+        ],
+      ),
+    );
+  }
+}
+
+class _RepositoryPickerError extends StatelessWidget {
+  const _RepositoryPickerError({required this.onRetry});
+
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              Icons.error_outline_rounded,
+              color: colorScheme.error,
+              size: 32,
+            ),
+            const SizedBox(height: 12),
+            const Text('repoの読み込みに失敗しました。'),
+            const SizedBox(height: 16),
+            FilledButton.icon(
+              onPressed: onRetry,
+              icon: const Icon(Icons.refresh_rounded),
+              label: const Text('再読み込み'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/apps/dashboard/lib/workspace/issue_board_ima_utils.dart
+++ b/apps/dashboard/lib/workspace/issue_board_ima_utils.dart
@@ -1,0 +1,320 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:cloud_functions/cloud_functions.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'issue_board_ima_models.dart';
+import 'issue_board_ima_overview.dart';
+
+Map<String, dynamic> asMap(Object? value) {
+  if (value is Map<String, dynamic>) {
+    return value;
+  }
+  if (value is Map) {
+    return value.map((key, value) => MapEntry(key.toString(), value));
+  }
+  return {};
+}
+
+List<Object?> asList(Object? value) {
+  return value is List ? value : const [];
+}
+
+String asString(Object? value, [String fallback = '']) {
+  return value is String && value.isNotEmpty ? value : fallback;
+}
+
+String? emptyToNull(String value) {
+  return value.isEmpty ? null : value;
+}
+
+int asInt(Object? value, [int fallback = 0]) {
+  if (value is int) {
+    return value;
+  }
+  if (value is num) {
+    return value.toInt();
+  }
+  return fallback;
+}
+
+double asDouble(Object? value, [double fallback = 0]) {
+  if (value is num) {
+    return value.toDouble();
+  }
+  return fallback;
+}
+
+List<String> asStringList(Object? value) {
+  if (value is! List) {
+    return const [];
+  }
+
+  return value
+      .whereType<String>()
+      .where((label) => label.trim().isNotEmpty)
+      .toList();
+}
+
+String pullRequestLinkId(String repository, int number) {
+  return '${repository}_$number'.replaceAll(RegExp(r'[^a-zA-Z0-9_-]'), '_');
+}
+
+int issueProgressWeight(Issue issue) {
+  return issue.resolution?.actualWeight ?? issue.weightEstimate?.value ?? 0;
+}
+
+DailyProgressPrediction buildDailyProgressPrediction({
+  required int targetWeight,
+  required DailyPaceBucket todayBucket,
+  required List<DailyPaceBucket> historicalBuckets,
+  required DateTime now,
+}) {
+  if (targetWeight <= 0) {
+    return const DailyProgressPrediction(
+      finishProbability: 0,
+      paceLabel: '未設定',
+      advice: '目標を設定してください',
+      color: Color(0xFF64748B),
+      requiredAfternoonWeight: 0,
+      historicalAfternoonMedian: 0,
+      sampleCount: 0,
+      usesFallback: true,
+    );
+  }
+
+  final remainingWeight = positive(targetWeight - todayBucket.totalWeight);
+  final requiredAfternoonWeight = now.hour < 12
+      ? positive(targetWeight - todayBucket.morningWeight)
+      : remainingWeight;
+  final historicalAfternoonMedian = median(
+    historicalBuckets.map((bucket) => bucket.afternoonWeight).toList(),
+  );
+
+  if (todayBucket.totalWeight >= targetWeight) {
+    final overWeight = todayBucket.totalWeight - targetWeight;
+    return DailyProgressPrediction(
+      finishProbability: 100,
+      paceLabel: '達成',
+      advice: overWeight > 0 ? '達成 · +W$overWeight' : '達成',
+      color: const Color(0xFF15803D),
+      requiredAfternoonWeight: 0,
+      historicalAfternoonMedian: historicalAfternoonMedian,
+      sampleCount: historicalBuckets.length,
+      usesFallback: false,
+    );
+  }
+
+  final comparableBuckets = historicalBuckets
+      .where(
+        (bucket) =>
+            bucket.totalWeight > 0 &&
+            bucket.weightAtCurrentTime <= todayBucket.weightAtCurrentTime,
+      )
+      .toList();
+  final futureWeights = historicalBuckets
+      .where((bucket) => bucket.totalWeight > 0)
+      .map(
+        (bucket) => positive(bucket.totalWeight - bucket.weightAtCurrentTime),
+      )
+      .toList();
+
+  final int finishProbability;
+  final int sampleCount;
+  final bool usesFallback;
+  if (comparableBuckets.length >= 3) {
+    final achievedDays = comparableBuckets
+        .where((bucket) => bucket.totalWeight >= targetWeight)
+        .length;
+    finishProbability = (achievedDays / comparableBuckets.length * 100).round();
+    sampleCount = comparableBuckets.length;
+    usesFallback = false;
+  } else {
+    final projectedWeight = todayBucket.totalWeight + median(futureWeights);
+    finishProbability = (projectedWeight / targetWeight * 100)
+        .round()
+        .clamp(0, 95)
+        .toInt();
+    sampleCount = futureWeights.length;
+    usesFallback = true;
+  }
+
+  final isMorning = now.hour < 12;
+  if (finishProbability >= 75) {
+    return DailyProgressPrediction(
+      finishProbability: finishProbability,
+      paceLabel: '順調',
+      advice: '順調 · このペースなら達成見込み',
+      color: const Color(0xFF15803D),
+      requiredAfternoonWeight: requiredAfternoonWeight,
+      historicalAfternoonMedian: historicalAfternoonMedian,
+      sampleCount: sampleCount,
+      usesFallback: usesFallback,
+    );
+  }
+
+  if (finishProbability >= 45) {
+    final advice = isMorning
+        ? '午前遅め · 午後にW$requiredAfternoonWeight必要'
+        : 'ペース遅め · 残りW$remainingWeight';
+    return DailyProgressPrediction(
+      finishProbability: finishProbability,
+      paceLabel: '遅め',
+      advice: advice,
+      color: const Color(0xFFA16207),
+      requiredAfternoonWeight: requiredAfternoonWeight,
+      historicalAfternoonMedian: historicalAfternoonMedian,
+      sampleCount: sampleCount,
+      usesFallback: usesFallback,
+    );
+  }
+
+  final advice = isMorning
+      ? '達成厳しめ · 午後にW$requiredAfternoonWeight必要'
+      : '達成厳しめ · いつもより速いペースが必要';
+  return DailyProgressPrediction(
+    finishProbability: finishProbability,
+    paceLabel: '厳しめ',
+    advice: advice,
+    color: const Color(0xFFDC2626),
+    requiredAfternoonWeight: requiredAfternoonWeight,
+    historicalAfternoonMedian: historicalAfternoonMedian,
+    sampleCount: sampleCount,
+    usesFallback: usesFallback,
+  );
+}
+
+int positive(num value) {
+  return value > 0 ? value.round() : 0;
+}
+
+double median(List<int> values) {
+  if (values.isEmpty) {
+    return 0;
+  }
+  values.sort();
+  final middle = values.length ~/ 2;
+  if (values.length.isOdd) {
+    return values[middle].toDouble();
+  }
+  return (values[middle - 1] + values[middle]) / 2;
+}
+
+bool isAtOrBeforeTimeOfDay(DateTime value, DateTime cutoff) {
+  if (value.hour != cutoff.hour) {
+    return value.hour < cutoff.hour;
+  }
+  if (value.minute != cutoff.minute) {
+    return value.minute <= cutoff.minute;
+  }
+  return value.second <= cutoff.second;
+}
+
+DateTime? asDate(Object? value) {
+  if (value is Timestamp) {
+    return value.toDate();
+  }
+  if (value is DateTime) {
+    return value;
+  }
+  return null;
+}
+
+Priority priorityFromString(String value) {
+  return Priority.values.firstWhere(
+    (priority) => priority.name == value,
+    orElse: () => Priority.medium,
+  );
+}
+
+double rankBetween(double? previousRank, double? nextRank) {
+  if (previousRank != null && nextRank != null) {
+    return (previousRank + nextRank) / 2;
+  }
+  if (previousRank != null) {
+    return previousRank + 1000;
+  }
+  if (nextRank != null) {
+    return nextRank - 1000;
+  }
+  return DateTime.now().millisecondsSinceEpoch.toDouble();
+}
+
+String friendlyError(Object error) {
+  if (error is FirebaseFunctionsException) {
+    return error.message ?? error.code;
+  }
+  if (error is FirebaseException) {
+    return error.message ?? error.code;
+  }
+  if (error is Error) {
+    return error.toString();
+  }
+  return '$error';
+}
+
+bool isGitHubAppNotInstalledError(Object error) {
+  if (error is! FirebaseFunctionsException) {
+    return false;
+  }
+  final message = error.message ?? '';
+  return error.code == 'failed-precondition' &&
+      message.contains('GitHub App') &&
+      message.contains('not installed');
+}
+
+DateTime dateOnly(DateTime date) {
+  return DateTime(date.year, date.month, date.day);
+}
+
+String formatDate(DateTime date) {
+  return '${date.month}月${date.day}日';
+}
+
+String dailyHistoryDateLabel(DateTime date) {
+  final today = dateOnly(DateTime.now());
+  final targetDate = dateOnly(date);
+  final daysAgo = today.difference(targetDate).inDays;
+
+  if (daysAgo == 0) {
+    return '今日';
+  }
+  if (daysAgo == 1) {
+    return '昨日';
+  }
+  return formatDate(targetDate);
+}
+
+String dueDateLabel(DateTime date) {
+  final status = dueDateStatus(date);
+
+  return switch (status) {
+    DueDateStatus.overdue => '期限切れ',
+    DueDateStatus.today => '今日',
+    DueDateStatus.soon => formatDate(date),
+    DueDateStatus.later => formatDate(date),
+  };
+}
+
+DueDateStatus dueDateStatus(DateTime date) {
+  final today = dateOnly(DateTime.now());
+  final dueDate = dateOnly(date);
+  final daysUntilDue = dueDate.difference(today).inDays;
+
+  if (daysUntilDue < 0) {
+    return DueDateStatus.overdue;
+  }
+
+  if (daysUntilDue == 0) {
+    return DueDateStatus.today;
+  }
+
+  if (daysUntilDue <= 3) {
+    return DueDateStatus.soon;
+  }
+
+  return DueDateStatus.later;
+}
+
+enum DueDateStatus { overdue, today, soon, later }
+
+enum Priority { high, medium, low }

--- a/apps/dashboard/lib/workspace/issue_board_page.dart
+++ b/apps/dashboard/lib/workspace/issue_board_page.dart
@@ -1,0 +1,40 @@
+import 'package:dashboard/team/team_provider.dart';
+import 'package:dashboard/team/switch_team_bottom_sheet.dart';
+import 'package:dashboard/users/user_provider.dart';
+import 'package:dashboard/utilities/async_error_widget.dart';
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import 'issue_board_ima_page.dart';
+
+class IssueBoardBody extends ConsumerWidget {
+  const IssueBoardBody({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final userAsync = ref.watch(userProvider);
+    final teamAsync = ref.watch(teamStateProvider);
+
+    return userAsync.when(
+      loading: () => const Center(child: CircularProgressIndicator.adaptive()),
+      error: asyncErrorWidget,
+      data: (user) {
+        final teamName = teamAsync.asData?.value.name;
+        return IssueBoardPage(
+          key: ValueKey(user.selectedTeamId),
+          workspaceId: user.selectedTeamId,
+          workspaceName: teamName ?? 'OpenCI team',
+          onSwitchTeam: () => _showSwitchTeamBottomSheet(context),
+        );
+      },
+    );
+  }
+
+  Future<void> _showSwitchTeamBottomSheet(BuildContext context) {
+    return showModalBottomSheet<void>(
+      context: context,
+      showDragHandle: true,
+      builder: (_) => const SwitchTeamBottomSheet(),
+    );
+  }
+}

--- a/apps/dashboard/test/workspace/issue_board_ima_page_test.dart
+++ b/apps/dashboard/test/workspace/issue_board_ima_page_test.dart
@@ -1,0 +1,547 @@
+import 'package:dashboard/workspace/issue_board_ima_page.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('shouldSpinCardBuildStatus', () {
+    test('does not spin when any current CI job failed', () {
+      expect(
+        shouldSpinCardBuildStatus(failed: 1, active: 1, queuedOnly: false),
+        isFalse,
+      );
+    });
+
+    test('spins while non-queued jobs are still running', () {
+      expect(
+        shouldSpinCardBuildStatus(failed: 0, active: 1, queuedOnly: false),
+        isTrue,
+      );
+    });
+
+    test('does not spin for queued-only jobs', () {
+      expect(
+        shouldSpinCardBuildStatus(failed: 0, active: 1, queuedOnly: true),
+        isFalse,
+      );
+    });
+  });
+
+  group('IssuePullRequestDiff', () {
+    test('parses changed files and truncation flags', () {
+      final diff = IssuePullRequestDiff.fromMap({
+        'repository': 'openci-org/openci',
+        'pullRequestNumber': 1956,
+        'title': 'Show pull request diff',
+        'url': 'https://github.com/openci-org/openci/pull/1956',
+        'state': 'open',
+        'merged': false,
+        'mergeable': false,
+        'mergeableState': 'dirty',
+        'branch': 'IMA-391',
+        'additions': 12,
+        'deletions': 3,
+        'changedFiles': 1,
+        'ci': {
+          'status': 'success',
+          'total': 4,
+          'passed': 4,
+          'failed': 0,
+          'pending': 0,
+          'skipped': 0,
+          'checksTruncated': false,
+        },
+        'comments': [
+          {
+            'id': 'comment-1',
+            'author': 'coderabbitai',
+            'authorAssociation': 'NONE',
+            'body': 'Consider handling this edge case.',
+            'url':
+                'https://github.com/openci-org/openci/pull/1956#discussion_r1',
+            'createdAt': '2026-05-16T00:00:00Z',
+            'updatedAt': '2026-05-16T00:00:00Z',
+            'kind': 'review',
+            'path': 'lib/workspace/issue_board_ima_issue_editor.dart',
+            'line': 42,
+            'side': 'RIGHT',
+          },
+        ],
+        'commentsTruncated': false,
+        'filesTruncated': true,
+        'files': [
+          {
+            'filename': 'lib/workspace/issue_board_ima_issue_editor.dart',
+            'status': 'modified',
+            'additions': 12,
+            'deletions': 3,
+            'changes': 15,
+            'patch': '@@ -1 +1 @@',
+            'patchTruncated': true,
+            'blobUrl':
+                'https://github.com/openci-org/openci/blob/main/file.dart',
+            'rawUrl': 'https://github.com/openci-org/openci/raw/main/file.dart',
+          },
+        ],
+      });
+
+      expect(diff.repository, 'openci-org/openci');
+      expect(diff.pullRequestNumber, 1956);
+      expect(diff.mergeable, isFalse);
+      expect(diff.mergeableState, 'dirty');
+      expect(diff.filesTruncated, isTrue);
+      expect(diff.files.single.patchTruncated, isTrue);
+      expect(diff.files.single.additions, 12);
+      expect(diff.ci.allPassed, isTrue);
+      expect(diff.ci.passed, 4);
+      expect(diff.comments.single.author, 'coderabbitai');
+      expect(diff.comments.single.kind, IssuePullRequestCommentKind.review);
+      expect(
+        diff.comments.single.path,
+        'lib/workspace/issue_board_ima_issue_editor.dart',
+      );
+      expect(diff.comments.single.line, 42);
+    });
+
+    test('defaults missing CI summary to no checks', () {
+      final diff = IssuePullRequestDiff.fromMap({
+        'repository': 'openci-org/openci',
+        'pullRequestNumber': 1956,
+        'title': 'Show pull request diff',
+        'url': 'https://github.com/openci-org/openci/pull/1956',
+        'state': 'open',
+        'merged': false,
+        'branch': 'IMA-391',
+        'additions': 0,
+        'deletions': 0,
+        'changedFiles': 0,
+        'files': [],
+      });
+
+      expect(diff.ci.status, PullRequestCiStatus.none);
+      expect(diff.ci.total, 0);
+      expect(diff.ci.allPassed, isFalse);
+    });
+
+    test('expands small textual diffs by default', () {
+      const file = IssuePullRequestDiffFile(
+        filename: 'lib/main.dart',
+        status: 'modified',
+        additions: 2,
+        deletions: 1,
+        changes: 3,
+        patch: '@@ -1 +1 @@',
+        patchTruncated: false,
+        blobUrl: '',
+        rawUrl: '',
+      );
+
+      expect(diffFileInitiallyExpanded(file), isTrue);
+    });
+
+    test('detects syntax language from diff file names', () {
+      expect(
+        diffLanguageForFilename('lib/workspace/issue_board_ima_page.dart'),
+        'dart',
+      );
+      expect(diffLanguageForFilename('.openci/functions-ci.yaml'), 'yaml');
+      expect(
+        diffLanguageForFilename('firebase/functions/src/index.ts'),
+        'typescript',
+      );
+      expect(diffLanguageForFilename('Dockerfile'), 'dockerfile');
+    });
+
+    test('parses patch line kinds and line numbers', () {
+      final lines = diffPatchLines(
+        '@@ -10,2 +10,3 @@\n'
+        ' final title = oldTitle;\n'
+        '-debugPrint(title);\n'
+        '+logger.info(title);\n'
+        '+logger.info("done");\n'
+        r'\ No newline at end of file',
+      );
+
+      expect(lines[0].kind, DiffPatchLineKind.hunk);
+      expect(lines[1].kind, DiffPatchLineKind.context);
+      expect(lines[1].oldLineNumber, 10);
+      expect(lines[1].newLineNumber, 10);
+      expect(lines[2].kind, DiffPatchLineKind.removed);
+      expect(lines[2].oldLineNumber, 11);
+      expect(lines[2].newLineNumber, isNull);
+      expect(lines[3].kind, DiffPatchLineKind.added);
+      expect(lines[3].oldLineNumber, isNull);
+      expect(lines[3].newLineNumber, 11);
+      expect(lines[4].newLineNumber, 12);
+      expect(lines[5].kind, DiffPatchLineKind.meta);
+    });
+
+    testWidgets('retry keeps async diff loading outside setState', (
+      tester,
+    ) async {
+      var attempts = 0;
+
+      Future<IssuePullRequestDiff> loadDiff() {
+        attempts += 1;
+        return Future<IssuePullRequestDiff>.error(
+          Exception('diff unavailable'),
+        );
+      }
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: PullRequestDiffSheet(
+              issue: const Issue(
+                id: 'issue-1',
+                repo: 'openci-org/openci',
+                title: 'Review PR in OpenCI',
+                labels: [],
+                comments: 0,
+                priority: Priority.medium,
+              ),
+              pullRequest: const IssuePullRequest(
+                number: 1956,
+                title: 'Show pull request diff',
+                state: 'open',
+                merged: false,
+                branch: 'IMA-391',
+              ),
+              loadDiff: loadDiff,
+              onMerge: null,
+            ),
+          ),
+        ),
+      );
+
+      await tester.pump(const Duration(milliseconds: 1));
+      await tester.pump();
+      expect(find.text('再読み込み'), findsOneWidget);
+
+      await tester.tap(find.text('再読み込み'));
+      await tester.pump(const Duration(milliseconds: 1));
+      await tester.pump();
+
+      expect(attempts, 2);
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('shows merge conflict status in pull request details', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: PullRequestDiffSheet(
+              issue: const Issue(
+                id: 'issue-1',
+                repo: 'openci-org/openci',
+                title: 'Review PR in OpenCI',
+                labels: [],
+                comments: 0,
+                priority: Priority.medium,
+              ),
+              pullRequest: const IssuePullRequest(
+                number: 1977,
+                title: 'PRの作成もOpenCI上で行いたい。',
+                state: 'open',
+                merged: false,
+                branch: 'IMA-397',
+              ),
+              mergeConflictMessage:
+                  'このPRはbase branchとconflictしています。GitHubでconflictを解消してから、もう一度マージしてください。',
+              loadDiff: () async => const IssuePullRequestDiff(
+                repository: 'openci-org/openci',
+                pullRequestNumber: 1977,
+                title: 'PRの作成もOpenCI上で行いたい。',
+                url: 'https://github.com/openci-org/openci/pull/1977',
+                state: 'open',
+                merged: false,
+                branch: 'IMA-397',
+                additions: 0,
+                deletions: 0,
+                changedFiles: 0,
+                ci: PullRequestCiSummary(
+                  status: PullRequestCiStatus.none,
+                  total: 0,
+                  passed: 0,
+                  failed: 0,
+                  pending: 0,
+                  skipped: 0,
+                  checksTruncated: false,
+                ),
+                comments: [],
+                commentsTruncated: false,
+                filesTruncated: false,
+                files: [],
+              ),
+              onMerge: null,
+            ),
+          ),
+        ),
+      );
+
+      await tester.pump();
+
+      expect(find.text('Conflictがあります'), findsOneWidget);
+      expect(find.textContaining('GitHubでconflictを解消'), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('shows conflict before merge when GitHub marks PR dirty', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: PullRequestDiffSheet(
+              issue: const Issue(
+                id: 'issue-1',
+                repo: 'openci-org/openci',
+                title: 'Review PR in OpenCI',
+                labels: [],
+                comments: 0,
+                priority: Priority.medium,
+              ),
+              pullRequest: const IssuePullRequest(
+                number: 1977,
+                title: 'PRの作成もOpenCI上で行いたい。',
+                state: 'open',
+                merged: false,
+                branch: 'IMA-397',
+              ),
+              loadDiff: () async => const IssuePullRequestDiff(
+                repository: 'openci-org/openci',
+                pullRequestNumber: 1977,
+                title: 'PRの作成もOpenCI上で行いたい。',
+                url: 'https://github.com/openci-org/openci/pull/1977',
+                state: 'open',
+                merged: false,
+                mergeable: false,
+                mergeableState: 'dirty',
+                branch: 'IMA-397',
+                additions: 0,
+                deletions: 0,
+                changedFiles: 0,
+                ci: PullRequestCiSummary(
+                  status: PullRequestCiStatus.success,
+                  total: 1,
+                  passed: 1,
+                  failed: 0,
+                  pending: 0,
+                  skipped: 0,
+                  checksTruncated: false,
+                ),
+                comments: [],
+                commentsTruncated: false,
+                filesTruncated: false,
+                files: [],
+              ),
+              onMerge: () async => true,
+            ),
+          ),
+        ),
+      );
+
+      await tester.pump();
+
+      expect(find.text('Conflictがあります'), findsOneWidget);
+      expect(find.text('Conflictあり'), findsOneWidget);
+      expect(find.text('CI pass・マージ'), findsNothing);
+      expect(
+        tester.widget<FilledButton>(find.byType(FilledButton).last).onPressed,
+        isNull,
+      );
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('opens pull request details inside the issue editor', (
+      tester,
+    ) async {
+      const issue = Issue(
+        id: 'issue-1',
+        displayId: 'IMA-391',
+        repo: 'openci-org/openci',
+        title: 'Review PR in OpenCI',
+        labels: [],
+        comments: 0,
+        priority: Priority.medium,
+        githubUrl: 'https://github.com/openci-org/openci/issues/1956',
+        pullRequests: [
+          IssuePullRequest(
+            number: 1956,
+            title: 'PR details stay inside the issue editor',
+            state: 'open',
+            merged: false,
+            branch: 'IMA-391',
+          ),
+        ],
+      );
+
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AddIssueDialog(
+              columns: [
+                BoardColumn(
+                  id: 'triage',
+                  title: 'Triage',
+                  description: 'New work',
+                  color: Colors.blue,
+                  issues: [issue],
+                ),
+              ],
+              repositoryOptions: ['openci-org/openci'],
+              initialIssue: issue,
+              initialColumnId: 'triage',
+            ),
+          ),
+        ),
+      );
+
+      final detailsButton = find.widgetWithText(FilledButton, 'PR詳細');
+      await tester.ensureVisible(detailsButton);
+      await tester.tap(detailsButton);
+      await tester.pump();
+
+      expect(find.byType(PullRequestDiffView), findsOneWidget);
+      expect(find.byType(PullRequestDiffSheet), findsNothing);
+      expect(find.byIcon(Icons.arrow_back_rounded), findsOneWidget);
+
+      await tester.tap(find.byIcon(Icons.arrow_back_rounded));
+      await tester.pump();
+
+      expect(find.byType(PullRequestDiffView), findsNothing);
+      expect(detailsButton, findsOneWidget);
+    });
+
+    testWidgets('creates a pull request from the recent branch dialog', (
+      tester,
+    ) async {
+      String? createdHead;
+      String? openedIssueId;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: RecentRemoteBranchesMetric(
+              isCompact: false,
+              loadBranches: () async {
+                return const WorkspaceRecentBranchList(
+                  repositories: 1,
+                  branches: [
+                    WorkspaceRecentBranch(
+                      repository: 'openci-org/openci',
+                      name: 'IMA-1973-create-pr',
+                      sha: 'abc123456789',
+                      base: 'develop',
+                      issueId: 'issue-1973',
+                      issueKey: 'IMA-1973',
+                      issueTitle: 'PRの作成もOpenCI上で行いたい。',
+                      issueStatusId: 'review',
+                    ),
+                  ],
+                );
+              },
+              onCreatePullRequest: (branch) async {
+                createdHead = branch.name;
+                return const IssuePullRequest(
+                  number: 1974,
+                  title: 'PRの作成もOpenCI上で行いたい。 IMA-1973',
+                  state: 'open',
+                  merged: false,
+                  branch: 'IMA-1973-create-pr',
+                );
+              },
+              onOpenIssue: (issueId) {
+                openedIssueId = issueId;
+              },
+            ),
+          ),
+        ),
+      );
+
+      await tester.pump();
+      expect(find.text('ブランチ'), findsOneWidget);
+      expect(find.text('1個'), findsOneWidget);
+      expect(find.text('IMA-1973-create-pr'), findsNothing);
+
+      await tester.tap(find.text('ブランチ'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('最近のブランチ'), findsOneWidget);
+      expect(find.text('IMA-1973-create-pr'), findsOneWidget);
+
+      await tester.tap(find.text('IMA-1973 PRの作成もOpenCI上で行いたい。'));
+      await tester.pumpAndSettle();
+      expect(openedIssueId, 'issue-1973');
+
+      await tester.tap(find.text('ブランチ'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('PR作成'));
+      await tester.pumpAndSettle();
+
+      expect(createdHead, 'IMA-1973-create-pr');
+      expect(find.text('作成済み'), findsOneWidget);
+    });
+
+    testWidgets('refreshes recent branches after a load error', (tester) async {
+      var loadCount = 0;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: RecentRemoteBranchesMetric(
+              isCompact: false,
+              loadBranches: () async {
+                loadCount += 1;
+                if (loadCount == 1) {
+                  throw StateError('temporary failure');
+                }
+                return const WorkspaceRecentBranchList(
+                  repositories: 1,
+                  branches: [
+                    WorkspaceRecentBranch(
+                      repository: 'openci-org/openci',
+                      name: 'IMA-1973-create-pr',
+                      sha: 'abc123456789',
+                      base: 'develop',
+                      issueId: 'issue-1973',
+                      issueKey: 'IMA-1973',
+                      issueTitle: 'PRの作成もOpenCI上で行いたい。',
+                      issueStatusId: 'review',
+                    ),
+                  ],
+                );
+              },
+              onCreatePullRequest: (branch) async {
+                return const IssuePullRequest(
+                  number: 1974,
+                  title: 'PRの作成もOpenCI上で行いたい。 IMA-1973',
+                  state: 'open',
+                  merged: false,
+                  branch: 'IMA-1973-create-pr',
+                );
+              },
+              onOpenIssue: (_) {},
+            ),
+          ),
+        ),
+      );
+
+      await tester.pump();
+      expect(find.text('読み込みエラー'), findsOneWidget);
+
+      await tester.tap(find.text('ブランチ'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('ブランチを読み込めませんでした'), findsOneWidget);
+
+      await tester.tap(find.byIcon(Icons.refresh_rounded).first);
+      await tester.pumpAndSettle();
+
+      expect(loadCount, 2);
+      expect(find.text('IMA-1973-create-pr'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
### Motivation

- The dashboard feature previously lived under an `issues` module but the codebase now models that area as a workspace; filenames and imports should reflect `workspace` instead of `issues`.
- Update all references so the dashboard uses `package:dashboard/workspace/...` and firestore paths use `workspaces/...` consistently in the UI layer.
- Keep existing behavior while moving code to a clearer `workspace` module layout for future work.

### Description

- Renamed and moved the dashboard issue board module from `apps/dashboard/lib/issues` to `apps/dashboard/lib/workspace` and adjusted corresponding test paths from `apps/dashboard/test/issues` to `apps/dashboard/test/workspace`.
- Added the new `workspace` module files and re-exports including `issue_board_ima_page.dart`, `issue_board_ima_app_shell.dart`, `issue_board_ima_board_page.dart`, `issue_board_ima_board_columns.dart`, `issue_board_ima_issue_cards.dart`, `issue_board_ima_issue_editor.dart`, `issue_board_ima_models.dart`, `issue_board_ima_navigation.dart`, `issue_board_ima_overview.dart`, `issue_board_ima_toolbar_search.dart`, and `issue_board_ima_utils.dart` to replace the previous `issues` layout.
- Updated imports and path references across the dashboard app (notably `apps/dashboard/lib/workflow/list/workflow_list_page.dart` now imports `package:dashboard/workspace/issue_board_page.dart`) and adjusted test source references inside `apps/dashboard/test/workspace/issue_board_ima_page_test.dart`.
- Kept the same public APIs and behavior in the moved files (the main `IssueBoardPage` and related widgets were preserved and rehomed under `workspace`).

### Testing

- Performed automated refactor steps locally (search/replace and directory move) and verified references via `rg`/file inspection to ensure imports point to `package:dashboard/workspace/...` (no compile-time checks were available here).
- Attempted to run `flutter test` for `apps/dashboard/test/workspace/issue_board_ima_page_test.dart` but the run could not be executed in this environment because the `flutter` CLI is not installed (`/bin/bash: flutter: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a088ecfd700832cbeb3f821ca0de025)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * Issue/PRボード画面を新規実装。課題とプルリクエストを列ごとに整理・管理できるようになりました
  * ドラッグ&ドロップで課題をステータス間で移動可能に
  * 日次進捗と完了予測を表示。目標設定で進捗を追跡できます
  * ワーカーのオンライン状態とCIビルド結果をリアルタイム表示
  * 課題検索機能で、タイトル・リポジトリ・ラベルから複合検索可能に

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openci-org/openci/pull/1995?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- ima-linked-issue:start -->
Fixes #1993
Ima: IMA-410
<!-- ima-linked-issue:end -->