### PR TITLE
feat: add docker-compose configuration and Caddy reverse proxy for server deployment

### DIFF
--- a/.github/workflows/openci-server-docker-ci.yml
+++ b/.github/workflows/openci-server-docker-ci.yml
@@ -1,0 +1,56 @@
+name: openci_server Docker CI
+
+on:
+  push:
+    branches:
+      - develop
+
+    paths:
+      - "apps/openci_server/**"
+      - "packages/openci_shared/**"
+      - "docker-compose.yml"
+      - "Caddyfile"
+      - ".github/workflows/openci-server-docker-ci.yml"
+
+  pull_request:
+    branches:
+      - develop
+
+    paths:
+      - "apps/openci_server/**"
+      - "packages/openci_shared/**"
+      - "docker-compose.yml"
+      - "Caddyfile"
+      - ".github/workflows/openci-server-docker-ci.yml"
+
+jobs:
+  docker-ci:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Start services with Docker Compose
+        run: docker compose up --build -d
+
+      - name: Wait for server to start
+        run: sleep 3
+
+      - name: Verify connection and response
+        run: |
+          RESPONSE=$(curl -s http://localhost/)
+          echo "Server Response: $RESPONSE"
+          if [[ "$RESPONSE" != *"OpenCI Server (Shelf) is running!"* ]]; then
+            echo "Verification failed! Unexpected response."
+            exit 1
+          fi
+          echo "Verification successful!"
+
+      - name: Show logs on failure
+        if: failure()
+        run: docker compose logs
+
+      - name: Shut down services
+        if: always()
+        run: docker compose down -v

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,3 @@
+:80 {
+    reverse_proxy server:8080
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     ports:
       - "80:80"
     volumes:
-      - ./Caddyfile:/etc/caddy/Caddyfile
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
       - caddy_data:/data
       - caddy_config:/config
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,27 @@
+services:
+  server:
+    build:
+      context: .
+      dockerfile: apps/openci_server/Dockerfile
+    container_name: openci-server
+    environment:
+      - HOST=any
+      - PORT=8080
+    expose:
+      - "8080"
+
+  caddy:
+    image: caddy:2-alpine
+    container_name: openci-caddy
+    ports:
+      - "80:80"
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile
+      - caddy_data:/data
+      - caddy_config:/config
+    depends_on:
+      - server
+
+volumes:
+  caddy_data:
+  caddy_config:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Docker Compose によるアプリケーションのコンテナ化構成を追加しました
  * リバースプロキシ経由で標準 HTTP ポート（80）でのアクセスに対応しました
* **Tests**
  * docker compose 環境での起動・疎通確認を行う CI ワークフローを追加しました
<!-- end of auto-generated comment: release notes by coderabbit.ai -->