### PR TITLE
fix: preserve installation and check run IDs when updating build jobs

### DIFF
--- a/apps/openci_server/routes/builds/[id]/index.dart
+++ b/apps/openci_server/routes/builds/[id]/index.dart
@@ -94,7 +94,10 @@ Future<Response> _patch(RequestContext context, String id) async {
           : job.completedAt,
     );
 
-    final updatedDriftJob = updatedJob.toDrift();
+    final updatedDriftJob = updatedJob.toDrift(
+      installationId: driftJob.installationId,
+      checkRunId: driftJob.checkRunId,
+    );
     await db.buildJobDao.updateBuildJob(updatedDriftJob);
 
     return Response.json(body: {'success': true});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリース ノート

* **Bug Fixes**
  * ビルドジョブ更新時の参照キーの一貫性が改善されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->