### PR TITLE
refactor: consolidate JSON body parsing into a reusable RequestContext extension

### DIFF
--- a/apps/openci_server/lib/request/request_extension.dart
+++ b/apps/openci_server/lib/request/request_extension.dart
@@ -1,0 +1,27 @@
+import 'dart:convert';
+
+import 'package:dart_frog/dart_frog.dart';
+
+class BadRequestException implements Exception {
+  const BadRequestException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => message;
+}
+
+extension RequestContextJsonExtension on RequestContext {
+  Future<Map<String, dynamic>> jsonBody() async {
+    try {
+      final body = await request.body();
+      final decoded = jsonDecode(body);
+      if (decoded is! Map<String, dynamic>) {
+        throw const FormatException('Body must be a JSON object');
+      }
+      return decoded;
+    } catch (e) {
+      throw BadRequestException('Invalid JSON format: $e');
+    }
+  }
+}

--- a/apps/openci_server/lib/request/request_extension.dart
+++ b/apps/openci_server/lib/request/request_extension.dart
@@ -20,7 +20,7 @@ extension RequestContextJsonExtension on RequestContext {
         throw const FormatException('Body must be a JSON object');
       }
       return decoded;
-    } catch (e) {
+    } on FormatException catch (e) {
       throw BadRequestException('Invalid JSON format: $e');
     }
   }

--- a/apps/openci_server/routes/builds/[id]/check-run.dart
+++ b/apps/openci_server/routes/builds/[id]/check-run.dart
@@ -1,10 +1,10 @@
 import 'dart:async';
-import 'dart:convert';
 import 'dart:io';
 
 import 'package:dart_frog/dart_frog.dart';
 import 'package:openci_server/database.dart';
 import 'package:openci_server/github/github_service.dart';
+import 'package:openci_server/request/request_extension.dart';
 
 FutureOr<Response> onRequest(RequestContext context, String id) {
   return switch (context.request.method) {
@@ -19,16 +19,11 @@ Future<Response> _post(RequestContext context, String id) async {
 
     final Map<String, dynamic> payload;
     try {
-      final body = await context.request.body();
-      final decoded = jsonDecode(body);
-      if (decoded is! Map<String, dynamic>) {
-        throw const FormatException('Body must be a JSON object');
-      }
-      payload = decoded;
-    } catch (e) {
+      payload = await context.jsonBody();
+    } on BadRequestException catch (e) {
       return Response.json(
         statusCode: HttpStatus.badRequest,
-        body: {'success': false, 'error': 'Invalid JSON: $e'},
+        body: {'success': false, 'error': e.message},
       );
     }
 

--- a/apps/openci_server/routes/builds/[id]/index.dart
+++ b/apps/openci_server/routes/builds/[id]/index.dart
@@ -1,10 +1,10 @@
 import 'dart:async';
-import 'dart:convert';
 import 'dart:io';
 
 import 'package:dart_frog/dart_frog.dart';
 import 'package:openci_server/build_job/build_job_mapper.dart';
 import 'package:openci_server/database.dart';
+import 'package:openci_server/request/request_extension.dart';
 import 'package:openci_shared/openci_shared.dart';
 
 FutureOr<Response> onRequest(RequestContext context, String id) {
@@ -39,16 +39,11 @@ Future<Response> _patch(RequestContext context, String id) async {
 
     final Map<String, dynamic> payload;
     try {
-      final body = await context.request.body();
-      final decoded = jsonDecode(body);
-      if (decoded is! Map<String, dynamic>) {
-        throw const FormatException('Body must be a JSON object');
-      }
-      payload = decoded;
-    } catch (e) {
+      payload = await context.jsonBody();
+    } on BadRequestException catch (e) {
       return Response.json(
         statusCode: HttpStatus.badRequest,
-        body: {'success': false, 'error': 'Invalid JSON: $e'},
+        body: {'success': false, 'error': e.message},
       );
     }
 

--- a/apps/openci_server/routes/builds/[id]/runs/[runId].dart
+++ b/apps/openci_server/routes/builds/[id]/runs/[runId].dart
@@ -1,10 +1,11 @@
 import 'dart:async';
-import 'dart:convert';
+
 import 'dart:io';
 
 import 'package:dart_frog/dart_frog.dart';
 import 'package:drift/drift.dart';
 import 'package:openci_server/database.dart';
+import 'package:openci_server/request/request_extension.dart';
 
 FutureOr<Response> onRequest(
   RequestContext context,
@@ -65,16 +66,11 @@ Future<Response> _patch(
 
     final Map<String, dynamic> payload;
     try {
-      final body = await context.request.body();
-      final decoded = jsonDecode(body);
-      if (decoded is! Map<String, dynamic>) {
-        throw const FormatException('Body must be a JSON object');
-      }
-      payload = decoded;
-    } catch (e) {
+      payload = await context.jsonBody();
+    } on BadRequestException catch (e) {
       return Response.json(
         statusCode: HttpStatus.badRequest,
-        body: {'success': false, 'error': 'Invalid JSON: $e'},
+        body: {'success': false, 'error': e.message},
       );
     }
 

--- a/apps/openci_server/routes/builds/[id]/runs/[runId]/logs.dart
+++ b/apps/openci_server/routes/builds/[id]/runs/[runId]/logs.dart
@@ -1,9 +1,10 @@
 import 'dart:async';
-import 'dart:convert';
+
 import 'dart:io';
 
 import 'package:dart_frog/dart_frog.dart';
 import 'package:openci_server/database.dart';
+import 'package:openci_server/request/request_extension.dart';
 
 FutureOr<Response> onRequest(
   RequestContext context,
@@ -70,16 +71,11 @@ Future<Response> _post(
 
     final Map<String, dynamic> payload;
     try {
-      final body = await context.request.body();
-      final decoded = jsonDecode(body);
-      if (decoded is! Map<String, dynamic>) {
-        throw const FormatException('Body must be a JSON object');
-      }
-      payload = decoded;
-    } catch (e) {
+      payload = await context.jsonBody();
+    } on BadRequestException catch (e) {
       return Response.json(
         statusCode: HttpStatus.badRequest,
-        body: {'success': false, 'error': 'Invalid JSON'},
+        body: {'success': false, 'error': e.message},
       );
     }
 

--- a/apps/openci_server/routes/builds/[id]/runs/index.dart
+++ b/apps/openci_server/routes/builds/[id]/runs/index.dart
@@ -1,9 +1,10 @@
 import 'dart:async';
-import 'dart:convert';
+
 import 'dart:io';
 
 import 'package:dart_frog/dart_frog.dart';
 import 'package:openci_server/database.dart';
+import 'package:openci_server/request/request_extension.dart';
 
 FutureOr<Response> onRequest(RequestContext context, String id) {
   return switch (context.request.method) {
@@ -49,16 +50,11 @@ Future<Response> _post(RequestContext context, String id) async {
 
     final Map<String, dynamic> payload;
     try {
-      final body = await context.request.body();
-      final decoded = jsonDecode(body);
-      if (decoded is! Map<String, dynamic>) {
-        throw const FormatException('Body must be a JSON object');
-      }
-      payload = decoded;
-    } catch (e) {
+      payload = await context.jsonBody();
+    } on BadRequestException catch (e) {
       return Response.json(
         statusCode: HttpStatus.badRequest,
-        body: {'success': false, 'error': 'Invalid JSON format: $e'},
+        body: {'success': false, 'error': e.message},
       );
     }
 

--- a/apps/openci_server/routes/builds/[id]/status-change.dart
+++ b/apps/openci_server/routes/builds/[id]/status-change.dart
@@ -1,11 +1,11 @@
 import 'dart:async';
-import 'dart:convert';
 import 'dart:io';
 
 import 'package:dart_frog/dart_frog.dart';
 import 'package:drift/drift.dart' show Value;
 import 'package:openci_server/database.dart';
 import 'package:openci_server/github/github_service.dart';
+import 'package:openci_server/request/request_extension.dart';
 import 'package:openci_shared/openci_shared.dart';
 
 FutureOr<Response> onRequest(RequestContext context, String id) {
@@ -22,16 +22,11 @@ Future<Response> _post(RequestContext context, String id) async {
 
     final Map<String, dynamic> payload;
     try {
-      final body = await context.request.body();
-      final decoded = jsonDecode(body);
-      if (decoded is! Map<String, dynamic>) {
-        throw const FormatException('Body must be a JSON object');
-      }
-      payload = decoded;
-    } catch (e) {
+      payload = await context.jsonBody();
+    } on BadRequestException catch (e) {
       return Response.json(
         statusCode: HttpStatus.badRequest,
-        body: {'success': false, 'error': 'Invalid JSON: $e'},
+        body: {'success': false, 'error': e.message},
       );
     }
 

--- a/apps/openci_server/routes/builds/claim.dart
+++ b/apps/openci_server/routes/builds/claim.dart
@@ -1,11 +1,11 @@
 import 'dart:async';
-import 'dart:convert';
 import 'dart:io';
 
 import 'package:dart_frog/dart_frog.dart';
 import 'package:openci_server/auth/worker_auth.dart';
 import 'package:openci_server/build_job/build_job_mapper.dart';
 import 'package:openci_server/database.dart';
+import 'package:openci_server/request/request_extension.dart';
 
 FutureOr<Response> onRequest(RequestContext context) {
   return switch (context.request.method) {
@@ -26,16 +26,11 @@ Future<Response> _post(RequestContext context) async {
 
     final Map<String, dynamic> payload;
     try {
-      final body = await context.request.body();
-      final decoded = jsonDecode(body);
-      if (decoded is! Map<String, dynamic>) {
-        throw const FormatException('Body must be a JSON object');
-      }
-      payload = decoded;
-    } catch (e) {
+      payload = await context.jsonBody();
+    } on BadRequestException catch (e) {
       return Response.json(
         statusCode: HttpStatus.badRequest,
-        body: {'success': false, 'error': 'Invalid JSON format: $e'},
+        body: {'success': false, 'error': e.message},
       );
     }
 

--- a/apps/openci_server/routes/builds/index.dart
+++ b/apps/openci_server/routes/builds/index.dart
@@ -1,10 +1,10 @@
 import 'dart:async';
-import 'dart:convert';
 import 'dart:io';
 
 import 'package:dart_frog/dart_frog.dart';
 import 'package:openci_server/build_job/build_job_mapper.dart';
 import 'package:openci_server/database.dart';
+import 'package:openci_server/request/request_extension.dart';
 import 'package:openci_shared/openci_shared.dart';
 
 FutureOr<Response> onRequest(RequestContext context) {
@@ -104,16 +104,11 @@ Future<Response> _post(RequestContext context) async {
 
     final Map<String, dynamic> payload;
     try {
-      final body = await context.request.body();
-      final decoded = jsonDecode(body);
-      if (decoded is! Map<String, dynamic>) {
-        throw const FormatException('Body must be a JSON object');
-      }
-      payload = decoded;
-    } catch (e) {
+      payload = await context.jsonBody();
+    } on BadRequestException catch (e) {
       return Response.json(
         statusCode: HttpStatus.badRequest,
-        body: {'success': false, 'error': 'Invalid JSON format: $e'},
+        body: {'success': false, 'error': e.message},
       );
     }
 

--- a/apps/openci_server/routes/teams/[id].dart
+++ b/apps/openci_server/routes/teams/[id].dart
@@ -1,9 +1,9 @@
 import 'dart:async';
-import 'dart:convert';
 import 'dart:io';
 
 import 'package:dart_frog/dart_frog.dart';
 import 'package:openci_server/database.dart';
+import 'package:openci_server/request/request_extension.dart';
 
 FutureOr<Response> onRequest(RequestContext context, String id) {
   return switch (context.request.method) {
@@ -33,16 +33,11 @@ Future<Response> _patch(RequestContext context, String id) async {
 
     final Map<String, dynamic> payload;
     try {
-      final body = await context.request.body();
-      final decoded = jsonDecode(body);
-      if (decoded is! Map<String, dynamic>) {
-        throw const FormatException('Body must be a JSON object');
-      }
-      payload = decoded;
-    } catch (e) {
+      payload = await context.jsonBody();
+    } on BadRequestException catch (e) {
       return Response.json(
         statusCode: HttpStatus.badRequest,
-        body: {'success': false, 'error': 'Invalid JSON: $e'},
+        body: {'success': false, 'error': e.message},
       );
     }
 

--- a/apps/openci_server/routes/teams/index.dart
+++ b/apps/openci_server/routes/teams/index.dart
@@ -1,9 +1,9 @@
 import 'dart:async';
-import 'dart:convert';
 import 'dart:io';
 
 import 'package:dart_frog/dart_frog.dart';
 import 'package:openci_server/database.dart';
+import 'package:openci_server/request/request_extension.dart';
 import 'package:openci_server/team/team_mapper.dart';
 import 'package:openci_shared/openci_shared.dart';
 import 'package:uuid/uuid.dart';
@@ -67,16 +67,11 @@ Future<Response> _post(RequestContext context) async {
 
     final Map<String, dynamic> payload;
     try {
-      final body = await context.request.body();
-      final decoded = jsonDecode(body);
-      if (decoded is! Map<String, dynamic>) {
-        throw const FormatException('Body must be a JSON object');
-      }
-      payload = decoded;
-    } catch (e) {
+      payload = await context.jsonBody();
+    } on BadRequestException catch (e) {
       return Response.json(
         statusCode: HttpStatus.badRequest,
-        body: {'success': false, 'error': 'Invalid JSON: $e'},
+        body: {'success': false, 'error': e.message},
       );
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * JSONリクエストの解析方式を統一し、無効なリクエストに対するエラーレスポンスを一貫した形式に改善しました。
  * JSON本体の取得を共通化し、400 Bad Request 時にエラーメッセージ内容を返すように変更しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->