### PR TITLE
feat: add GET /builds/<id>/runs endpoint to retrieve build run history with authorization checks

### DIFF
--- a/apps/openci_server/routes/builds/[id]/runs/index.dart
+++ b/apps/openci_server/routes/builds/[id]/runs/index.dart
@@ -7,9 +7,73 @@ import 'package:openci_server/database.dart';
 
 FutureOr<Response> onRequest(RequestContext context, String id) {
   return switch (context.request.method) {
+    HttpMethod.get => _get(context, id),
     HttpMethod.post => _post(context, id),
     _ => Response(statusCode: HttpStatus.methodNotAllowed),
   };
+}
+
+Future<Response> _get(RequestContext context, String id) async {
+  final db = context.read<AppDatabase>();
+  final uid = context.read<String?>();
+
+  if (uid == null) {
+    return Response.json(
+      statusCode: HttpStatus.forbidden,
+      body: {'success': false, 'error': 'Unauthorized'},
+    );
+  }
+
+  try {
+    final driftJob = await db.buildJobDao.getBuildJob(id);
+    if (driftJob == null) {
+      return Response.json(
+        statusCode: HttpStatus.notFound,
+        body: {'success': false, 'error': 'Build job not found'},
+      );
+    }
+
+    final teamId = driftJob.teamId;
+    if (teamId == null) {
+      return Response.json(
+        statusCode: HttpStatus.forbidden,
+        body: {'success': false, 'error': 'Forbidden'},
+      );
+    }
+
+    final isMember = await db.teamDao.isTeamMember(uid, teamId);
+    if (!isMember) {
+      return Response.json(
+        statusCode: HttpStatus.forbidden,
+        body: {'success': false, 'error': 'Forbidden'},
+      );
+    }
+
+    final runs = await db.buildRunDao.getBuildRuns(id);
+    final responseBody = runs
+        .map(
+          (run) => {
+            'id': run.id,
+            'buildJobId': run.buildJobId,
+            'status': run.status,
+            'conclusion': run.conclusion,
+            'createdAt': run.createdAt.toUtc().toIso8601String(),
+            'updatedAt': run.updatedAt.toUtc().toIso8601String(),
+          },
+        )
+        .toList();
+
+    return Response.json(body: responseBody);
+  } catch (e, s) {
+    stderr.writeln('Failed to get build runs for job $id: $e\n$s');
+    return Response.json(
+      statusCode: HttpStatus.internalServerError,
+      body: {
+        'success': false,
+        'error': 'Internal server error',
+      },
+    );
+  }
 }
 
 Future<Response> _post(RequestContext context, String id) async {

--- a/apps/openci_server/test/routes/builds/[id]/runs_test.dart
+++ b/apps/openci_server/test/routes/builds/[id]/runs_test.dart
@@ -440,4 +440,261 @@ void main() {
       },
     );
   });
+
+  group('GET /builds/<id>/runs', () {
+    test(
+      'responds with 403 Forbidden (Unauthorized) when uid is null',
+      () async {
+        final context = TestRequestContext(
+          path: '/builds/job-123/runs',
+          method: HttpMethod.get,
+        );
+
+        context.provide<AppDatabase>(db);
+        context.provide<String?>(null);
+
+        final response = await route.onRequest(context.context, 'job-123');
+
+        expect(response.statusCode, equals(HttpStatus.forbidden));
+
+        final body = await response.json() as Map<String, dynamic>;
+        expect(body['success'], isFalse);
+        expect(body['error'], equals('Unauthorized'));
+      },
+    );
+
+    test(
+      'responds with 404 Not Found when build job does not exist',
+      () async {
+        final context = TestRequestContext(
+          path: '/builds/non-existent-job/runs',
+          method: HttpMethod.get,
+        );
+
+        context.provide<AppDatabase>(db);
+        context.provide<String?>('user-123');
+
+        final response = await route.onRequest(
+          context.context,
+          'non-existent-job',
+        );
+
+        expect(response.statusCode, equals(HttpStatus.notFound));
+
+        final body = await response.json() as Map<String, dynamic>;
+        expect(body['success'], isFalse);
+        expect(body['error'], equals('Build job not found'));
+      },
+    );
+
+    test(
+      'responds with 403 Forbidden (Forbidden) when build job teamId is null',
+      () async {
+        final now = _getNormalizedNow();
+        final job = DriftBuildJob(
+          id: 'job-no-team',
+          status: BuildJobStatus.QUEUED,
+          owner: 'owner',
+          repo: 'repo',
+          workflowName: 'workflow',
+          teamId: null,
+          createdAt: now,
+          updatedAt: now,
+        );
+
+        await db.buildJobDao.insertBuildJob(job);
+
+        final context = TestRequestContext(
+          path: '/builds/job-no-team/runs',
+          method: HttpMethod.get,
+        );
+
+        context.provide<AppDatabase>(db);
+        context.provide<String?>('user-123');
+
+        final response = await route.onRequest(context.context, 'job-no-team');
+
+        expect(response.statusCode, equals(HttpStatus.forbidden));
+
+        final body = await response.json() as Map<String, dynamic>;
+        expect(body['success'], isFalse);
+        expect(body['error'], equals('Forbidden'));
+      },
+    );
+
+    test(
+      'responds with 403 Forbidden (Forbidden) when user is not a member of the team',
+      () async {
+        final now = _getNormalizedNow();
+        final team = DriftTeam(
+          id: 'team-xyz',
+          name: 'Team XYZ',
+          githubBaseUrl: null,
+          githubApiBaseUrl: null,
+          installationIds: const [],
+          runNumber: 1,
+          aiEnabled: true,
+          createdAt: now,
+          updatedAt: now,
+        );
+
+        await db.teamDao.createTeamAndMember(team, 'user-abc');
+
+        final job = DriftBuildJob(
+          id: 'job-xyz',
+          status: BuildJobStatus.QUEUED,
+          owner: 'owner',
+          repo: 'repo',
+          workflowName: 'workflow',
+          teamId: 'team-xyz',
+          createdAt: now,
+          updatedAt: now,
+        );
+
+        await db.buildJobDao.insertBuildJob(job);
+
+        final context = TestRequestContext(
+          path: '/builds/job-xyz/runs',
+          method: HttpMethod.get,
+        );
+
+        context.provide<AppDatabase>(db);
+        context.provide<String?>('user-123');
+
+        final response = await route.onRequest(context.context, 'job-xyz');
+
+        expect(response.statusCode, equals(HttpStatus.forbidden));
+
+        final body = await response.json() as Map<String, dynamic>;
+        expect(body['success'], isFalse);
+        expect(body['error'], equals('Forbidden'));
+      },
+    );
+
+    test(
+      'responds with 200 OK and returns a list of build runs when authorized',
+      () async {
+        final now = _getNormalizedNow();
+        final team = DriftTeam(
+          id: 'team-xyz',
+          name: 'Team XYZ',
+          githubBaseUrl: null,
+          githubApiBaseUrl: null,
+          installationIds: const [],
+          runNumber: 1,
+          aiEnabled: true,
+          createdAt: now,
+          updatedAt: now,
+        );
+
+        await db.teamDao.createTeamAndMember(team, 'user-123');
+
+        final job = DriftBuildJob(
+          id: 'job-xyz',
+          status: BuildJobStatus.QUEUED,
+          owner: 'owner',
+          repo: 'repo',
+          workflowName: 'workflow',
+          teamId: 'team-xyz',
+          createdAt: now,
+          updatedAt: now,
+        );
+
+        await db.buildJobDao.insertBuildJob(job);
+
+        final run1 = DriftBuildRun(
+          id: 'run-1',
+          buildJobId: 'job-xyz',
+          status: 'success',
+          conclusion: 'completed',
+          createdAt: now.subtract(const Duration(minutes: 5)),
+          updatedAt: now.subtract(const Duration(minutes: 4)),
+        );
+
+        final run2 = DriftBuildRun(
+          id: 'run-2',
+          buildJobId: 'job-xyz',
+          status: 'in_progress',
+          conclusion: null,
+          createdAt: now,
+          updatedAt: now,
+        );
+
+        await db.buildRunDao.insertBuildRun(run1);
+        await db.buildRunDao.insertBuildRun(run2);
+
+        final context = TestRequestContext(
+          path: '/builds/job-xyz/runs',
+          method: HttpMethod.get,
+        );
+
+        context.provide<AppDatabase>(db);
+        context.provide<String?>('user-123');
+
+        final response = await route.onRequest(context.context, 'job-xyz');
+
+        expect(response.statusCode, equals(HttpStatus.ok));
+
+        final body = await response.json() as List<dynamic>;
+        expect(body, hasLength(2));
+
+        final r1 = body[0] as Map<String, dynamic>;
+        expect(r1['id'], equals('run-1'));
+        expect(r1['buildJobId'], equals('job-xyz'));
+        expect(r1['status'], equals('success'));
+        expect(r1['conclusion'], equals('completed'));
+        expect(
+          r1['createdAt'],
+          equals(run1.createdAt.toUtc().toIso8601String()),
+        );
+        expect(
+          r1['updatedAt'],
+          equals(run1.updatedAt.toUtc().toIso8601String()),
+        );
+
+        final r2 = body[1] as Map<String, dynamic>;
+        expect(r2['id'], equals('run-2'));
+        expect(r2['buildJobId'], equals('job-xyz'));
+        expect(r2['status'], equals('in_progress'));
+        expect(r2['conclusion'], isNull);
+        expect(
+          r2['createdAt'],
+          equals(run2.createdAt.toUtc().toIso8601String()),
+        );
+        expect(
+          r2['updatedAt'],
+          equals(run2.updatedAt.toUtc().toIso8601String()),
+        );
+      },
+    );
+
+    test(
+      'responds with 500 Internal Server Error when database fails',
+      () async {
+        final mockDb = MockAppDatabase();
+        final mockBuildJobDao = MockBuildJobDao();
+
+        when(() => mockDb.buildJobDao).thenReturn(mockBuildJobDao);
+        when(
+          () => mockBuildJobDao.getBuildJob(any()),
+        ).thenThrow(Exception('Database failure'));
+
+        final context = TestRequestContext(
+          path: '/builds/job-123/runs',
+          method: HttpMethod.get,
+        );
+
+        context.provide<AppDatabase>(mockDb);
+        context.provide<String?>('user-123');
+
+        final response = await route.onRequest(context.context, 'job-123');
+
+        expect(response.statusCode, equals(HttpStatus.internalServerError));
+
+        final body = await response.json() as Map<String, dynamic>;
+        expect(body['success'], isFalse);
+        expect(body['error'], equals('Internal server error'));
+      },
+    );
+  });
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * ビルドランの一覧取得APIを追加。認証・認可チェックに対応し、権限のあるユーザーのみがビルドランのデータ（ID、ステータス、更新日時など）を取得可能に。エラーハンドリングも実装。

* **テスト**
  * ビルドラン一覧取得API の包括的なテストを追加。認証エラー、認可エラー、正常系など複数のシナリオに対応。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->