### PR TITLE
feat: implement Server-Sent Events (SSE) endpoint to stream build logs and track job status

### DIFF
--- a/apps/openci_server/lib/build_job/build_job_router.dart
+++ b/apps/openci_server/lib/build_job/build_job_router.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
@@ -220,6 +221,86 @@ class BuildJobRouter {
           headers: {'content-type': 'application/json'},
         );
       }
+    });
+
+    router.get('/<buildJobId>/runs/<runId>/logs/stream', (
+      Request request,
+      String buildJobId,
+      String runId,
+    ) async {
+      final controller = StreamController<List<int>>();
+      StreamSubscription<List<DriftBuildJobLog>>? logsSubscription;
+      StreamSubscription<DriftBuildJob?>? jobSubscription;
+
+      controller.onListen = () {
+        int lastSentId = 0;
+
+        logsSubscription = db.buildJobDao
+            .watchBuildJobLogs(runId)
+            .listen(
+              (logs) {
+                final newLogs = logs
+                    .where((log) => log.id > lastSentId)
+                    .toList();
+                if (newLogs.isNotEmpty) {
+                  for (final log in newLogs) {
+                    final data = jsonEncode({
+                      'id': log.id,
+                      'content': log.logContent,
+                      'createdAt': log.createdAt.toUtc().toIso8601String(),
+                    });
+                    controller.add(utf8.encode('data: $data\n\n'));
+                  }
+                  lastSentId = newLogs.last.id;
+                }
+              },
+              onError: (Object error, StackTrace stackTrace) {
+                stderr.writeln(
+                  'Error in logs stream for run $runId: $error\n$stackTrace',
+                );
+                if (!controller.isClosed) {
+                  controller.addError(error, stackTrace);
+                  controller.close();
+                }
+              },
+            );
+
+        jobSubscription = db.buildJobDao
+            .watchBuildJob(buildJobId)
+            .listen(
+              (job) {
+                if (job != null) {
+                  final status = job.status;
+                  if (status == BuildJobStatus.SUCCESS ||
+                      status == BuildJobStatus.FAILURE ||
+                      status == BuildJobStatus.CANCELLED ||
+                      status == BuildJobStatus.SKIPPED ||
+                      status == BuildJobStatus.TIMED_OUT) {
+                    controller.add(utf8.encode('event: done\ndata: {}\n\n'));
+                  }
+                }
+              },
+              onError: (Object error, StackTrace stackTrace) {
+                stderr.writeln(
+                  'Error in job status watch: $error\n$stackTrace',
+                );
+              },
+            );
+      };
+
+      controller.onCancel = () async {
+        await logsSubscription?.cancel();
+        await jobSubscription?.cancel();
+      };
+
+      return Response.ok(
+        controller.stream,
+        headers: {
+          'Content-Type': 'text/event-stream',
+          'Cache-Control': 'no-cache',
+          'Connection': 'keep-alive',
+        },
+      );
     });
 
     return router;

--- a/apps/openci_server/lib/build_job/build_job_router.dart
+++ b/apps/openci_server/lib/build_job/build_job_router.dart
@@ -232,6 +232,17 @@ class BuildJobRouter {
       StreamSubscription<List<DriftBuildJobLog>>? logsSubscription;
       StreamSubscription<DriftBuildJob?>? jobSubscription;
 
+      bool isCleanedUp = false;
+      Future<void> cleanup() async {
+        if (isCleanedUp) return;
+        isCleanedUp = true;
+        await logsSubscription?.cancel();
+        await jobSubscription?.cancel();
+        if (!controller.isClosed) {
+          await controller.close();
+        }
+      }
+
       controller.onListen = () {
         int lastSentId = 0;
 
@@ -249,26 +260,28 @@ class BuildJobRouter {
                       'content': log.logContent,
                       'createdAt': log.createdAt.toUtc().toIso8601String(),
                     });
-                    controller.add(utf8.encode('data: $data\n\n'));
+                    if (!controller.isClosed) {
+                      controller.add(utf8.encode('data: $data\n\n'));
+                    }
                   }
                   lastSentId = newLogs.last.id;
                 }
               },
-              onError: (Object error, StackTrace stackTrace) {
+              onError: (Object error, StackTrace stackTrace) async {
                 stderr.writeln(
                   'Error in logs stream for run $runId: $error\n$stackTrace',
                 );
                 if (!controller.isClosed) {
                   controller.addError(error, stackTrace);
-                  controller.close();
                 }
+                await cleanup();
               },
             );
 
         jobSubscription = db.buildJobDao
             .watchBuildJob(buildJobId)
             .listen(
-              (job) {
+              (job) async {
                 if (job != null) {
                   final status = job.status;
                   if (status == BuildJobStatus.SUCCESS ||
@@ -276,7 +289,10 @@ class BuildJobRouter {
                       status == BuildJobStatus.CANCELLED ||
                       status == BuildJobStatus.SKIPPED ||
                       status == BuildJobStatus.TIMED_OUT) {
-                    controller.add(utf8.encode('event: done\ndata: {}\n\n'));
+                    if (!controller.isClosed) {
+                      controller.add(utf8.encode('event: done\ndata: {}\n\n'));
+                    }
+                    await cleanup();
                   }
                 }
               },
@@ -289,8 +305,7 @@ class BuildJobRouter {
       };
 
       controller.onCancel = () async {
-        await logsSubscription?.cancel();
-        await jobSubscription?.cancel();
+        await cleanup();
       };
 
       return Response.ok(

--- a/apps/openci_server/test/server/log_stream_integration_test.dart
+++ b/apps/openci_server/test/server/log_stream_integration_test.dart
@@ -1,0 +1,114 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:drift/native.dart';
+import 'package:openci_server/database.dart';
+import 'package:openci_server/middleware.dart';
+import 'package:openci_server/router.dart';
+import 'package:openci_shared/openci_shared.dart';
+import 'package:shelf/shelf.dart';
+import 'package:test/test.dart';
+
+import '../storage/fake_storage.dart';
+
+void main() {
+  group('SSE Log Streaming Tests', () {
+    late Handler handler;
+    late AppDatabase db;
+    late FakeStorageManager storage;
+    const localHost = "http://localhost";
+
+    setUp(() {
+      storage = FakeStorageManager();
+      db = AppDatabase(NativeDatabase.memory());
+      handler = applyMiddleware(getRouter(storage, db: db));
+    });
+
+    tearDown(() async {
+      await db.close();
+    });
+
+    test(
+      'GET /builds/<buildJobId>/runs/<runId>/logs/stream returns SSE and streams logs',
+      () async {
+        final buildJobId = 'test-job-id';
+        final runId = 'test-run-id';
+
+        final now = DateTime.now().toUtc();
+        await db.buildJobDao.insertBuildJob(
+          DriftBuildJob(
+            id: buildJobId,
+            status: BuildJobStatus.IN_PROGRESS,
+            owner: 'owner',
+            repo: 'repo',
+            workflowName: 'workflow',
+            createdAt: now,
+            updatedAt: now,
+          ),
+        );
+
+        await db.buildJobDao.insertBuildJobLog(runId, 'log line 1\n');
+
+        final request = Request(
+          'GET',
+          Uri.parse('$localHost/builds/$buildJobId/runs/$runId/logs/stream'),
+        );
+        final response = await handler(request);
+
+        expect(response.statusCode, equals(200));
+        expect(response.headers['Content-Type'], equals('text/event-stream'));
+        expect(response.headers['Cache-Control'], equals('no-cache'));
+        expect(response.headers['Connection'], equals('keep-alive'));
+
+        final stream = response.read();
+        final linesStream = stream
+            .transform(utf8.decoder)
+            .transform(const LineSplitter());
+        final iterator = StreamIterator(linesStream);
+
+        expect(await iterator.moveNext(), isTrue);
+        expect(iterator.current, startsWith('data: '));
+        final jsonStr = iterator.current.substring(6);
+        final data = jsonDecode(jsonStr) as Map<String, dynamic>;
+        expect(data['id'], equals(1));
+        expect(data['content'], equals('log line 1\n'));
+
+        expect(await iterator.moveNext(), isTrue);
+        expect(iterator.current, isEmpty);
+
+        await db.buildJobDao.insertBuildJobLog(runId, 'log line 2\n');
+
+        expect(await iterator.moveNext(), isTrue);
+        expect(iterator.current, startsWith('data: '));
+        final jsonStr2 = iterator.current.substring(6);
+        final data2 = jsonDecode(jsonStr2) as Map<String, dynamic>;
+        expect(data2['id'], equals(2));
+        expect(data2['content'], equals('log line 2\n'));
+
+        expect(await iterator.moveNext(), isTrue);
+        expect(iterator.current, isEmpty);
+
+        await db.buildJobDao.updateBuildJob(
+          DriftBuildJob(
+            id: buildJobId,
+            status: BuildJobStatus.SUCCESS,
+            owner: 'owner',
+            repo: 'repo',
+            workflowName: 'workflow',
+            createdAt: now,
+            updatedAt: DateTime.now().toUtc(),
+          ),
+        );
+
+        expect(await iterator.moveNext(), isTrue);
+        expect(iterator.current, equals('event: done'));
+        expect(await iterator.moveNext(), isTrue);
+        expect(iterator.current, equals('data: {}'));
+        expect(await iterator.moveNext(), isTrue);
+        expect(iterator.current, isEmpty);
+
+        await iterator.cancel();
+      },
+    );
+  });
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * ビルド実行ログをServer-Sent Events（SSE）形式でリアルタイムにストリーミング配信可能に。ログは逐次受信され、ジョブ終了時に完了イベントが送信されます。

* **テスト**
  * SSEログストリーミングの統合テストを追加し、ヘッダー・イベント順序・完了通知を検証します。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->