### PR TITLE
refactor: update CORS middleware to reflect requested origin and enable credentials support

### DIFF
--- a/apps/openci_server/lib/middleware/apply_middleware.dart
+++ b/apps/openci_server/lib/middleware/apply_middleware.dart
@@ -4,7 +4,11 @@ import 'package:openci_server/middleware/cors_middleware.dart';
 import 'package:shelf/shelf.dart';
 import 'package:shelf_router/shelf_router.dart';
 
-Handler applyMiddleware(Router router, {FirebaseApp? firebaseApp}) {
+Handler applyMiddleware(
+  Router router, {
+  FirebaseApp? firebaseApp,
+  Map<String, String>? environment,
+}) {
   final Middleware authMiddlewareInstance;
   if (firebaseApp == null) {
     authMiddlewareInstance = (Handler innerHandler) {
@@ -18,7 +22,7 @@ Handler applyMiddleware(Router router, {FirebaseApp? firebaseApp}) {
   }
 
   return const Pipeline()
-      .addMiddleware(corsMiddleware())
+      .addMiddleware(corsMiddleware(environment: environment))
       .addMiddleware(logRequests())
       .addMiddleware(authMiddlewareInstance)
       .addHandler(router.call);

--- a/apps/openci_server/lib/middleware/cors_middleware.dart
+++ b/apps/openci_server/lib/middleware/cors_middleware.dart
@@ -1,11 +1,38 @@
+import 'dart:io';
+
 import 'package:shelf/shelf.dart';
 
-Middleware corsMiddleware() {
+Middleware corsMiddleware({Map<String, String>? environment}) {
+  final env = environment ?? Platform.environment;
+  final origins = env['ALLOWED_ORIGINS'] ?? '';
+  final list = origins
+      .split(',')
+      .map((o) => o.trim().replaceAll(RegExp(r'/$'), ''))
+      .where((o) => o.isNotEmpty)
+      .toList();
+  final allowedOrigins = {
+    'https://dashboard.openci.org',
+    ...list,
+  };
+
+  bool isAllowed(String origin) {
+    final sanitized = origin.trim().replaceAll(RegExp(r'/$'), '');
+    if (allowedOrigins.contains(sanitized)) {
+      return true;
+    }
+    try {
+      final uri = Uri.parse(sanitized);
+      return uri.host == 'localhost' || uri.host == '127.0.0.1';
+    } catch (_) {
+      return false;
+    }
+  }
+
   return (Handler innerHandler) {
     return (Request request) async {
       final origin = request.headers['origin'] ?? request.headers['Origin'];
 
-      if (origin == null) {
+      if (origin == null || !isAllowed(origin)) {
         return innerHandler(request);
       }
 

--- a/apps/openci_server/lib/middleware/cors_middleware.dart
+++ b/apps/openci_server/lib/middleware/cors_middleware.dart
@@ -54,7 +54,7 @@ Middleware corsMiddleware({Map<String, String>? environment}) {
 
       final response = await innerHandler(request);
       return response.change(
-        headers: corsHeaders,
+        headers: {...response.headers, ...corsHeaders},
       );
     };
   };

--- a/apps/openci_server/lib/middleware/cors_middleware.dart
+++ b/apps/openci_server/lib/middleware/cors_middleware.dart
@@ -1,24 +1,33 @@
 import 'package:shelf/shelf.dart';
 
-const _corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS, PATCH',
-  'Access-Control-Allow-Headers': 'Origin, Content-Type, Accept, Authorization',
-};
-
 Middleware corsMiddleware() {
   return (Handler innerHandler) {
     return (Request request) async {
+      final origin = request.headers['origin'] ?? request.headers['Origin'];
+
+      if (origin == null) {
+        return innerHandler(request);
+      }
+
+      final corsHeaders = {
+        'Access-Control-Allow-Origin': origin,
+        'Access-Control-Allow-Methods':
+            'GET, POST, PUT, DELETE, OPTIONS, PATCH',
+        'Access-Control-Allow-Headers':
+            'Origin, Content-Type, Accept, Authorization',
+        'Access-Control-Allow-Credentials': 'true',
+      };
+
       if (request.method == 'OPTIONS') {
         return Response.ok(
           '',
-          headers: _corsHeaders,
+          headers: corsHeaders,
         );
       }
 
       final response = await innerHandler(request);
       return response.change(
-        headers: _corsHeaders,
+        headers: corsHeaders,
       );
     };
   };

--- a/apps/openci_server/test/server/server_test.dart
+++ b/apps/openci_server/test/server/server_test.dart
@@ -36,11 +36,22 @@ void main() {
     });
 
     test('OPTIONS / returns 200 and CORS headers', () async {
-      final request = Request('OPTIONS', Uri.parse('$localHost/'));
+      final request = Request(
+        'OPTIONS',
+        Uri.parse('$localHost/'),
+        headers: {'Origin': 'http://localhost'},
+      );
       final response = await handler(request);
 
       expect(response.statusCode, equals(200));
-      expect(response.headers['Access-Control-Allow-Origin'], equals('*'));
+      expect(
+        response.headers['Access-Control-Allow-Origin'],
+        equals('http://localhost'),
+      );
+      expect(
+        response.headers['Access-Control-Allow-Credentials'],
+        equals('true'),
+      );
       expect(
         response.headers['Access-Control-Allow-Methods'],
         contains('GET'),
@@ -52,11 +63,22 @@ void main() {
     });
 
     test('GET / response includes CORS headers', () async {
-      final request = Request('GET', Uri.parse('$localHost/'));
+      final request = Request(
+        'GET',
+        Uri.parse('$localHost/'),
+        headers: {'Origin': 'http://localhost'},
+      );
       final response = await handler(request);
 
       expect(response.statusCode, equals(200));
-      expect(response.headers['Access-Control-Allow-Origin'], equals('*'));
+      expect(
+        response.headers['Access-Control-Allow-Origin'],
+        equals('http://localhost'),
+      );
+      expect(
+        response.headers['Access-Control-Allow-Credentials'],
+        equals('true'),
+      );
     });
 
     test('GET /invalid-path returns 404', () async {

--- a/apps/openci_server/test/server/server_test.dart
+++ b/apps/openci_server/test/server/server_test.dart
@@ -62,7 +62,7 @@ void main() {
       );
     });
 
-    test('GET / response includes CORS headers', () async {
+    test('GET / response includes CORS headers for localhost', () async {
       final request = Request(
         'GET',
         Uri.parse('$localHost/'),
@@ -74,6 +74,68 @@ void main() {
       expect(
         response.headers['Access-Control-Allow-Origin'],
         equals('http://localhost'),
+      );
+      expect(
+        response.headers['Access-Control-Allow-Credentials'],
+        equals('true'),
+      );
+    });
+
+    test(
+      'GET / response includes CORS headers for official dashboard',
+      () async {
+        final request = Request(
+          'GET',
+          Uri.parse('$localHost/'),
+          headers: {'Origin': 'https://dashboard.openci.org'},
+        );
+        final response = await handler(request);
+
+        expect(response.statusCode, equals(200));
+        expect(
+          response.headers['Access-Control-Allow-Origin'],
+          equals('https://dashboard.openci.org'),
+        );
+        expect(
+          response.headers['Access-Control-Allow-Credentials'],
+          equals('true'),
+        );
+      },
+    );
+
+    test(
+      'GET / with unauthorized Origin does not return CORS headers',
+      () async {
+        final request = Request(
+          'GET',
+          Uri.parse('$localHost/'),
+          headers: {'Origin': 'http://evil.com'},
+        );
+        final response = await handler(request);
+
+        expect(response.statusCode, equals(200));
+        expect(response.headers['Access-Control-Allow-Origin'], isNull);
+        expect(response.headers['Access-Control-Allow-Credentials'], isNull);
+      },
+    );
+
+    test('GET / with custom allowed origin from environment', () async {
+      final customHandler = applyMiddleware(
+        getRouter(storage, db: db),
+        environment: {'ALLOWED_ORIGINS': 'https://my-custom-dashboard.com'},
+      );
+
+      final request = Request(
+        'GET',
+        Uri.parse('$localHost/'),
+        headers: {'Origin': 'https://my-custom-dashboard.com'},
+      );
+      final response = await customHandler(request);
+
+      expect(response.statusCode, equals(200));
+      expect(
+        response.headers['Access-Control-Allow-Origin'],
+        equals('https://my-custom-dashboard.com'),
       );
       expect(
         response.headers['Access-Control-Allow-Credentials'],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 変更内容

* **バグ修正**
  * CORS 設定をリクエストの `Origin` に基づいて動的に判定し、許可されたオリジンのみ `Access-Control-Allow-Origin` を返すよう改善しました。
  * 許可された場合は `Access-Control-Allow-Credentials: true` を付与します。
  * `OPTIONS` リクエストは適切な CORS ヘッダ付きで応答します。

* **テスト**
  * `Origin` ヘッダ有無、許可/不許可オリジン（環境変数の許可オリジン、公式ダッシュボード、不正オリジン）ごとに個別に検証するよう更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->