### PR TITLE
Restore Settings tab in workspace dashboard navigation

### DIFF
--- a/apps/dashboard/lib/workspace/issue_board_ima_app_shell.dart
+++ b/apps/dashboard/lib/workspace/issue_board_ima_app_shell.dart
@@ -29,6 +29,7 @@ enum CompactBoardDestination {
   workflows,
   variables,
   storeRelease,
+  settings,
 }
 
 const boardNavigationDestinations = [
@@ -38,6 +39,7 @@ const boardNavigationDestinations = [
   CompactBoardDestination.workflows,
   CompactBoardDestination.variables,
   CompactBoardDestination.storeRelease,
+  CompactBoardDestination.settings,
 ];
 
 extension CompactBoardDestinationLabel on CompactBoardDestination {
@@ -48,6 +50,7 @@ extension CompactBoardDestinationLabel on CompactBoardDestination {
     CompactBoardDestination.workflows => 'CI/CD設定',
     CompactBoardDestination.variables => '変数',
     CompactBoardDestination.storeRelease => 'ストアリリース',
+    CompactBoardDestination.settings => '設定',
   };
 
   IconData get icon => switch (this) {
@@ -57,6 +60,7 @@ extension CompactBoardDestinationLabel on CompactBoardDestination {
     CompactBoardDestination.workflows => Icons.schema_rounded,
     CompactBoardDestination.variables => Icons.key_rounded,
     CompactBoardDestination.storeRelease => Icons.rocket_launch_outlined,
+    CompactBoardDestination.settings => Icons.settings_outlined,
   };
 
   IconData get selectedIcon => switch (this) {
@@ -66,6 +70,7 @@ extension CompactBoardDestinationLabel on CompactBoardDestination {
     CompactBoardDestination.workflows => Icons.schema_rounded,
     CompactBoardDestination.variables => Icons.key_rounded,
     CompactBoardDestination.storeRelease => Icons.rocket_launch_rounded,
+    CompactBoardDestination.settings => Icons.settings_rounded,
   };
 }
 

--- a/apps/dashboard/lib/workspace/issue_board_ima_board_page.dart
+++ b/apps/dashboard/lib/workspace/issue_board_ima_board_page.dart
@@ -1382,6 +1382,8 @@ class _IssueBoardPageState extends State<IssueBoardPage> {
         _selectCompactDestination(CompactBoardDestination.variables);
     void onStoreReleaseTap() =>
         _selectCompactDestination(CompactBoardDestination.storeRelease);
+    void onSettingsTap() =>
+        _selectCompactDestination(CompactBoardDestination.settings);
 
     return SyncedSpinnerScope(
       child: _IssueBoardShortcuts(
@@ -1467,6 +1469,7 @@ class _IssueBoardPageState extends State<IssueBoardPage> {
                   onWorkflowsTap: onWorkflowsTap,
                   onVariablesTap: onVariablesTap,
                   onStoreReleaseTap: onStoreReleaseTap,
+                  onSettingsTap: onSettingsTap,
                 )
               : null,
           floatingActionButton:
@@ -1541,6 +1544,7 @@ class _IssueBoardPageState extends State<IssueBoardPage> {
                             onWorkflowsTap: onWorkflowsTap,
                             onVariablesTap: onVariablesTap,
                             onStoreReleaseTap: onStoreReleaseTap,
+                            onSettingsTap: onSettingsTap,
                             showNavigationActions: isCompactLayout,
                           ),
                           if (isCompactLayout && canShowRecentBranches)
@@ -2404,6 +2408,8 @@ class _IssueBoardShortcuts extends StatelessWidget {
           onDestinationSelected(CompactBoardDestination.variables),
       const SingleActivator(LogicalKeyboardKey.digit6, meta: true): () =>
           onDestinationSelected(CompactBoardDestination.storeRelease),
+      const SingleActivator(LogicalKeyboardKey.digit7, meta: true): () =>
+          onDestinationSelected(CompactBoardDestination.settings),
     };
 
     if (!kIsWeb) {

--- a/apps/dashboard/lib/workspace/issue_board_ima_navigation.dart
+++ b/apps/dashboard/lib/workspace/issue_board_ima_navigation.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:dashboard/build_info.dart';
 import 'package:dashboard/build_logs/build_logs_page.dart';
+import 'package:dashboard/settings/settings_page.dart';
 import 'package:dashboard/store_release/store_release_page.dart';
 import 'package:dashboard/variables/variables_page.dart';
 import 'package:dashboard/workers/worker_status_page.dart';
@@ -12,9 +13,14 @@ import 'package:intl/intl.dart';
 import 'issue_board_ima_app_shell.dart';
 
 class CompactDestinationBody extends StatelessWidget {
-  const CompactDestinationBody({super.key, required this.destination});
+  const CompactDestinationBody({
+    super.key,
+    required this.destination,
+    this.onSwitchTeam,
+  });
 
   final CompactBoardDestination destination;
+  final VoidCallback? onSwitchTeam;
 
   @override
   Widget build(BuildContext context) {
@@ -25,6 +31,9 @@ class CompactDestinationBody extends StatelessWidget {
       CompactBoardDestination.workflows => const WorkflowsBody(),
       CompactBoardDestination.variables => const VariablesBody(),
       CompactBoardDestination.storeRelease => const StoreReleaseBody(),
+      CompactBoardDestination.settings => SettingsPage(
+        onSwitchTeam: onSwitchTeam,
+      ),
     };
   }
 }

--- a/apps/dashboard/lib/workspace/issue_board_ima_toolbar_search.dart
+++ b/apps/dashboard/lib/workspace/issue_board_ima_toolbar_search.dart
@@ -155,6 +155,7 @@ class BoardToolbar extends StatelessWidget {
     required this.onWorkflowsTap,
     required this.onVariablesTap,
     required this.onStoreReleaseTap,
+    required this.onSettingsTap,
     this.showNavigationActions = true,
   });
 
@@ -173,6 +174,7 @@ class BoardToolbar extends StatelessWidget {
   final VoidCallback onWorkflowsTap;
   final VoidCallback onVariablesTap;
   final VoidCallback onStoreReleaseTap;
+  final VoidCallback onSettingsTap;
   final bool showNavigationActions;
 
   @override
@@ -452,6 +454,7 @@ class CompactBoardDrawer extends StatelessWidget {
     required this.onWorkflowsTap,
     required this.onVariablesTap,
     required this.onStoreReleaseTap,
+    required this.onSettingsTap,
     this.onSwitchTeam,
   });
 
@@ -472,6 +475,7 @@ class CompactBoardDrawer extends StatelessWidget {
   final VoidCallback onWorkflowsTap;
   final VoidCallback onVariablesTap;
   final VoidCallback onStoreReleaseTap;
+  final VoidCallback onSettingsTap;
   final VoidCallback? onSwitchTeam;
 
   @override
@@ -564,6 +568,12 @@ class CompactBoardDrawer extends StatelessWidget {
               selected:
                   selectedDestination == CompactBoardDestination.storeRelease,
               onTap: () => runAfterClose(onStoreReleaseTap),
+            ),
+            _CompactDrawerTile(
+              icon: Icons.settings_outlined,
+              label: '設定',
+              selected: selectedDestination == CompactBoardDestination.settings,
+              onTap: () => runAfterClose(onSettingsTap),
             ),
             const Divider(height: 24),
             const _CompactDrawerSectionLabel('GitHub'),


### PR DESCRIPTION
### Motivation
- The workspace dashboard lost the `Settings` (設定) tab because `settings` was removed from the compact navigation enum and plumbing, making the page unreachable from the workspace UI.
- Restore parity with the issues board navigation so users can open `Settings` from the workspace dashboard.

### Description
- Re-added `settings` to `CompactBoardDestination` and included it in `boardNavigationDestinations` with label and icons in `apps/dashboard/lib/workspace/issue_board_ima_app_shell.dart`.
- Wired `SettingsPage` into the workspace navigation by importing `settings_page.dart` and adding the `settings` branch to `CompactDestinationBody`, forwarding `onSwitchTeam` where needed in `apps/dashboard/lib/workspace/issue_board_ima_navigation.dart`.
- Added `onSettingsTap` handler and passed it through `BoardToolbar` / `CompactBoardDrawer` and the board page so the compact drawer and toolbar can open Settings in `apps/dashboard/lib/workspace/issue_board_ima_board_page.dart` and `apps/dashboard/lib/workspace/issue_board_ima_toolbar_search.dart`.
- Restored the compact drawer tile for `設定` and added a keyboard shortcut (`Cmd/Ctrl + 7`) to switch to Settings in `apps/dashboard/lib/workspace/issue_board_ima_toolbar_search.dart` and `apps/dashboard/lib/workspace/issue_board_ima_board_page.dart`.

### Testing
- Verified file changes with `git diff` and `git status` and committed the change (`Restore settings tab in workspace dashboard navigation`).
- Attempted to run `dart format` and `flutter format` on modified files but formatting failed because `dart`/`flutter` are not available in this environment (commands returned `command not found`).
- No unit/integration tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a089f646948832ca9c17fd0a2842b1f)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ダッシュボードに新しい「設定」ページを追加しました。サイドバーのナビゲーションメニュー、ツールバー、またはキーボードショートカット（Meta + 7）から設定にアクセスできます。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openci-org/openci/pull/1997?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- ima-linked-issue:start -->
Fixes #1996
Ima: IMA-411
<!-- ima-linked-issue:end -->