### PR TITLE
feat: add dynamic Firebase API key configuration via command line arguments

### DIFF
--- a/apps/openci_worker_cli/bin/openci_worker_cli.dart
+++ b/apps/openci_worker_cli/bin/openci_worker_cli.dart
@@ -30,6 +30,7 @@ Future<void> main(List<String> arguments) async {
     if (config == null) return;
 
     final authManager = AuthManager(
+      apiKey: config.apiKey,
       email: config.email,
       password: config.password,
     );

--- a/apps/openci_worker_cli/lib/args.dart
+++ b/apps/openci_worker_cli/lib/args.dart
@@ -30,10 +30,7 @@ ArgParser get argParser {
       help: 'The Firebase project ID (defaults to openci-b1b91).',
       defaultsTo: 'openci-b1b91',
     )
-    ..addOption(
-      'api-key',
-      help: 'The Firebase Web API key.',
-    )
+    ..addOption('api-key', help: 'The Firebase Web API key.')
     ..addOption('sentry-dsn', help: 'Sentry DSN for error reporting.')
     ..addFlag(
       'supervised',

--- a/apps/openci_worker_cli/lib/args.dart
+++ b/apps/openci_worker_cli/lib/args.dart
@@ -30,6 +30,10 @@ ArgParser get argParser {
       help: 'The Firebase project ID (defaults to openci-b1b91).',
       defaultsTo: 'openci-b1b91',
     )
+    ..addOption(
+      'api-key',
+      help: 'The Firebase Web API key.',
+    )
     ..addOption('sentry-dsn', help: 'Sentry DSN for error reporting.')
     ..addFlag(
       'supervised',

--- a/apps/openci_worker_cli/lib/args.dart
+++ b/apps/openci_worker_cli/lib/args.dart
@@ -15,23 +15,6 @@ ArgParser get argParser {
       negatable: false,
       help: 'Update to the latest version.',
     )
-    ..addOption(
-      'email',
-      abbr: 'e',
-      help: 'The Firebase Auth email for this worker.',
-    )
-    ..addOption(
-      'password',
-      abbr: 'p',
-      help: 'The Firebase Auth password for this worker.',
-    )
-    ..addOption(
-      'project-id',
-      help: 'The Firebase project ID (defaults to openci-b1b91).',
-      defaultsTo: 'openci-b1b91',
-    )
-    ..addOption('api-key', help: 'The Firebase Web API key.')
-    ..addOption('sentry-dsn', help: 'Sentry DSN for error reporting.')
     ..addFlag(
       'supervised',
       negatable: false,

--- a/apps/openci_worker_cli/lib/constants.dart
+++ b/apps/openci_worker_cli/lib/constants.dart
@@ -12,3 +12,7 @@ const dockerImage = 'openci-ubuntu:latest';
 
 // Exit codes for supervisor communication
 const exitCodeUpdateRequested = 42;
+
+const firebaseSignInUrl =
+    'https://identitytoolkit.googleapis.com/v1/accounts:signInWithPassword';
+const firebaseTokenRefreshUrl = 'https://securetoken.googleapis.com/v1/token';

--- a/apps/openci_worker_cli/lib/firebase.dart
+++ b/apps/openci_worker_cli/lib/firebase.dart
@@ -1,13 +1,13 @@
 import 'dart:convert';
 import 'dart:io';
+
 import 'package:http/http.dart' as http;
 import 'package:logging/logging.dart';
 
 final _log = Logger('AuthManager');
 
 class AuthManager {
-  static const String _apiKey = 'AIzaSyCJj_DPhFXk0RtAUmxp-jHuJ0a85-WlTDs';
-
+  final String apiKey;
   final String email;
   final String password;
 
@@ -15,7 +15,11 @@ class AuthManager {
   String? _refreshToken;
   DateTime? _tokenExpiry;
 
-  AuthManager({required this.email, required this.password});
+  AuthManager({
+    required this.apiKey,
+    required this.email,
+    required this.password,
+  });
 
   /// Signs in to Firebase Auth using Email & Password.
   Future<void> signIn() async {
@@ -35,7 +39,7 @@ class AuthManager {
     }
 
     final url =
-        'https://identitytoolkit.googleapis.com/v1/accounts:signInWithPassword?key=$_apiKey';
+        'https://identitytoolkit.googleapis.com/v1/accounts:signInWithPassword?key=$apiKey';
 
     final response = await http.post(
       Uri.parse(url),
@@ -87,7 +91,7 @@ class AuthManager {
 
   Future<void> _refreshTokenValue() async {
     _log.info('Refreshing Firebase Auth ID token...');
-    final url = 'https://securetoken.googleapis.com/v1/token?key=$_apiKey';
+    final url = 'https://securetoken.googleapis.com/v1/token?key=$apiKey';
 
     final response = await http.post(
       Uri.parse(url),

--- a/apps/openci_worker_cli/lib/firebase.dart
+++ b/apps/openci_worker_cli/lib/firebase.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import 'package:http/http.dart' as http;
 import 'package:logging/logging.dart';
+import 'package:openci_worker_cli/constants.dart';
 
 final _log = Logger('AuthManager');
 
@@ -38,8 +39,7 @@ class AuthManager {
       return;
     }
 
-    final url =
-        'https://identitytoolkit.googleapis.com/v1/accounts:signInWithPassword?key=$apiKey';
+    final url = '$firebaseSignInUrl?key=$apiKey';
 
     final response = await http.post(
       Uri.parse(url),
@@ -91,7 +91,7 @@ class AuthManager {
 
   Future<void> _refreshTokenValue() async {
     _log.info('Refreshing Firebase Auth ID token...');
-    final url = 'https://securetoken.googleapis.com/v1/token?key=$apiKey';
+    final url = '$firebaseTokenRefreshUrl?key=$apiKey';
 
     final response = await http.post(
       Uri.parse(url),

--- a/apps/openci_worker_cli/lib/worker_config.dart
+++ b/apps/openci_worker_cli/lib/worker_config.dart
@@ -8,7 +8,12 @@ import 'package:sentry/sentry.dart';
 
 final _log = Logger('Config');
 
-typedef WorkerConfig = ({String email, String password, String projectId});
+typedef WorkerConfig = ({
+  String email,
+  String password,
+  String projectId,
+  String apiKey,
+});
 
 Future<WorkerConfig?> parseWorkerConfig(List<String> arguments) async {
   final results = argParser.parse(arguments);
@@ -55,6 +60,13 @@ Future<WorkerConfig?> parseWorkerConfig(List<String> arguments) async {
       Platform.environment['OPENCI_PROJECT_ID'] ??
       'openci-b1b91';
 
+  final apiKey = results['api-key'] as String?;
+  if (apiKey == null || apiKey.isEmpty) {
+    _log.severe('--api-key option is required.');
+    printArgsUsage();
+    return null;
+  }
+
   final sentryDsn =
       (results['sentry-dsn'] as String?) ?? Platform.environment['SENTRY_DSN'];
   if (sentryDsn != null && sentryDsn.isNotEmpty) {
@@ -64,5 +76,10 @@ Future<WorkerConfig?> parseWorkerConfig(List<String> arguments) async {
     });
   }
 
-  return (email: email, password: password, projectId: projectId);
+  return (
+    email: email,
+    password: password,
+    projectId: projectId,
+    apiKey: apiKey,
+  );
 }

--- a/apps/openci_worker_cli/lib/worker_config.dart
+++ b/apps/openci_worker_cli/lib/worker_config.dart
@@ -36,39 +36,31 @@ Future<WorkerConfig?> parseWorkerConfig(List<String> arguments) async {
     return null;
   }
 
-  final email =
-      (results['email'] as String?) ?? Platform.environment['OPENCI_EMAIL'];
+  final email = Platform.environment['OPENCI_EMAIL'];
   if (email == null || email.isEmpty) {
-    _log.severe('--email or OPENCI_EMAIL environment variable is required.');
-    printArgsUsage();
+    _log.severe('OPENCI_EMAIL environment variable is required.');
     return null;
   }
 
-  final password =
-      (results['password'] as String?) ??
-      Platform.environment['OPENCI_PASSWORD'];
+  final password = Platform.environment['OPENCI_PASSWORD'];
   if (password == null || password.isEmpty) {
-    _log.severe(
-      '--password or OPENCI_PASSWORD environment variable is required.',
-    );
-    printArgsUsage();
+    _log.severe('OPENCI_PASSWORD environment variable is required.');
     return null;
   }
 
-  final projectId =
-      (results['project-id'] as String?) ??
-      Platform.environment['OPENCI_PROJECT_ID'] ??
-      'openci-b1b91';
+  final projectId = Platform.environment['OPENCI_PROJECT_ID'];
+  if (projectId == null || projectId.isEmpty) {
+    _log.severe('OPENCI_PROJECT_ID environment variable is required.');
+    return null;
+  }
 
-  final apiKey = results['api-key'] as String?;
+  final apiKey = Platform.environment['OPENCI_API_KEY'];
   if (apiKey == null || apiKey.isEmpty) {
-    _log.severe('--api-key option is required.');
-    printArgsUsage();
+    _log.severe('OPENCI_API_KEY environment variable is required.');
     return null;
   }
 
-  final sentryDsn =
-      (results['sentry-dsn'] as String?) ?? Platform.environment['SENTRY_DSN'];
+  final sentryDsn = Platform.environment['SENTRY_DSN'];
   if (sentryDsn != null && sentryDsn.isNotEmpty) {
     await Sentry.init((options) {
       options.dsn = sentryDsn;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 起動時フラグで Firebase Web API キーを指定可能に（--api-key）。
  * 環境変数からの API キー取得に対応（OPENCI_API_KEY）。

* **変更**
  * 認証処理で API キーが必須化。未指定または空の場合はエラー表示して起動を中止します。
  * ワーカー設定に API キー項目を追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->