### PR TITLE
feat: add POST endpoint to create teams and corresponding unit tests

### DIFF
--- a/apps/openci_server/routes/teams/index.dart
+++ b/apps/openci_server/routes/teams/index.dart
@@ -89,8 +89,9 @@ Future<Response> _post(RequestContext context) async {
     );
   }
   final teamName = payload['name'] as String?;
+  final trimmedTeamName = teamName?.trim();
 
-  if (teamName == null || teamName.trim().isEmpty) {
+  if (trimmedTeamName == null || trimmedTeamName.isEmpty) {
     return Response.json(
       statusCode: HttpStatus.badRequest,
       body: {'success': false, 'error': 'name is required'},
@@ -103,7 +104,7 @@ Future<Response> _post(RequestContext context) async {
 
     final driftTeam = DriftTeam(
       id: teamId,
-      name: teamName,
+      name: trimmedTeamName,
       githubBaseUrl: null,
       githubApiBaseUrl: null,
       installationIds: const [],

--- a/apps/openci_server/routes/teams/index.dart
+++ b/apps/openci_server/routes/teams/index.dart
@@ -1,14 +1,17 @@
 import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:dart_frog/dart_frog.dart';
 import 'package:openci_server/database.dart';
 import 'package:openci_server/team/team_mapper.dart';
 import 'package:openci_shared/openci_shared.dart';
+import 'package:uuid/uuid.dart';
 
 FutureOr<Response> onRequest(RequestContext context) {
   return switch (context.request.method) {
     HttpMethod.get => _get(context),
+    HttpMethod.post => _post(context),
     _ => Response(statusCode: HttpStatus.methodNotAllowed),
   };
 }
@@ -41,6 +44,82 @@ Future<Response> _get(RequestContext context) async {
     );
   } catch (e, s) {
     stderr.writeln('Failed to get teams for user $uid: $e\n$s');
+    return Response.json(
+      statusCode: HttpStatus.internalServerError,
+      body: {
+        'success': false,
+        'error': 'Internal server error',
+      },
+    );
+  }
+}
+
+Future<Response> _post(RequestContext context) async {
+  final db = context.read<AppDatabase>();
+  final uid = context.read<String?>();
+  if (uid == null) {
+    return Response.json(
+      statusCode: HttpStatus.forbidden,
+      body: {'success': false, 'error': 'Unauthorized'},
+    );
+  }
+
+  final Map<String, dynamic> payload;
+  try {
+    final body = await context.request.body();
+    final decoded = jsonDecode(body);
+    if (decoded is! Map<String, dynamic>) {
+      throw const FormatException('Body must be a JSON object');
+    }
+    payload = decoded;
+  } catch (e) {
+    return Response.json(
+      statusCode: HttpStatus.badRequest,
+      body: {'success': false, 'error': 'Invalid JSON: $e'},
+    );
+  }
+
+  if (payload.containsKey('name') && payload['name'] is! String) {
+    return Response.json(
+      statusCode: HttpStatus.badRequest,
+      body: {
+        'success': false,
+        'error': 'name must be a string',
+      },
+    );
+  }
+  final teamName = payload['name'] as String?;
+
+  if (teamName == null || teamName.trim().isEmpty) {
+    return Response.json(
+      statusCode: HttpStatus.badRequest,
+      body: {'success': false, 'error': 'name is required'},
+    );
+  }
+
+  try {
+    final teamId = const Uuid().v4();
+    final now = DateTime.now().toUtc();
+
+    final driftTeam = DriftTeam(
+      id: teamId,
+      name: teamName,
+      githubBaseUrl: null,
+      githubApiBaseUrl: null,
+      installationIds: const [],
+      aiEnabled: true,
+      runNumber: 1,
+      createdAt: now,
+      updatedAt: now,
+    );
+
+    await db.teamDao.createTeamAndMember(driftTeam, uid);
+
+    return Response.json(
+      body: {'success': true, 'id': teamId},
+    );
+  } catch (e, s) {
+    stderr.writeln('Failed to create team: $e\n$s');
     return Response.json(
       statusCode: HttpStatus.internalServerError,
       body: {

--- a/apps/openci_server/test/routes/teams/index_test.dart
+++ b/apps/openci_server/test/routes/teams/index_test.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:dart_frog/dart_frog.dart';
@@ -15,6 +16,22 @@ class MockAppDatabase extends Mock implements AppDatabase {}
 class MockTeamDao extends Mock implements TeamDao {}
 
 void main() {
+  setUpAll(() {
+    registerFallbackValue(
+      DriftTeam(
+        id: 'dummy',
+        name: 'dummy',
+        githubBaseUrl: null,
+        githubApiBaseUrl: null,
+        installationIds: const [],
+        aiEnabled: true,
+        runNumber: 1,
+        createdAt: DateTime.now(),
+        updatedAt: DateTime.now(),
+      ),
+    );
+  });
+
   late AppDatabase db;
 
   setUp(() {
@@ -129,6 +146,184 @@ void main() {
         final context = TestRequestContext(
           path: '/teams',
           method: HttpMethod.get,
+        );
+
+        context.provide<AppDatabase>(mockDb);
+        context.provide<String?>('user-1');
+
+        final response = await route.onRequest(context.context);
+
+        expect(response.statusCode, equals(HttpStatus.internalServerError));
+
+        final body = await response.json() as Map<String, dynamic>;
+        expect(body['success'], isFalse);
+        expect(body['error'], equals('Internal server error'));
+      },
+    );
+  });
+
+  group('POST /teams', () {
+    test(
+      'responds with 403 Forbidden when unauthorized (uid is null)',
+      () async {
+        final context = TestRequestContext(
+          path: '/teams',
+          method: HttpMethod.post,
+          body: jsonEncode({'name': 'New Team'}),
+        );
+
+        context.provide<AppDatabase>(db);
+        context.provide<String?>(null);
+
+        final response = await route.onRequest(context.context);
+
+        expect(response.statusCode, equals(HttpStatus.forbidden));
+
+        final body = await response.json() as Map<String, dynamic>;
+        expect(body['success'], isFalse);
+        expect(body['error'], equals('Unauthorized'));
+      },
+    );
+
+    test(
+      'responds with 400 Bad Request when body is invalid JSON',
+      () async {
+        final context = TestRequestContext(
+          path: '/teams',
+          method: HttpMethod.post,
+          body: 'not a json',
+        );
+
+        context.provide<AppDatabase>(db);
+        context.provide<String?>('user-1');
+
+        final response = await route.onRequest(context.context);
+
+        expect(response.statusCode, equals(HttpStatus.badRequest));
+
+        final body = await response.json() as Map<String, dynamic>;
+        expect(body['success'], isFalse);
+        expect(body['error'], contains('Invalid JSON'));
+      },
+    );
+
+    test(
+      'responds with 400 Bad Request when body is not a JSON object',
+      () async {
+        final context = TestRequestContext(
+          path: '/teams',
+          method: HttpMethod.post,
+          body: jsonEncode([1, 2, 3]),
+        );
+
+        context.provide<AppDatabase>(db);
+        context.provide<String?>('user-1');
+
+        final response = await route.onRequest(context.context);
+
+        expect(response.statusCode, equals(HttpStatus.badRequest));
+
+        final body = await response.json() as Map<String, dynamic>;
+        expect(body['success'], isFalse);
+        expect(body['error'], contains('Body must be a JSON object'));
+      },
+    );
+
+    test(
+      'responds with 400 Bad Request when name is not a string',
+      () async {
+        final context = TestRequestContext(
+          path: '/teams',
+          method: HttpMethod.post,
+          body: jsonEncode({'name': 123}),
+        );
+
+        context.provide<AppDatabase>(db);
+        context.provide<String?>('user-1');
+
+        final response = await route.onRequest(context.context);
+
+        expect(response.statusCode, equals(HttpStatus.badRequest));
+
+        final body = await response.json() as Map<String, dynamic>;
+        expect(body['success'], isFalse);
+        expect(body['error'], contains('name must be a string'));
+      },
+    );
+
+    test(
+      'responds with 400 Bad Request when name is empty',
+      () async {
+        final context = TestRequestContext(
+          path: '/teams',
+          method: HttpMethod.post,
+          body: jsonEncode({'name': '   '}),
+        );
+
+        context.provide<AppDatabase>(db);
+        context.provide<String?>('user-1');
+
+        final response = await route.onRequest(context.context);
+
+        expect(response.statusCode, equals(HttpStatus.badRequest));
+
+        final body = await response.json() as Map<String, dynamic>;
+        expect(body['success'], isFalse);
+        expect(body['error'], contains('name is required'));
+      },
+    );
+
+    test(
+      'responds with 200 OK and team ID on successful creation',
+      () async {
+        final context = TestRequestContext(
+          path: '/teams',
+          method: HttpMethod.post,
+          body: jsonEncode({'name': 'Test Team'}),
+        );
+
+        context.provide<AppDatabase>(db);
+        context.provide<String?>('user-1');
+
+        final response = await route.onRequest(context.context);
+
+        expect(response.statusCode, equals(HttpStatus.ok));
+
+        final body = await response.json() as Map<String, dynamic>;
+        expect(body['success'], isTrue);
+        expect(body['id'], isNotEmpty);
+
+        final teamId = body['id'] as String;
+
+        final team = await (db.select(
+          db.teams,
+        )..where((t) => t.id.equals(teamId))).getSingleOrNull();
+        expect(team, isNotNull);
+        expect(team!.name, equals('Test Team'));
+
+        final members = await (db.select(
+          db.teamMembers,
+        )..where((m) => m.teamId.equals(teamId))).get();
+        expect(members, hasLength(1));
+        expect(members.first.userId, equals('user-1'));
+      },
+    );
+
+    test(
+      'responds with 500 Internal Server Error when database fails',
+      () async {
+        final mockDb = MockAppDatabase();
+        final mockTeamDao = MockTeamDao();
+
+        when(() => mockDb.teamDao).thenReturn(mockTeamDao);
+        when(
+          () => mockTeamDao.createTeamAndMember(any(), any()),
+        ).thenThrow(Exception('Database error'));
+
+        final context = TestRequestContext(
+          path: '/teams',
+          method: HttpMethod.post,
+          body: jsonEncode({'name': 'Failed Team'}),
         );
 
         context.provide<AppDatabase>(mockDb);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **New Features**
  * `POST /teams` を追加し、認可チェックとリクエスト本文のJSON/項目検証を行ったうえでチーム作成と参加者登録を実行します。成功時は作成結果（ID）を返します。
* **Tests**
  * `POST /teams` の包括的なテストを追加しました（不正認可、無効なJSON/入力、成功時のDB反映、DBエラー時の応答確認）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->