### PR TITLE
feat: add POST /builds route to persist build jobs with team member authentication

### DIFF
--- a/apps/openci_server/lib/build_job/build_job_router.dart
+++ b/apps/openci_server/lib/build_job/build_job_router.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:drift/drift.dart';
 import 'package:openci_server/database.dart';
 import 'package:openci_shared/openci_shared.dart';
 import 'package:shelf/shelf.dart';
@@ -19,84 +18,6 @@ class BuildJobRouter {
 
   Router get router {
     final router = Router();
-
-    router.patch('/<buildJobId>/runs/<runId>', (
-      Request request,
-      String buildJobId,
-      String runId,
-    ) async {
-      try {
-        final payload =
-            jsonDecode(await request.readAsString()) as Map<String, dynamic>;
-        final status = payload['status'] as String?;
-        if (status == null || status.isEmpty) {
-          return Response.badRequest(
-            body: jsonEncode({'success': false, 'error': 'status is required'}),
-            headers: {'content-type': 'application/json'},
-          );
-        }
-        final conclusion = payload['conclusion'] as String?;
-
-        final driftRun = await db.buildRunDao.getBuildRun(buildJobId, runId);
-        if (driftRun == null) {
-          return Response.notFound(
-            jsonEncode({'success': false, 'error': 'Build run not found'}),
-            headers: {'content-type': 'application/json'},
-          );
-        }
-        if (driftRun.buildJobId != buildJobId) {
-          return Response.notFound(
-            jsonEncode({
-              'success': false,
-              'error': 'Build run not found for the specified build job',
-            }),
-            headers: {'content-type': 'application/json'},
-          );
-        }
-
-        final updatedRun = driftRun.copyWith(
-          status: status,
-          conclusion: payload.containsKey('conclusion')
-              ? Value(conclusion)
-              : const Value.absent(),
-          updatedAt: DateTime.now().toUtc(),
-        );
-
-        await db.buildRunDao.updateBuildRun(updatedRun);
-
-        return Response.ok(
-          jsonEncode({'success': true}),
-          headers: {'content-type': 'application/json'},
-        );
-      } on FormatException catch (e) {
-        return Response.badRequest(
-          body: jsonEncode({
-            'success': false,
-            'error': 'Invalid JSON format: $e',
-          }),
-          headers: {'content-type': 'application/json'},
-        );
-      } on TypeError catch (e) {
-        return Response.badRequest(
-          body: jsonEncode({
-            'success': false,
-            'error': 'Invalid payload structure: $e',
-          }),
-          headers: {'content-type': 'application/json'},
-        );
-      } catch (e, s) {
-        stderr.writeln(
-          'Failed to update build run status for run $runId: $e\n$s',
-        );
-        return Response.internalServerError(
-          body: jsonEncode({
-            'success': false,
-            'error': 'Internal server error',
-          }),
-          headers: {'content-type': 'application/json'},
-        );
-      }
-    });
 
     router.get('/<buildJobId>/runs/<runId>/logs', (
       Request request,

--- a/apps/openci_server/lib/build_job/build_job_router.dart
+++ b/apps/openci_server/lib/build_job/build_job_router.dart
@@ -3,7 +3,6 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:drift/drift.dart';
-import 'package:openci_server/build_job/build_job_mapper.dart';
 import 'package:openci_server/database.dart';
 import 'package:openci_shared/openci_shared.dart';
 import 'package:shelf/shelf.dart';
@@ -89,47 +88,6 @@ class BuildJobRouter {
         stderr.writeln(
           'Failed to update build run status for run $runId: $e\n$s',
         );
-        return Response.internalServerError(
-          body: jsonEncode({
-            'success': false,
-            'error': 'Internal server error',
-          }),
-          headers: {'content-type': 'application/json'},
-        );
-      }
-    });
-
-    router.post('/', (Request request) async {
-      try {
-        final payload =
-            jsonDecode(await request.readAsString()) as Map<String, dynamic>;
-        final job = BuildJob.fromJson(payload);
-        final driftJob = job.toDrift();
-
-        await db.buildJobDao.insertBuildJob(driftJob);
-
-        return Response.ok(
-          jsonEncode({'success': true, 'id': job.id}),
-          headers: {'content-type': 'application/json'},
-        );
-      } on FormatException catch (e) {
-        return Response.badRequest(
-          body: jsonEncode({
-            'success': false,
-            'error': 'Invalid JSON format: $e',
-          }),
-          headers: {'content-type': 'application/json'},
-        );
-      } on TypeError catch (e) {
-        return Response.badRequest(
-          body: jsonEncode({
-            'success': false,
-            'error': 'Invalid payload structure: $e',
-          }),
-          headers: {'content-type': 'application/json'},
-        );
-      } catch (e, s) {
-        stderr.writeln('Failed to insert build job: $e\n$s');
         return Response.internalServerError(
           body: jsonEncode({
             'success': false,

--- a/apps/openci_server/routes/builds/[id].dart
+++ b/apps/openci_server/routes/builds/[id].dart
@@ -22,8 +22,8 @@ Future<Response> _get(RequestContext context, String id) async {
 
     if (uid == null) {
       return Response.json(
-        statusCode: HttpStatus.forbidden,
-        body: {'success': false, 'error': 'Unauthorized'},
+        statusCode: HttpStatus.unauthorized,
+        body: {'success': false, 'error': 'Authentication required'},
       );
     }
     final driftJob = await db.buildJobDao.getBuildJob(id);
@@ -71,8 +71,8 @@ Future<Response> _patch(RequestContext context, String id) async {
 
     if (uid == null) {
       return Response.json(
-        statusCode: HttpStatus.forbidden,
-        body: {'success': false, 'error': 'Unauthorized'},
+        statusCode: HttpStatus.unauthorized,
+        body: {'success': false, 'error': 'Authentication required'},
       );
     }
 

--- a/apps/openci_server/routes/builds/[id]/runs/[runId].dart
+++ b/apps/openci_server/routes/builds/[id]/runs/[runId].dart
@@ -29,8 +29,8 @@ Future<Response> _get(
 
     if (uid == null) {
       return Response.json(
-        statusCode: HttpStatus.forbidden,
-        body: {'success': false, 'error': 'Unauthorized'},
+        statusCode: HttpStatus.unauthorized,
+        body: {'success': false, 'error': 'Authentication required'},
       );
     }
     final driftJob = await db.buildJobDao.getBuildJob(id);
@@ -98,8 +98,8 @@ Future<Response> _patch(
 
     if (uid == null) {
       return Response.json(
-        statusCode: HttpStatus.forbidden,
-        body: {'success': false, 'error': 'Unauthorized'},
+        statusCode: HttpStatus.unauthorized,
+        body: {'success': false, 'error': 'Authentication required'},
       );
     }
 

--- a/apps/openci_server/routes/builds/[id]/runs/index.dart
+++ b/apps/openci_server/routes/builds/[id]/runs/index.dart
@@ -20,8 +20,8 @@ Future<Response> _get(RequestContext context, String id) async {
 
     if (uid == null) {
       return Response.json(
-        statusCode: HttpStatus.forbidden,
-        body: {'success': false, 'error': 'Unauthorized'},
+        statusCode: HttpStatus.unauthorized,
+        body: {'success': false, 'error': 'Authentication required'},
       );
     }
     final driftJob = await db.buildJobDao.getBuildJob(id);
@@ -82,8 +82,8 @@ Future<Response> _post(RequestContext context, String id) async {
 
     if (uid == null) {
       return Response.json(
-        statusCode: HttpStatus.forbidden,
-        body: {'success': false, 'error': 'Unauthorized'},
+        statusCode: HttpStatus.unauthorized,
+        body: {'success': false, 'error': 'Authentication required'},
       );
     }
 

--- a/apps/openci_server/routes/builds/index.dart
+++ b/apps/openci_server/routes/builds/index.dart
@@ -21,8 +21,8 @@ Future<Response> _post(RequestContext context) async {
 
     if (uid == null) {
       return Response.json(
-        statusCode: HttpStatus.forbidden,
-        body: {'success': false, 'error': 'Unauthorized'},
+        statusCode: HttpStatus.unauthorized,
+        body: {'success': false, 'error': 'Authentication required'},
       );
     }
 

--- a/apps/openci_server/routes/builds/index.dart
+++ b/apps/openci_server/routes/builds/index.dart
@@ -1,0 +1,96 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:dart_frog/dart_frog.dart';
+import 'package:openci_server/build_job/build_job_mapper.dart';
+import 'package:openci_server/database.dart';
+import 'package:openci_shared/openci_shared.dart';
+
+FutureOr<Response> onRequest(RequestContext context) {
+  return switch (context.request.method) {
+    HttpMethod.post => _post(context),
+    _ => Response(statusCode: HttpStatus.methodNotAllowed),
+  };
+}
+
+Future<Response> _post(RequestContext context) async {
+  try {
+    final db = context.read<AppDatabase>();
+    final uid = context.read<String?>();
+
+    if (uid == null) {
+      return Response.json(
+        statusCode: HttpStatus.forbidden,
+        body: {'success': false, 'error': 'Unauthorized'},
+      );
+    }
+
+    final Map<String, dynamic> payload;
+    try {
+      final body = await context.request.body();
+      final decoded = jsonDecode(body);
+      if (decoded is! Map<String, dynamic>) {
+        throw const FormatException('Body must be a JSON object');
+      }
+      payload = decoded;
+    } catch (e) {
+      return Response.json(
+        statusCode: HttpStatus.badRequest,
+        body: {'success': false, 'error': 'Invalid JSON format: $e'},
+      );
+    }
+
+    final BuildJob job;
+    try {
+      job = BuildJob.fromJson(payload);
+    } on TypeError catch (e) {
+      return Response.json(
+        statusCode: HttpStatus.badRequest,
+        body: {'success': false, 'error': 'Invalid payload structure: $e'},
+      );
+    } on ArgumentError catch (e) {
+      return Response.json(
+        statusCode: HttpStatus.badRequest,
+        body: {'success': false, 'error': 'Invalid payload values: $e'},
+      );
+    } catch (e) {
+      return Response.json(
+        statusCode: HttpStatus.badRequest,
+        body: {'success': false, 'error': 'Invalid payload: $e'},
+      );
+    }
+
+    final teamId = job.teamId;
+    if (teamId == null) {
+      return Response.json(
+        statusCode: HttpStatus.forbidden,
+        body: {'success': false, 'error': 'Forbidden'},
+      );
+    }
+
+    final isMember = await db.teamDao.isTeamMember(uid, teamId);
+    if (!isMember) {
+      return Response.json(
+        statusCode: HttpStatus.forbidden,
+        body: {'success': false, 'error': 'Forbidden'},
+      );
+    }
+
+    final driftJob = job.toDrift();
+    await db.buildJobDao.insertBuildJob(driftJob);
+
+    return Response.json(
+      body: {'success': true, 'id': job.id},
+    );
+  } catch (e, s) {
+    stderr.writeln('Failed to insert build job: $e\n$s');
+    return Response.json(
+      statusCode: HttpStatus.internalServerError,
+      body: {
+        'success': false,
+        'error': 'Internal server error',
+      },
+    );
+  }
+}

--- a/apps/openci_server/routes/teams/[id].dart
+++ b/apps/openci_server/routes/teams/[id].dart
@@ -19,8 +19,8 @@ Future<Response> _patch(RequestContext context, String id) async {
     final uid = context.read<String?>();
     if (uid == null) {
       return Response.json(
-        statusCode: HttpStatus.forbidden,
-        body: {'success': false, 'error': 'Unauthorized'},
+        statusCode: HttpStatus.unauthorized,
+        body: {'success': false, 'error': 'Authentication required'},
       );
     }
     final isMember = await db.teamDao.isTeamMember(uid, id);
@@ -172,8 +172,8 @@ Future<Response> _delete(RequestContext context, String id) async {
     final uid = context.read<String?>();
     if (uid == null) {
       return Response.json(
-        statusCode: HttpStatus.forbidden,
-        body: {'success': false, 'error': 'Unauthorized'},
+        statusCode: HttpStatus.unauthorized,
+        body: {'success': false, 'error': 'Authentication required'},
       );
     }
     final isMember = await db.teamDao.isTeamMember(uid, id);

--- a/apps/openci_server/routes/teams/index.dart
+++ b/apps/openci_server/routes/teams/index.dart
@@ -23,8 +23,8 @@ Future<Response> _get(RequestContext context) async {
     uid = context.read<String?>();
     if (uid == null) {
       return Response.json(
-        statusCode: HttpStatus.forbidden,
-        body: {'success': false, 'error': 'Unauthorized'},
+        statusCode: HttpStatus.unauthorized,
+        body: {'success': false, 'error': 'Authentication required'},
       );
     }
     final driftTeams = await db.teamDao.getTeamsForUser(uid);
@@ -60,8 +60,8 @@ Future<Response> _post(RequestContext context) async {
     final uid = context.read<String?>();
     if (uid == null) {
       return Response.json(
-        statusCode: HttpStatus.forbidden,
-        body: {'success': false, 'error': 'Unauthorized'},
+        statusCode: HttpStatus.unauthorized,
+        body: {'success': false, 'error': 'Authentication required'},
       );
     }
 

--- a/apps/openci_server/test/routes/builds/[id]/runs/[runId]_test.dart
+++ b/apps/openci_server/test/routes/builds/[id]/runs/[runId]_test.dart
@@ -58,7 +58,7 @@ void main() {
 
   group('GET /builds/<id>/runs/<runId>', () {
     test(
-      'responds with 403 Forbidden (Unauthorized) when uid is null',
+      'responds with 401 Unauthorized (Authentication required) when uid is null',
       () async {
         final context = TestRequestContext(
           path: '/builds/job-123/runs/run-456',
@@ -74,11 +74,11 @@ void main() {
           'run-456',
         );
 
-        expect(response.statusCode, equals(HttpStatus.forbidden));
+        expect(response.statusCode, equals(HttpStatus.unauthorized));
 
         final body = await response.json() as Map<String, dynamic>;
         expect(body['success'], isFalse);
-        expect(body['error'], equals('Unauthorized'));
+        expect(body['error'], equals('Authentication required'));
       },
     );
 
@@ -362,7 +362,7 @@ void main() {
 
   group('PATCH /builds/<id>/runs/<runId>', () {
     test(
-      'responds with 403 Forbidden (Unauthorized) when uid is null',
+      'responds with 401 Unauthorized (Authentication required) when uid is null',
       () async {
         final context = TestRequestContext(
           path: '/builds/job-123/runs/run-456',
@@ -379,11 +379,11 @@ void main() {
           'run-456',
         );
 
-        expect(response.statusCode, equals(HttpStatus.forbidden));
+        expect(response.statusCode, equals(HttpStatus.unauthorized));
 
         final body = await response.json() as Map<String, dynamic>;
         expect(body['success'], isFalse);
-        expect(body['error'], equals('Unauthorized'));
+        expect(body['error'], equals('Authentication required'));
       },
     );
 

--- a/apps/openci_server/test/routes/builds/[id]/runs_test.dart
+++ b/apps/openci_server/test/routes/builds/[id]/runs_test.dart
@@ -40,7 +40,7 @@ void main() {
 
   group('POST /builds/<id>/runs', () {
     test(
-      'responds with 403 Forbidden (Unauthorized) when uid is null',
+      'responds with 401 Unauthorized (Authentication required) when uid is null',
       () async {
         final context = TestRequestContext(
           path: '/builds/job-123/runs',
@@ -53,11 +53,11 @@ void main() {
 
         final response = await route.onRequest(context.context, 'job-123');
 
-        expect(response.statusCode, equals(HttpStatus.forbidden));
+        expect(response.statusCode, equals(HttpStatus.unauthorized));
 
         final body = await response.json() as Map<String, dynamic>;
         expect(body['success'], isFalse);
-        expect(body['error'], equals('Unauthorized'));
+        expect(body['error'], equals('Authentication required'));
       },
     );
 
@@ -443,7 +443,7 @@ void main() {
 
   group('GET /builds/<id>/runs', () {
     test(
-      'responds with 403 Forbidden (Unauthorized) when uid is null',
+      'responds with 401 Unauthorized (Authentication required) when uid is null',
       () async {
         final context = TestRequestContext(
           path: '/builds/job-123/runs',
@@ -455,11 +455,11 @@ void main() {
 
         final response = await route.onRequest(context.context, 'job-123');
 
-        expect(response.statusCode, equals(HttpStatus.forbidden));
+        expect(response.statusCode, equals(HttpStatus.unauthorized));
 
         final body = await response.json() as Map<String, dynamic>;
         expect(body['success'], isFalse);
-        expect(body['error'], equals('Unauthorized'));
+        expect(body['error'], equals('Authentication required'));
       },
     );
 

--- a/apps/openci_server/test/routes/builds/[id]_test.dart
+++ b/apps/openci_server/test/routes/builds/[id]_test.dart
@@ -41,7 +41,7 @@ void main() {
 
   group('GET /builds/<id>', () {
     test(
-      'responds with 403 Forbidden (Unauthorized) when uid is null',
+      'responds with 401 Unauthorized (Authentication required) when uid is null',
       () async {
         final context = TestRequestContext(
           path: '/builds/job-123',
@@ -53,11 +53,11 @@ void main() {
 
         final response = await route.onRequest(context.context, 'job-123');
 
-        expect(response.statusCode, equals(HttpStatus.forbidden));
+        expect(response.statusCode, equals(HttpStatus.unauthorized));
 
         final body = await response.json() as Map<String, dynamic>;
         expect(body['success'], isFalse);
-        expect(body['error'], equals('Unauthorized'));
+        expect(body['error'], equals('Authentication required'));
       },
     );
 
@@ -251,7 +251,7 @@ void main() {
 
   group('PATCH /builds/<id>', () {
     test(
-      'responds with 403 Forbidden (Unauthorized) when uid is null',
+      'responds with 401 Unauthorized (Authentication required) when uid is null',
       () async {
         final context = TestRequestContext(
           path: '/builds/job-123',
@@ -264,11 +264,11 @@ void main() {
 
         final response = await route.onRequest(context.context, 'job-123');
 
-        expect(response.statusCode, equals(HttpStatus.forbidden));
+        expect(response.statusCode, equals(HttpStatus.unauthorized));
 
         final body = await response.json() as Map<String, dynamic>;
         expect(body['success'], isFalse);
-        expect(body['error'], equals('Unauthorized'));
+        expect(body['error'], equals('Authentication required'));
       },
     );
 

--- a/apps/openci_server/test/routes/builds/index_test.dart
+++ b/apps/openci_server/test/routes/builds/index_test.dart
@@ -1,0 +1,314 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:dart_frog/dart_frog.dart';
+import 'package:dart_frog_test/dart_frog_test.dart';
+import 'package:drift/native.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openci_server/build_job/build_job_dao.dart';
+import 'package:openci_server/database.dart';
+import 'package:openci_server/team/team_dao.dart';
+import 'package:openci_shared/openci_shared.dart';
+import 'package:test/test.dart';
+
+import '../../../routes/builds/index.dart' as route;
+
+class MockAppDatabase extends Mock implements AppDatabase {}
+
+class MockBuildJobDao extends Mock implements BuildJobDao {}
+
+class MockTeamDao extends Mock implements TeamDao {}
+
+void main() {
+  late AppDatabase db;
+
+  setUpAll(() {
+    registerFallbackValue(
+      DriftBuildJob(
+        id: '',
+        status: BuildJobStatus.QUEUED,
+        owner: '',
+        repo: '',
+        workflowName: '',
+        createdAt: DateTime.now(),
+        updatedAt: DateTime.now(),
+      ),
+    );
+  });
+
+  setUp(() {
+    db = AppDatabase(NativeDatabase.memory());
+  });
+
+  tearDown(() async {
+    await db.close();
+  });
+
+  group('POST /builds', () {
+    test(
+      'responds with 403 Forbidden (Unauthorized) when uid is null',
+      () async {
+        final context = TestRequestContext(
+          path: '/builds',
+          method: HttpMethod.post,
+        );
+
+        context.provide<AppDatabase>(db);
+        context.provide<String?>(null);
+
+        final response = await route.onRequest(context.context);
+
+        expect(response.statusCode, equals(HttpStatus.forbidden));
+
+        final body = await response.json() as Map<String, dynamic>;
+        expect(body['success'], isFalse);
+        expect(body['error'], equals('Unauthorized'));
+      },
+    );
+
+    test(
+      'responds with 400 Bad Request when body is invalid JSON',
+      () async {
+        final context = TestRequestContext(
+          path: '/builds',
+          method: HttpMethod.post,
+          body: 'not-a-json',
+        );
+
+        context.provide<AppDatabase>(db);
+        context.provide<String?>('user-123');
+
+        final response = await route.onRequest(context.context);
+
+        expect(response.statusCode, equals(HttpStatus.badRequest));
+
+        final body = await response.json() as Map<String, dynamic>;
+        expect(body['success'], isFalse);
+        expect(body['error'], contains('Invalid JSON'));
+      },
+    );
+
+    test(
+      'responds with 400 Bad Request when body is not a JSON object',
+      () async {
+        final context = TestRequestContext(
+          path: '/builds',
+          method: HttpMethod.post,
+          body: '"just a string"',
+        );
+
+        context.provide<AppDatabase>(db);
+        context.provide<String?>('user-123');
+
+        final response = await route.onRequest(context.context);
+
+        expect(response.statusCode, equals(HttpStatus.badRequest));
+
+        final body = await response.json() as Map<String, dynamic>;
+        expect(body['success'], isFalse);
+        expect(body['error'], contains('Body must be a JSON object'));
+      },
+    );
+
+    test(
+      'responds with 400 Bad Request when payload structure is invalid (missing required fields)',
+      () async {
+        final context = TestRequestContext(
+          path: '/builds',
+          method: HttpMethod.post,
+          body: '{"invalid": "field"}',
+        );
+
+        context.provide<AppDatabase>(db);
+        context.provide<String?>('user-123');
+
+        final response = await route.onRequest(context.context);
+
+        expect(response.statusCode, equals(HttpStatus.badRequest));
+
+        final body = await response.json() as Map<String, dynamic>;
+        expect(body['success'], isFalse);
+        expect(body['error'], contains('Invalid payload structure'));
+      },
+    );
+
+    test(
+      'responds with 403 Forbidden when build job teamId is null',
+      () async {
+        final payload = {
+          'id': 'job-123',
+          'status': 'QUEUED',
+          'owner': 'owner',
+          'repo': 'repo',
+          'workflowName': 'workflow',
+          'teamId': null,
+          'createdAt': DateTime.now().toUtc().toIso8601String(),
+          'updatedAt': DateTime.now().toUtc().toIso8601String(),
+        };
+
+        final context = TestRequestContext(
+          path: '/builds',
+          method: HttpMethod.post,
+          body: jsonEncode(payload),
+        );
+
+        context.provide<AppDatabase>(db);
+        context.provide<String?>('user-123');
+
+        final response = await route.onRequest(context.context);
+
+        expect(response.statusCode, equals(HttpStatus.forbidden));
+
+        final body = await response.json() as Map<String, dynamic>;
+        expect(body['success'], isFalse);
+        expect(body['error'], equals('Forbidden'));
+      },
+    );
+
+    test(
+      'responds with 403 Forbidden when user is not a member of the team',
+      () async {
+        final team = DriftTeam(
+          id: 'team-xyz',
+          name: 'Team XYZ',
+          githubBaseUrl: null,
+          githubApiBaseUrl: null,
+          installationIds: const [],
+          runNumber: 1,
+          aiEnabled: true,
+          createdAt: DateTime.now().toUtc(),
+          updatedAt: DateTime.now().toUtc(),
+        );
+
+        await db.teamDao.createTeamAndMember(team, 'user-abc');
+
+        final payload = {
+          'id': 'job-123',
+          'status': 'QUEUED',
+          'owner': 'owner',
+          'repo': 'repo',
+          'workflowName': 'workflow',
+          'teamId': 'team-xyz',
+          'createdAt': DateTime.now().toUtc().toIso8601String(),
+          'updatedAt': DateTime.now().toUtc().toIso8601String(),
+        };
+
+        final context = TestRequestContext(
+          path: '/builds',
+          method: HttpMethod.post,
+          body: jsonEncode(payload),
+        );
+
+        context.provide<AppDatabase>(db);
+        context.provide<String?>('user-123');
+
+        final response = await route.onRequest(context.context);
+
+        expect(response.statusCode, equals(HttpStatus.forbidden));
+
+        final body = await response.json() as Map<String, dynamic>;
+        expect(body['success'], isFalse);
+        expect(body['error'], equals('Forbidden'));
+      },
+    );
+
+    test(
+      'responds with 200 OK and inserts build job when user is a member of the team',
+      () async {
+        final team = DriftTeam(
+          id: 'team-xyz',
+          name: 'Team XYZ',
+          githubBaseUrl: null,
+          githubApiBaseUrl: null,
+          installationIds: const [],
+          runNumber: 1,
+          aiEnabled: true,
+          createdAt: DateTime.now().toUtc(),
+          updatedAt: DateTime.now().toUtc(),
+        );
+
+        await db.teamDao.createTeamAndMember(team, 'user-123');
+
+        final payload = {
+          'id': 'job-123',
+          'status': 'QUEUED',
+          'owner': 'owner',
+          'repo': 'repo',
+          'workflowName': 'workflow',
+          'teamId': 'team-xyz',
+          'createdAt': DateTime.now().toUtc().toIso8601String(),
+          'updatedAt': DateTime.now().toUtc().toIso8601String(),
+        };
+
+        final context = TestRequestContext(
+          path: '/builds',
+          method: HttpMethod.post,
+          body: jsonEncode(payload),
+        );
+
+        context.provide<AppDatabase>(db);
+        context.provide<String?>('user-123');
+
+        final response = await route.onRequest(context.context);
+
+        expect(response.statusCode, equals(HttpStatus.ok));
+
+        final body = await response.json() as Map<String, dynamic>;
+        expect(body['success'], isTrue);
+        expect(body['id'], equals('job-123'));
+
+        final inserted = await db.buildJobDao.getBuildJob('job-123');
+        expect(inserted, isNotNull);
+        expect(inserted!.id, equals('job-123'));
+        expect(inserted.teamId, equals('team-xyz'));
+      },
+    );
+
+    test(
+      'responds with 500 Internal Server Error when database fails',
+      () async {
+        final mockDb = MockAppDatabase();
+        final mockBuildJobDao = MockBuildJobDao();
+
+        when(() => mockDb.buildJobDao).thenReturn(mockBuildJobDao);
+        when(
+          () => mockBuildJobDao.insertBuildJob(any()),
+        ).thenThrow(Exception('Database failure'));
+
+        final mockTeamDao = MockTeamDao();
+        when(() => mockDb.teamDao).thenReturn(mockTeamDao);
+        when(
+          () => mockTeamDao.isTeamMember('user-123', 'team-xyz'),
+        ).thenAnswer((_) async => true);
+
+        final payload = {
+          'id': 'job-123',
+          'status': 'QUEUED',
+          'owner': 'owner',
+          'repo': 'repo',
+          'workflowName': 'workflow',
+          'teamId': 'team-xyz',
+          'createdAt': DateTime.now().toUtc().toIso8601String(),
+          'updatedAt': DateTime.now().toUtc().toIso8601String(),
+        };
+
+        final context = TestRequestContext(
+          path: '/builds',
+          method: HttpMethod.post,
+          body: jsonEncode(payload),
+        );
+
+        context.provide<AppDatabase>(mockDb);
+        context.provide<String?>('user-123');
+
+        final response = await route.onRequest(context.context);
+
+        expect(response.statusCode, equals(HttpStatus.internalServerError));
+
+        final body = await response.json() as Map<String, dynamic>;
+        expect(body['success'], isFalse);
+        expect(body['error'], equals('Internal server error'));
+      },
+    );
+  });
+}

--- a/apps/openci_server/test/routes/builds/index_test.dart
+++ b/apps/openci_server/test/routes/builds/index_test.dart
@@ -46,7 +46,7 @@ void main() {
 
   group('POST /builds', () {
     test(
-      'responds with 403 Forbidden (Unauthorized) when uid is null',
+      'responds with 401 Unauthorized (Authentication required) when uid is null',
       () async {
         final context = TestRequestContext(
           path: '/builds',
@@ -58,11 +58,11 @@ void main() {
 
         final response = await route.onRequest(context.context);
 
-        expect(response.statusCode, equals(HttpStatus.forbidden));
+        expect(response.statusCode, equals(HttpStatus.unauthorized));
 
         final body = await response.json() as Map<String, dynamic>;
         expect(body['success'], isFalse);
-        expect(body['error'], equals('Unauthorized'));
+        expect(body['error'], equals('Authentication required'));
       },
     );
 

--- a/apps/openci_server/test/routes/teams/[id]_test.dart
+++ b/apps/openci_server/test/routes/teams/[id]_test.dart
@@ -44,7 +44,7 @@ void main() {
 
   group('PATCH /teams/<id>', () {
     test(
-      'responds with 403 Forbidden when unauthorized (uid is null)',
+      'responds with 401 Unauthorized when unauthorized (uid is null)',
       () async {
         final context = TestRequestContext(
           path: '/teams/team-123',
@@ -57,11 +57,11 @@ void main() {
 
         final response = await route.onRequest(context.context, 'team-123');
 
-        expect(response.statusCode, equals(HttpStatus.forbidden));
+        expect(response.statusCode, equals(HttpStatus.unauthorized));
 
         final body = await response.json() as Map<String, dynamic>;
         expect(body['success'], isFalse);
-        expect(body['error'], equals('Unauthorized'));
+        expect(body['error'], equals('Authentication required'));
       },
     );
 
@@ -463,7 +463,7 @@ void main() {
 
   group('DELETE /teams/<id>', () {
     test(
-      'responds with 403 Forbidden when unauthorized (uid is null)',
+      'responds with 401 Unauthorized when unauthorized (uid is null)',
       () async {
         final context = TestRequestContext(
           path: '/teams/team-123',
@@ -475,11 +475,11 @@ void main() {
 
         final response = await route.onRequest(context.context, 'team-123');
 
-        expect(response.statusCode, equals(HttpStatus.forbidden));
+        expect(response.statusCode, equals(HttpStatus.unauthorized));
 
         final body = await response.json() as Map<String, dynamic>;
         expect(body['success'], isFalse);
-        expect(body['error'], equals('Unauthorized'));
+        expect(body['error'], equals('Authentication required'));
       },
     );
 

--- a/apps/openci_server/test/routes/teams/index_test.dart
+++ b/apps/openci_server/test/routes/teams/index_test.dart
@@ -44,7 +44,7 @@ void main() {
 
   group('GET /teams', () {
     test(
-      'responds with 403 Forbidden when unauthorized (uid is null)',
+      'responds with 401 Unauthorized when unauthorized (uid is null)',
       () async {
         final context = TestRequestContext(
           path: '/teams',
@@ -56,11 +56,11 @@ void main() {
 
         final response = await route.onRequest(context.context);
 
-        expect(response.statusCode, equals(HttpStatus.forbidden));
+        expect(response.statusCode, equals(HttpStatus.unauthorized));
 
         final body = await response.json() as Map<String, dynamic>;
         expect(body['success'], isFalse);
-        expect(body['error'], equals('Unauthorized'));
+        expect(body['error'], equals('Authentication required'));
       },
     );
 
@@ -164,7 +164,7 @@ void main() {
 
   group('POST /teams', () {
     test(
-      'responds with 403 Forbidden when unauthorized (uid is null)',
+      'responds with 401 Unauthorized when unauthorized (uid is null)',
       () async {
         final context = TestRequestContext(
           path: '/teams',
@@ -177,11 +177,11 @@ void main() {
 
         final response = await route.onRequest(context.context);
 
-        expect(response.statusCode, equals(HttpStatus.forbidden));
+        expect(response.statusCode, equals(HttpStatus.unauthorized));
 
         final body = await response.json() as Map<String, dynamic>;
         expect(body['success'], isFalse);
-        expect(body['error'], equals('Unauthorized'));
+        expect(body['error'], equals('Authentication required'));
       },
     );
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ビルドジョブ作成用の新しいエンドポイント（`POST /builds`）を追加しました。認証とチームメンバーシップの検証、リクエストの妥当性チェック、エラーハンドリング機能を備えています。

* **その他の変更**
  * ルーティング構造を再編成し、ログ関連のエンドポイントはそのまま維持されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->