### PR TITLE
feat: add webhook route with HMAC signature verification using crypto package

### DIFF
--- a/apps/openci_server/pubspec.yaml
+++ b/apps/openci_server/pubspec.yaml
@@ -8,6 +8,7 @@ environment:
 resolution: workspace
 
 dependencies:
+  crypto: ^3.0.3
   dart_frog: ^1.2.6
   drift: ^2.33.0
   drift_postgres: ^1.3.1

--- a/apps/openci_server/pubspec.yaml
+++ b/apps/openci_server/pubspec.yaml
@@ -9,10 +9,12 @@ resolution: workspace
 
 dependencies:
   crypto: ^3.0.3
+  dart_jsonwebtoken: ^3.2.0
   dart_frog: ^1.2.6
   drift: ^2.33.0
   drift_postgres: ^1.3.1
   firebase_admin_sdk: ^0.5.3
+  http: ^1.6.0
   minio: ^3.5.8
   openci_shared: ^1.0.1
   postgres: ^3.5.11
@@ -20,6 +22,7 @@ dependencies:
   shelf: ^1.4.1
   shelf_router: ^1.1.4
   uuid: ^4.5.3
+  yaml: ^3.1.2
 
 dev_dependencies:
   build_runner: ^2.15.0

--- a/apps/openci_server/routes/webhook.dart
+++ b/apps/openci_server/routes/webhook.dart
@@ -1,0 +1,54 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:crypto/crypto.dart';
+import 'package:dart_frog/dart_frog.dart';
+
+Future<Response> onRequest(RequestContext context) async {
+  if (context.request.method != HttpMethod.post) {
+    return Response(statusCode: HttpStatus.methodNotAllowed);
+  }
+
+  Map<String, String> env;
+  try {
+    env = context.read<Map<String, String>>();
+  } catch (_) {
+    env = Platform.environment;
+  }
+  final secret = env['GITHUB_WEBHOOK_SECRET'];
+  if (secret == null || secret.isEmpty) {
+    stderr.writeln('Warning: GITHUB_WEBHOOK_SECRET is not configured.');
+    return Response.json(
+      statusCode: HttpStatus.internalServerError,
+      body: {'success': false, 'error': 'Server configuration error'},
+    );
+  }
+
+  final signatureHeader = context.request.headers['x-hub-signature-256'];
+  if (signatureHeader == null || !signatureHeader.startsWith('sha256=')) {
+    return Response.json(
+      statusCode: HttpStatus.unauthorized,
+      body: {'success': false, 'error': 'Missing or invalid signature header'},
+    );
+  }
+
+  final rawBody = await context.request.body();
+  final rawBodyBytes = utf8.encode(rawBody);
+  final expectedSignature = signatureHeader.substring(7);
+
+  final key = utf8.encode(secret);
+  final hmacSha256 = Hmac(sha256, key);
+  final digest = hmacSha256.convert(rawBodyBytes);
+  final computedSignature = digest.toString();
+
+  if (computedSignature != expectedSignature) {
+    return Response.json(
+      statusCode: HttpStatus.unauthorized,
+      body: {'success': false, 'error': 'Signature mismatch'},
+    );
+  }
+
+  return Response.json(
+    body: {'success': true, 'message': 'Signature verified'},
+  );
+}

--- a/apps/openci_server/routes/webhook.dart
+++ b/apps/openci_server/routes/webhook.dart
@@ -41,7 +41,10 @@ Future<Response> onRequest(RequestContext context) async {
   final digest = hmacSha256.convert(rawBodyBytes);
   final computedSignature = digest.toString();
 
-  if (computedSignature != expectedSignature) {
+  final computedSignatureBytes = utf8.encode(computedSignature);
+  final expectedSignatureBytes = utf8.encode(expectedSignature);
+
+  if (!constantTimeCompare(computedSignatureBytes, expectedSignatureBytes)) {
     return Response.json(
       statusCode: HttpStatus.unauthorized,
       body: {'success': false, 'error': 'Signature mismatch'},
@@ -51,4 +54,16 @@ Future<Response> onRequest(RequestContext context) async {
   return Response.json(
     body: {'success': true, 'message': 'Signature verified'},
   );
+}
+
+bool constantTimeCompare(List<int> a, List<int> b) {
+  if (a.length != b.length) {
+    return false;
+  }
+
+  var result = 0;
+  for (var i = 0; i < a.length; i++) {
+    result |= a[i] ^ b[i];
+  }
+  return result == 0;
 }

--- a/apps/openci_server/test/routes/webhook_test.dart
+++ b/apps/openci_server/test/routes/webhook_test.dart
@@ -141,4 +141,52 @@ void main() {
       expect(body['message'], equals('Signature verified'));
     });
   });
+
+  group('constantTimeCompare', () {
+    test('returns true for identical lists', () {
+      expect(
+        route.constantTimeCompare([1, 2, 3], [1, 2, 3]),
+        isTrue,
+      );
+    });
+
+    test('returns false for lists of different lengths', () {
+      expect(
+        route.constantTimeCompare([1, 2, 3], [1, 2]),
+        isFalse,
+      );
+      expect(
+        route.constantTimeCompare([1, 2], [1, 2, 3]),
+        isFalse,
+      );
+    });
+
+    test('returns false for lists with different values at the beginning', () {
+      expect(
+        route.constantTimeCompare([9, 2, 3], [1, 2, 3]),
+        isFalse,
+      );
+    });
+
+    test('returns false for lists with different values in the middle', () {
+      expect(
+        route.constantTimeCompare([1, 9, 3], [1, 2, 3]),
+        isFalse,
+      );
+    });
+
+    test('returns false for lists with different values at the end', () {
+      expect(
+        route.constantTimeCompare([1, 2, 9], [1, 2, 3]),
+        isFalse,
+      );
+    });
+
+    test('returns true for empty lists', () {
+      expect(
+        route.constantTimeCompare([], []),
+        isTrue,
+      );
+    });
+  });
 }

--- a/apps/openci_server/test/routes/webhook_test.dart
+++ b/apps/openci_server/test/routes/webhook_test.dart
@@ -1,0 +1,144 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:crypto/crypto.dart';
+import 'package:dart_frog/dart_frog.dart';
+import 'package:dart_frog_test/dart_frog_test.dart';
+import 'package:test/test.dart';
+
+import '../../routes/webhook.dart' as route;
+
+void main() {
+  group('POST /webhook', () {
+    const testSecret = 'super-secret-key';
+    const testBody = '{"event": "push", "ref": "refs/heads/main"}';
+
+    String computeSignature(String body, String secret) {
+      final key = utf8.encode(secret);
+      final hmacSha256 = Hmac(sha256, key);
+      final digest = hmacSha256.convert(utf8.encode(body));
+      return 'sha256=$digest';
+    }
+
+    test(
+      'responds with 405 Method Not Allowed when method is not POST',
+      () async {
+        final context = TestRequestContext(
+          path: '/webhook',
+          method: HttpMethod.get,
+        );
+
+        final response = await route.onRequest(context.context);
+
+        expect(response.statusCode, equals(HttpStatus.methodNotAllowed));
+      },
+    );
+
+    test(
+      'responds with 500 when GITHUB_WEBHOOK_SECRET is not configured',
+      () async {
+        final context = TestRequestContext(
+          path: '/webhook',
+          method: HttpMethod.post,
+          body: testBody,
+        );
+
+        context.provide<Map<String, String>>({});
+
+        final response = await route.onRequest(context.context);
+
+        expect(response.statusCode, equals(HttpStatus.internalServerError));
+        final body = await response.json() as Map<String, dynamic>;
+        expect(body['success'], isFalse);
+        expect(body['error'], equals('Server configuration error'));
+      },
+    );
+
+    test('responds with 401 when signature header is missing', () async {
+      final context = TestRequestContext(
+        path: '/webhook',
+        method: HttpMethod.post,
+        body: testBody,
+      );
+
+      context.provide<Map<String, String>>({
+        'GITHUB_WEBHOOK_SECRET': testSecret,
+      });
+
+      final response = await route.onRequest(context.context);
+
+      expect(response.statusCode, equals(HttpStatus.unauthorized));
+      final body = await response.json() as Map<String, dynamic>;
+      expect(body['success'], isFalse);
+      expect(body['error'], equals('Missing or invalid signature header'));
+    });
+
+    test('responds with 401 when signature header format is invalid', () async {
+      final context = TestRequestContext(
+        path: '/webhook',
+        method: HttpMethod.post,
+        body: testBody,
+        headers: {
+          'x-hub-signature-256': 'invalid-format-signature-value',
+        },
+      );
+
+      context.provide<Map<String, String>>({
+        'GITHUB_WEBHOOK_SECRET': testSecret,
+      });
+
+      final response = await route.onRequest(context.context);
+
+      expect(response.statusCode, equals(HttpStatus.unauthorized));
+      final body = await response.json() as Map<String, dynamic>;
+      expect(body['success'], isFalse);
+      expect(body['error'], equals('Missing or invalid signature header'));
+    });
+
+    test('responds with 401 when signature does not match', () async {
+      final context = TestRequestContext(
+        path: '/webhook',
+        method: HttpMethod.post,
+        body: testBody,
+        headers: {
+          'x-hub-signature-256':
+              'sha256=wrongsignaturevalue12345678901234567890',
+        },
+      );
+
+      context.provide<Map<String, String>>({
+        'GITHUB_WEBHOOK_SECRET': testSecret,
+      });
+
+      final response = await route.onRequest(context.context);
+
+      expect(response.statusCode, equals(HttpStatus.unauthorized));
+      final body = await response.json() as Map<String, dynamic>;
+      expect(body['success'], isFalse);
+      expect(body['error'], equals('Signature mismatch'));
+    });
+
+    test('responds with 200 OK and verifies signature when valid', () async {
+      final signature = computeSignature(testBody, testSecret);
+      final context = TestRequestContext(
+        path: '/webhook',
+        method: HttpMethod.post,
+        body: testBody,
+        headers: {
+          'x-hub-signature-256': signature,
+        },
+      );
+
+      context.provide<Map<String, String>>({
+        'GITHUB_WEBHOOK_SECRET': testSecret,
+      });
+
+      final response = await route.onRequest(context.context);
+
+      expect(response.statusCode, equals(HttpStatus.ok));
+      final body = await response.json() as Map<String, dynamic>;
+      expect(body['success'], isTrue);
+      expect(body['message'], equals('Signature verified'));
+    });
+  });
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **New Features**
  * GitHub Webhook エンドポイントを追加。POST リクエストのみ受け付け、HMAC-SHA256 による署名検証を実施します。
* **Bug Fixes**
  * 署名ヘッダの欠落・形式不正・不一致時は適切なエラーを返すようにしました。
* **Chores**
  * 暗号化ライブラリの依存関係を追加しました。
* **Tests**
  * Webhook エンドポイントのテストケースを追加（メソッド制御、設定エラー、署名検証、レスポンス内容の確認）。署名比較のテストも追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->