### PR TITLE
feat: add GET /builds endpoint to retrieve paginated build jobs by team and filter by hasIpa

### DIFF
--- a/apps/openci_server/lib/build_job/build_job_dao.dart
+++ b/apps/openci_server/lib/build_job/build_job_dao.dart
@@ -14,6 +14,23 @@ class BuildJobDao extends DatabaseAccessor<AppDatabase>
   Future<DriftBuildJob?> getBuildJob(String id) =>
       (select(buildJobs)..where((t) => t.id.equals(id))).getSingleOrNull();
 
+  Future<List<DriftBuildJob>> getBuildJobsForTeam({
+    required String teamId,
+    bool? hasIpa,
+    int limit = 100,
+  }) {
+    final query = select(buildJobs)
+      ..where((t) => t.teamId.equals(teamId))
+      ..orderBy([(t) => OrderingTerm.desc(t.createdAt)])
+      ..limit(limit);
+
+    if (hasIpa != null) {
+      query.where((t) => t.hasIpa.equals(hasIpa));
+    }
+
+    return query.get();
+  }
+
   Stream<DriftBuildJob?> watchBuildJob(String id) =>
       (select(buildJobs)..where((t) => t.id.equals(id))).watchSingleOrNull();
 

--- a/apps/openci_server/routes/builds/index.dart
+++ b/apps/openci_server/routes/builds/index.dart
@@ -45,10 +45,30 @@ Future<Response> _get(RequestContext context) async {
     }
 
     final hasIpaParam = queryParams['hasIpa'];
-    final bool? hasIpa = hasIpaParam == null ? null : hasIpaParam == 'true';
+    bool? hasIpa;
+    if (hasIpaParam != null) {
+      if (hasIpaParam == 'true') {
+        hasIpa = true;
+      } else if (hasIpaParam == 'false') {
+        hasIpa = false;
+      } else {
+        return Response.json(
+          statusCode: HttpStatus.badRequest,
+          body: {'success': false, 'error': 'Invalid hasIpa parameter'},
+        );
+      }
+    }
 
     final limitParam = queryParams['limit'];
-    final limit = limitParam != null ? int.tryParse(limitParam) ?? 100 : 100;
+    const maxLimit = 200;
+    final parsedLimit = limitParam == null ? 100 : int.tryParse(limitParam);
+    if (parsedLimit == null || parsedLimit < 1 || parsedLimit > maxLimit) {
+      return Response.json(
+        statusCode: HttpStatus.badRequest,
+        body: {'success': false, 'error': 'Invalid limit parameter'},
+      );
+    }
+    final limit = parsedLimit;
 
     final driftJobs = await db.buildJobDao.getBuildJobsForTeam(
       teamId: teamId,

--- a/apps/openci_server/routes/builds/index.dart
+++ b/apps/openci_server/routes/builds/index.dart
@@ -9,9 +9,65 @@ import 'package:openci_shared/openci_shared.dart';
 
 FutureOr<Response> onRequest(RequestContext context) {
   return switch (context.request.method) {
+    HttpMethod.get => _get(context),
     HttpMethod.post => _post(context),
     _ => Response(statusCode: HttpStatus.methodNotAllowed),
   };
+}
+
+Future<Response> _get(RequestContext context) async {
+  try {
+    final db = context.read<AppDatabase>();
+    final uid = context.read<String?>();
+
+    if (uid == null) {
+      return Response.json(
+        statusCode: HttpStatus.unauthorized,
+        body: {'success': false, 'error': 'Authentication required'},
+      );
+    }
+
+    final queryParams = context.request.uri.queryParameters;
+    final teamId = queryParams['teamId'];
+    if (teamId == null || teamId.isEmpty) {
+      return Response.json(
+        statusCode: HttpStatus.badRequest,
+        body: {'success': false, 'error': 'Missing teamId parameter'},
+      );
+    }
+
+    final isMember = await db.teamDao.isTeamMember(uid, teamId);
+    if (!isMember) {
+      return Response.json(
+        statusCode: HttpStatus.forbidden,
+        body: {'success': false, 'error': 'Forbidden'},
+      );
+    }
+
+    final hasIpaParam = queryParams['hasIpa'];
+    final bool? hasIpa = hasIpaParam == null ? null : hasIpaParam == 'true';
+
+    final limitParam = queryParams['limit'];
+    final limit = limitParam != null ? int.tryParse(limitParam) ?? 100 : 100;
+
+    final driftJobs = await db.buildJobDao.getBuildJobsForTeam(
+      teamId: teamId,
+      hasIpa: hasIpa,
+      limit: limit,
+    );
+
+    final jobs = driftJobs.map((j) => j.toShared().toJson()).toList();
+    return Response.json(body: {'success': true, 'buildJobs': jobs});
+  } catch (e, s) {
+    stderr.writeln('Failed to get build jobs: $e\n$s');
+    return Response.json(
+      statusCode: HttpStatus.internalServerError,
+      body: {
+        'success': false,
+        'error': 'Internal server error',
+      },
+    );
+  }
 }
 
 Future<Response> _post(RequestContext context) async {

--- a/apps/openci_server/test/routes/builds/index_test.dart
+++ b/apps/openci_server/test/routes/builds/index_test.dart
@@ -311,4 +311,161 @@ void main() {
       },
     );
   });
+
+  group('GET /builds', () {
+    test('responds with 401 Unauthorized when uid is null', () async {
+      final context = TestRequestContext(
+        path: '/builds?teamId=team-xyz',
+        method: HttpMethod.get,
+      );
+
+      context.provide<AppDatabase>(db);
+      context.provide<String?>(null);
+
+      final response = await route.onRequest(context.context);
+
+      expect(response.statusCode, equals(HttpStatus.unauthorized));
+    });
+
+    test(
+      'responds with 400 Bad Request when teamId parameter is missing',
+      () async {
+        final context = TestRequestContext(
+          path: '/builds',
+          method: HttpMethod.get,
+        );
+
+        context.provide<AppDatabase>(db);
+        context.provide<String?>('user-123');
+
+        final response = await route.onRequest(context.context);
+
+        expect(response.statusCode, equals(HttpStatus.badRequest));
+        final body = await response.json() as Map<String, dynamic>;
+        expect(body['success'], isFalse);
+        expect(body['error'], contains('Missing teamId parameter'));
+      },
+    );
+
+    test(
+      'responds with 403 Forbidden when user is not a member of the team',
+      () async {
+        final team = DriftTeam(
+          id: 'team-xyz',
+          name: 'Team XYZ',
+          githubBaseUrl: null,
+          githubApiBaseUrl: null,
+          installationIds: const [],
+          runNumber: 1,
+          aiEnabled: true,
+          createdAt: DateTime.now().toUtc(),
+          updatedAt: DateTime.now().toUtc(),
+        );
+
+        await db.teamDao.createTeamAndMember(team, 'user-abc');
+
+        final context = TestRequestContext(
+          path: '/builds?teamId=team-xyz',
+          method: HttpMethod.get,
+        );
+
+        context.provide<AppDatabase>(db);
+        context.provide<String?>('user-123');
+
+        final response = await route.onRequest(context.context);
+
+        expect(response.statusCode, equals(HttpStatus.forbidden));
+      },
+    );
+
+    test('responds with 200 OK and returns build jobs for the team', () async {
+      final team = DriftTeam(
+        id: 'team-xyz',
+        name: 'Team XYZ',
+        githubBaseUrl: null,
+        githubApiBaseUrl: null,
+        installationIds: const [],
+        runNumber: 1,
+        aiEnabled: true,
+        createdAt: DateTime.now().toUtc(),
+        updatedAt: DateTime.now().toUtc(),
+      );
+
+      await db.teamDao.createTeamAndMember(team, 'user-123');
+
+      final now = DateTime.now().toUtc();
+      final job1 = DriftBuildJob(
+        id: 'job-1',
+        status: BuildJobStatus.QUEUED,
+        owner: 'owner',
+        repo: 'repo',
+        workflowName: 'workflow',
+        teamId: 'team-xyz',
+        hasIpa: false,
+        createdAt: now,
+        updatedAt: now,
+      );
+      final job2 = DriftBuildJob(
+        id: 'job-2',
+        status: BuildJobStatus.SUCCESS,
+        owner: 'owner',
+        repo: 'repo',
+        workflowName: 'workflow',
+        teamId: 'team-xyz',
+        hasIpa: true,
+        createdAt: now.add(const Duration(seconds: 1)),
+        updatedAt: now.add(const Duration(seconds: 1)),
+      );
+      final jobOther = DriftBuildJob(
+        id: 'job-other',
+        status: BuildJobStatus.QUEUED,
+        owner: 'owner',
+        repo: 'repo',
+        workflowName: 'workflow',
+        teamId: 'team-other',
+        hasIpa: false,
+        createdAt: now,
+        updatedAt: now,
+      );
+
+      await db.buildJobDao.insertBuildJob(job1);
+      await db.buildJobDao.insertBuildJob(job2);
+      await db.buildJobDao.insertBuildJob(jobOther);
+
+      // Query all jobs for team-xyz
+      final contextAll = TestRequestContext(
+        path: '/builds?teamId=team-xyz',
+        method: HttpMethod.get,
+      );
+      contextAll.provide<AppDatabase>(db);
+      contextAll.provide<String?>('user-123');
+
+      final responseAll = await route.onRequest(contextAll.context);
+      expect(responseAll.statusCode, equals(HttpStatus.ok));
+      final bodyAll = await responseAll.json() as Map<String, dynamic>;
+      expect(bodyAll['success'], isTrue);
+      final listAll = bodyAll['buildJobs'] as List<dynamic>;
+      expect(listAll, hasLength(2));
+      expect(
+        listAll[0]['id'],
+        equals('job-2'),
+      ); // ordered descending by createdAt
+      expect(listAll[1]['id'], equals('job-1'));
+
+      // Query jobs with hasIpa=true
+      final contextIpa = TestRequestContext(
+        path: '/builds?teamId=team-xyz&hasIpa=true',
+        method: HttpMethod.get,
+      );
+      contextIpa.provide<AppDatabase>(db);
+      contextIpa.provide<String?>('user-123');
+
+      final responseIpa = await route.onRequest(contextIpa.context);
+      expect(responseIpa.statusCode, equals(HttpStatus.ok));
+      final bodyIpa = await responseIpa.json() as Map<String, dynamic>;
+      final listIpa = bodyIpa['buildJobs'] as List<dynamic>;
+      expect(listIpa, hasLength(1));
+      expect(listIpa[0]['id'], equals('job-2'));
+    });
+  });
 }

--- a/apps/openci_server/test/routes/builds/index_test.dart
+++ b/apps/openci_server/test/routes/builds/index_test.dart
@@ -467,5 +467,85 @@ void main() {
       expect(listIpa, hasLength(1));
       expect(listIpa[0]['id'], equals('job-2'));
     });
+
+    test('responds with 400 Bad Request when hasIpa parameter is invalid', () async {
+      final team = DriftTeam(
+        id: 'team-xyz',
+        name: 'Team XYZ',
+        githubBaseUrl: null,
+        githubApiBaseUrl: null,
+        installationIds: const [],
+        runNumber: 1,
+        aiEnabled: true,
+        createdAt: DateTime.now().toUtc(),
+        updatedAt: DateTime.now().toUtc(),
+      );
+
+      await db.teamDao.createTeamAndMember(team, 'user-123');
+
+      final context = TestRequestContext(
+        path: '/builds?teamId=team-xyz&hasIpa=invalid',
+        method: HttpMethod.get,
+      );
+      context.provide<AppDatabase>(db);
+      context.provide<String?>('user-123');
+
+      final response = await route.onRequest(context.context);
+      expect(response.statusCode, equals(HttpStatus.badRequest));
+      final body = await response.json() as Map<String, dynamic>;
+      expect(body['success'], isFalse);
+      expect(body['error'], contains('Invalid hasIpa parameter'));
+    });
+
+    test('responds with 400 Bad Request when limit parameter is invalid', () async {
+      final team = DriftTeam(
+        id: 'team-xyz',
+        name: 'Team XYZ',
+        githubBaseUrl: null,
+        githubApiBaseUrl: null,
+        installationIds: const [],
+        runNumber: 1,
+        aiEnabled: true,
+        createdAt: DateTime.now().toUtc(),
+        updatedAt: DateTime.now().toUtc(),
+      );
+
+      await db.teamDao.createTeamAndMember(team, 'user-123');
+
+      // Test with non-integer limit
+      final contextInvalidString = TestRequestContext(
+        path: '/builds?teamId=team-xyz&limit=abc',
+        method: HttpMethod.get,
+      );
+      contextInvalidString.provide<AppDatabase>(db);
+      contextInvalidString.provide<String?>('user-123');
+
+      final responseInvalidString = await route.onRequest(contextInvalidString.context);
+      expect(responseInvalidString.statusCode, equals(HttpStatus.badRequest));
+      final bodyInvalidString = await responseInvalidString.json() as Map<String, dynamic>;
+      expect(bodyInvalidString['error'], contains('Invalid limit parameter'));
+
+      // Test with limit < 1
+      final contextZero = TestRequestContext(
+        path: '/builds?teamId=team-xyz&limit=0',
+        method: HttpMethod.get,
+      );
+      contextZero.provide<AppDatabase>(db);
+      contextZero.provide<String?>('user-123');
+
+      final responseZero = await route.onRequest(contextZero.context);
+      expect(responseZero.statusCode, equals(HttpStatus.badRequest));
+
+      // Test with limit > 200
+      final contextTooLarge = TestRequestContext(
+        path: '/builds?teamId=team-xyz&limit=201',
+        method: HttpMethod.get,
+      );
+      contextTooLarge.provide<AppDatabase>(db);
+      contextTooLarge.provide<String?>('user-123');
+
+      final responseTooLarge = await route.onRequest(contextTooLarge.context);
+      expect(responseTooLarge.statusCode, equals(HttpStatus.badRequest));
+    });
   });
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * `GET /builds` にてチーム単位のビルドジョブ一覧を取得できるようにしました
  * IPA有無（`hasIpa`）での絞り込みに対応しました
  * 一覧は作成日時の新しい順に並び替えます
  * チームメンバーであることの権限確認を追加しました
* **テスト**
  * 認証・入力バリデーション・権限・応答内容（並び順、絞り込み、件数上限）を検証するテストを追加しました
<!-- end of auto-generated comment: release notes by coderabbit.ai -->