### PR TITLE
refactor: migrate build jobs provider from Firestore snapshots to polling custom HTTP API endpoints

### DIFF
--- a/apps/dashboard/lib/build_logs/build_jobs_provider.dart
+++ b/apps/dashboard/lib/build_logs/build_jobs_provider.dart
@@ -1,9 +1,12 @@
-import 'package:cloud_firestore/cloud_firestore.dart';
+import 'dart:async';
+import 'dart:convert';
+
 import 'package:dashboard/auth/auth_provider.dart';
 import 'package:dashboard/firebase/firestore.dart';
 import 'package:dashboard/firebase/functions.dart';
 import 'package:dashboard/users/user_provider.dart';
 import 'package:flutter/foundation.dart';
+import 'package:http/http.dart' as http;
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:uuid/uuid.dart';
 
@@ -23,26 +26,51 @@ class BuildJobs extends _$BuildJobs {
       return;
     }
 
-    final query = firestore
-        .collection(buildJobsCollection)
-        .where('teamId', isEqualTo: teamId)
-        .orderBy('createdAt', descending: true)
-        .limit(_buildJobsHistoryLimit);
+    const serverUrl = String.fromEnvironment('OPENCI_SERVER_URL');
+    if (serverUrl.isEmpty) {
+      throw UnimplementedError('OPENCI_SERVER_URL is not set');
+    }
 
-    final initialResult = await query.get();
-    final initialJobs = _sortedBuildJobs(
-      initialResult.docs.map((doc) => _buildJobFromData(doc.id, doc.data())),
-    );
-    yield initialJobs;
+    yield await _fetchBuildJobs(serverUrl, teamId);
 
-    yield* query.snapshots().map(
-      (result) {
-        final jobs = _sortedBuildJobs(
-          result.docs.map((doc) => _buildJobFromData(doc.id, doc.data())),
-        );
-        return jobs;
-      },
-    );
+    yield* Stream.periodic(const Duration(seconds: 5)).asyncMap((_) async {
+      return _fetchBuildJobs(serverUrl, teamId);
+    });
+  }
+
+  Future<List<BuildJob>> _fetchBuildJobs(
+    String serverUrl,
+    String teamId,
+  ) async {
+    try {
+      final url = Uri.parse(
+        '$serverUrl/builds?teamId=$teamId&limit=$_buildJobsHistoryLimit',
+      );
+      final token = await ref.watch(firebaseIdTokenProvider.future);
+      if (token == null) return const [];
+
+      final response = await http
+          .get(
+            url,
+            headers: {
+              'Authorization': 'Bearer $token',
+            },
+          )
+          .timeout(const Duration(seconds: 5));
+
+      if (response.statusCode != 200) return const [];
+
+      final data = jsonDecode(response.body) as Map<String, dynamic>;
+      final items = data['buildJobs'] as List<dynamic>;
+      return items
+          .map(
+            (item) => BuildJob.fromJson(Map<String, dynamic>.from(item as Map)),
+          )
+          .toList();
+    } catch (e, s) {
+      debugPrint('Error fetching build jobs: $e\n$s');
+      return const [];
+    }
   }
 
   Future<void> retryBuildJob(String buildJobId) async {
@@ -211,159 +239,133 @@ class OtaBuildJobs extends _$OtaBuildJobs {
       return;
     }
 
-    final query = firestore
-        .collection(buildJobsCollection)
-        .where('teamId', isEqualTo: teamId)
-        .where('hasIpa', isEqualTo: true)
-        .orderBy('createdAt', descending: true)
-        .limit(100);
+    const serverUrl = String.fromEnvironment('OPENCI_SERVER_URL');
+    if (serverUrl.isEmpty) {
+      throw UnimplementedError('OPENCI_SERVER_URL is not set');
+    }
 
-    final initialResult = await query.get();
-    final initialJobs = _sortedBuildJobs(
-      initialResult.docs.map((doc) => _buildJobFromData(doc.id, doc.data())),
-    );
-    yield initialJobs;
+    yield await _fetchOtaBuildJobs(serverUrl, teamId);
 
-    yield* query.snapshots().map(
-      (result) {
-        final jobs = _sortedBuildJobs(
-          result.docs.map((doc) => _buildJobFromData(doc.id, doc.data())),
-        );
-        return jobs;
-      },
-    );
+    yield* Stream.periodic(const Duration(seconds: 5)).asyncMap((_) async {
+      return _fetchOtaBuildJobs(serverUrl, teamId);
+    });
+  }
+
+  Future<List<BuildJob>> _fetchOtaBuildJobs(
+    String serverUrl,
+    String teamId,
+  ) async {
+    try {
+      final url = Uri.parse(
+        '$serverUrl/builds?teamId=$teamId&hasIpa=true&limit=100',
+      );
+      final token = await ref.watch(firebaseIdTokenProvider.future);
+      if (token == null) return const [];
+
+      final response = await http
+          .get(
+            url,
+            headers: {
+              'Authorization': 'Bearer $token',
+            },
+          )
+          .timeout(const Duration(seconds: 5));
+
+      if (response.statusCode != 200) return const [];
+
+      final data = jsonDecode(response.body) as Map<String, dynamic>;
+      final items = data['buildJobs'] as List<dynamic>;
+      return items
+          .map(
+            (item) => BuildJob.fromJson(Map<String, dynamic>.from(item as Map)),
+          )
+          .toList();
+    } catch (e, s) {
+      debugPrint('Error fetching ota build jobs: $e\n$s');
+      return const [];
+    }
   }
 }
 
 @riverpod
-Stream<BuildJob?> buildJobById(Ref ref, String buildJobId) {
+Stream<BuildJob?> buildJobById(Ref ref, String buildJobId) async* {
   final authState = ref.watch(authStateChangesProvider);
   if (authState.value == null) {
-    return Stream.value(null);
+    yield null;
+    return;
   }
 
-  return firestore
-      .collection(buildJobsCollection)
-      .doc(buildJobId)
-      .snapshots()
-      .map((snapshot) {
-        final job = _buildJobFromSnapshot(snapshot);
-        if (job != null && job.teamId != null) {
-          final userAsync = ref.read(userProvider);
-          userAsync.whenData((user) {
-            if (user.selectedTeamId != job.teamId) {
-              Future.microtask(() {
-                ref
-                    .read(userProvider.notifier)
-                    .updateSelectedTeamId(job.teamId!);
-              });
-            }
-          });
-        }
-        return job;
-      })
-      .handleError((error) {
-        debugPrint('Error loading build job in buildJobById: $error');
-        return null;
-      });
+  const serverUrl = String.fromEnvironment('OPENCI_SERVER_URL');
+  if (serverUrl.isEmpty) {
+    throw UnimplementedError('OPENCI_SERVER_URL is not set');
+  }
+
+  Future<BuildJob?> fetchJob() async {
+    try {
+      final url = Uri.parse('$serverUrl/builds/$buildJobId');
+      final token = await ref.watch(firebaseIdTokenProvider.future);
+      if (token == null) return null;
+
+      final response = await http
+          .get(
+            url,
+            headers: {
+              'Authorization': 'Bearer $token',
+            },
+          )
+          .timeout(const Duration(seconds: 5));
+
+      if (response.statusCode != 200) return null;
+
+      final data = jsonDecode(response.body) as Map<String, dynamic>;
+      final job = BuildJob.fromJson(data);
+      if (job.teamId != null) {
+        final userAsync = ref.read(userProvider);
+        userAsync.whenData((user) {
+          if (user.selectedTeamId != job.teamId) {
+            Future.microtask(() {
+              ref.read(userProvider.notifier).updateSelectedTeamId(job.teamId!);
+            });
+          }
+        });
+      }
+      return job;
+    } catch (e, s) {
+      debugPrint('Error fetching build job by id: $e\n$s');
+      return null;
+    }
+  }
+
+  yield await fetchJob();
+
+  yield* Stream.periodic(const Duration(seconds: 5)).asyncMap((_) async {
+    return fetchJob();
+  });
 }
 
 @riverpod
-Stream<Duration?> runDuration(Ref ref, BuildJob buildJob) {
-  final runId = buildJob.latestRunId;
-  if (runId == null) {
-    return Stream.value(_durationFromBuildJob(buildJob));
+Stream<Duration?> runDuration(Ref ref, BuildJob buildJob) async* {
+  Duration? calculate() {
+    final completedAt = buildJob.completedAt;
+    if (completedAt != null) {
+      return _positiveDuration(buildJob.createdAt, completedAt);
+    }
+    if (buildJob.status == BuildJobStatus.IN_PROGRESS ||
+        buildJob.status == BuildJobStatus.QUEUED) {
+      return _positiveDuration(buildJob.createdAt, DateTime.now().toUtc());
+    }
+    return null;
   }
 
-  return firestore
-      .collection(buildJobsCollection)
-      .doc(buildJob.id)
-      .collection('runs')
-      .doc(runId)
-      .snapshots()
-      .map((snapshot) {
-        final data = snapshot.data();
-        final runStartedAt = _nullableDateTimeFromFirestore(data?['createdAt']);
-        final runUpdatedAt = _nullableDateTimeFromFirestore(data?['updatedAt']);
-        final runCompleted =
-            data?['status'] == 'completed' || data?['conclusion'] != null;
-        final runCompletedAt = runCompleted ? runUpdatedAt : null;
-        final completedAt = runCompletedAt ?? buildJob.completedAt;
-        if (runStartedAt != null && completedAt != null) {
-          return _positiveDuration(runStartedAt, completedAt);
-        }
-        return _durationFromBuildJob(buildJob);
-      });
-}
+  yield calculate();
 
-DateTime? _nullableDateTimeFromFirestore(Object? value) {
-  if (value == null) return null;
-  if (value is Timestamp) return value.toDate();
-  if (value is DateTime) return value;
-  if (value is String) return DateTime.tryParse(value);
-  return null;
-}
-
-Duration? _durationFromBuildJob(BuildJob buildJob) {
-  final completedAt = buildJob.completedAt;
-  if (completedAt == null) return null;
-  return _positiveDuration(buildJob.createdAt, completedAt);
+  if (buildJob.completedAt == null) {
+    yield* Stream.periodic(const Duration(seconds: 1)).map((_) => calculate());
+  }
 }
 
 Duration? _positiveDuration(DateTime startedAt, DateTime completedAt) {
   final duration = completedAt.difference(startedAt);
   if (duration.isNegative || duration.inSeconds == 0) return null;
   return duration;
-}
-
-BuildJob? _buildJobFromSnapshot(DocumentSnapshot<Map<String, dynamic>> doc) {
-  final data = doc.data();
-  if (data == null) return null;
-  return _buildJobFromData(doc.id, data);
-}
-
-BuildJob _buildJobFromData(String id, Map<String, dynamic> job) {
-  return BuildJob(
-    id: id,
-    status: buildJobStatusFromFirestore(job['status']),
-    owner: job['owner'] as String? ?? '',
-    repo: job['repo'] as String? ?? '',
-    workflowName: job['workflowName'] as String,
-    teamId: job['teamId'] as String?,
-    workflowId: job['workflowId'] as String?,
-    workflowFileName: job['workflowFileName'] as String?,
-    commitSha: job['commitSha'] as String?,
-    pullRequestNumber: job['pullRequestNumber'] as int?,
-    runCount: job['runCount'] as int?,
-    latestRunId: job['latestRunId'] as String?,
-    tagName: job['tagName'] as String?,
-    branch: job['branch'] as String?,
-    jobKey: job['jobKey'] as String?,
-    workflowJobKey: job['workflowJobKey'] as String?,
-    matrix: (job['matrix'] as Map?)?.cast<String, Object?>(),
-    matrixLabel: job['matrixLabel'] as String?,
-    workflowRunId: job['workflowRunId'] as String?,
-    needs: (job['needs'] as List?)?.whereType<String>().toList(),
-    failureSummary: job['failureSummary'] as String?,
-    failureSummaryModel: job['failureSummaryModel'] as String?,
-    failureSummaryStatus: job['failureSummaryStatus'] as String?,
-    failureSummaryDurationMs: job['failureSummaryDurationMs'] as int?,
-    provisionedUdids: (job['provisionedUdids'] as List?)
-        ?.whereType<String>()
-        .toList(),
-    ipaUrl: job['ipaUrl'] as String?,
-    hasIpa: job['hasIpa'] as bool?,
-    bundleId: job['bundleId'] as String?,
-    ipaVersion: job['ipaVersion'] as String?,
-    appName: job['appName'] as String?,
-    createdAt: dateTimeFromFirestore(job['createdAt']),
-    updatedAt: dateTimeFromFirestore(job['updatedAt']),
-    completedAt: job['completedAt'] == null
-        ? null
-        : dateTimeFromFirestore(job['completedAt']),
-  );
-}
-
-List<BuildJob> _sortedBuildJobs(Iterable<BuildJob> jobs) {
-  return jobs.toList()..sort((a, b) => b.createdAt.compareTo(a.createdAt));
 }

--- a/apps/dashboard/lib/build_logs/build_jobs_provider.g.dart
+++ b/apps/dashboard/lib/build_logs/build_jobs_provider.g.dart
@@ -33,7 +33,7 @@ final class BuildJobsProvider
   BuildJobs create() => BuildJobs();
 }
 
-String _$buildJobsHash() => r'3a94a99bb0980e53fba156e3e44284917b7ae13c';
+String _$buildJobsHash() => r'800e66539f2d96f85d8c0a32f554ddde55132a07';
 
 abstract class _$BuildJobs extends $StreamNotifier<List<BuildJob>> {
   Stream<List<BuildJob>> build();
@@ -77,7 +77,7 @@ final class OtaBuildJobsProvider
   OtaBuildJobs create() => OtaBuildJobs();
 }
 
-String _$otaBuildJobsHash() => r'a4b96a45c137b4616ceb764e3c0ade5590f93b76';
+String _$otaBuildJobsHash() => r'a57525e69d2400ee46f0c886a829ba8e547db116';
 
 abstract class _$OtaBuildJobs extends $StreamNotifier<List<BuildJob>> {
   Stream<List<BuildJob>> build();
@@ -147,7 +147,7 @@ final class BuildJobByIdProvider
   }
 }
 
-String _$buildJobByIdHash() => r'a71c253c6271cfd89cb7ed98c56900e66b954b41';
+String _$buildJobByIdHash() => r'c1ce631e86c3f1e31b0b54f95492f262ee3b3302';
 
 final class BuildJobByIdFamily extends $Family
     with $FunctionalFamilyOverride<Stream<BuildJob?>, String> {
@@ -217,7 +217,7 @@ final class RunDurationProvider
   }
 }
 
-String _$runDurationHash() => r'1fe2804ef7376e6eec2a3a4ef20d17d6251c8af0';
+String _$runDurationHash() => r'ba337f70f379080b9c8bf5ccce034a8fa48bcfc2';
 
 final class RunDurationFamily extends $Family
     with $FunctionalFamilyOverride<Stream<Duration?>, BuildJob> {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **リファクタリング**
  * ビルドログ取得機能のバックエンド実装を更新しました。定期的な再取得により、ビルド情報がより頻繁に更新されるようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->