### PR TITLE
feat: implement persistent background webhook task queue with worker pool

### DIFF
--- a/apps/openci_server/lib/database.dart
+++ b/apps/openci_server/lib/database.dart
@@ -10,6 +10,8 @@ import 'package:openci_server/processed_webhook/processed_webhook_table.dart';
 import 'package:openci_server/secret/secret_table.dart';
 import 'package:openci_server/team/team_dao.dart';
 import 'package:openci_server/team/team_table.dart';
+import 'package:openci_server/webhook_task/webhook_task_dao.dart';
+import 'package:openci_server/webhook_task/webhook_task_table.dart';
 import 'package:openci_shared/openci_shared.dart';
 import 'package:postgres/postgres.dart' as pg;
 
@@ -24,14 +26,15 @@ part 'database.g.dart';
     TeamMembers,
     Secrets,
     ProcessedWebhooks,
+    WebhookTasks,
   ],
-  daos: [BuildJobDao, BuildRunDao, TeamDao],
+  daos: [BuildJobDao, BuildRunDao, TeamDao, WebhookTaskDao],
 )
 class AppDatabase extends _$AppDatabase {
   AppDatabase([QueryExecutor? executor]) : super(executor ?? _openConnection());
 
   @override
-  int get schemaVersion => 9;
+  int get schemaVersion => 10;
 
   @override
   MigrationStrategy get migration {
@@ -65,6 +68,9 @@ class AppDatabase extends _$AppDatabase {
         }
         if (from < 9) {
           await m.addColumn(buildJobs, buildJobs.runsOn);
+        }
+        if (from < 10) {
+          await m.createTable(webhookTasks);
         }
       },
     );

--- a/apps/openci_server/lib/database.g.dart
+++ b/apps/openci_server/lib/database.g.dart
@@ -4154,6 +4154,572 @@ class ProcessedWebhooksCompanion
   }
 }
 
+class $WebhookTasksTable extends WebhookTasks
+    with TableInfo<$WebhookTasksTable, DriftWebhookTask> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $WebhookTasksTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<String> id = GeneratedColumn<String>(
+    'id',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _deliveryIdMeta = const VerificationMeta(
+    'deliveryId',
+  );
+  @override
+  late final GeneratedColumn<String> deliveryId = GeneratedColumn<String>(
+    'delivery_id',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+    defaultConstraints: GeneratedColumn.constraintIsAlways('UNIQUE'),
+  );
+  static const VerificationMeta _eventTypeMeta = const VerificationMeta(
+    'eventType',
+  );
+  @override
+  late final GeneratedColumn<String> eventType = GeneratedColumn<String>(
+    'event_type',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _payloadMeta = const VerificationMeta(
+    'payload',
+  );
+  @override
+  late final GeneratedColumn<String> payload = GeneratedColumn<String>(
+    'payload',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _statusMeta = const VerificationMeta('status');
+  @override
+  late final GeneratedColumn<String> status = GeneratedColumn<String>(
+    'status',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+    defaultValue: const Constant('pending'),
+  );
+  static const VerificationMeta _retryCountMeta = const VerificationMeta(
+    'retryCount',
+  );
+  @override
+  late final GeneratedColumn<int> retryCount = GeneratedColumn<int>(
+    'retry_count',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+    defaultValue: const Constant(0),
+  );
+  static const VerificationMeta _errorMessageMeta = const VerificationMeta(
+    'errorMessage',
+  );
+  @override
+  late final GeneratedColumn<String> errorMessage = GeneratedColumn<String>(
+    'error_message',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _createdAtMeta = const VerificationMeta(
+    'createdAt',
+  );
+  @override
+  late final GeneratedColumn<DateTime> createdAt = GeneratedColumn<DateTime>(
+    'created_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.dateTime,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _updatedAtMeta = const VerificationMeta(
+    'updatedAt',
+  );
+  @override
+  late final GeneratedColumn<DateTime> updatedAt = GeneratedColumn<DateTime>(
+    'updated_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.dateTime,
+    requiredDuringInsert: true,
+  );
+  @override
+  List<GeneratedColumn> get $columns => [
+    id,
+    deliveryId,
+    eventType,
+    payload,
+    status,
+    retryCount,
+    errorMessage,
+    createdAt,
+    updatedAt,
+  ];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'webhook_tasks';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<DriftWebhookTask> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    } else if (isInserting) {
+      context.missing(_idMeta);
+    }
+    if (data.containsKey('delivery_id')) {
+      context.handle(
+        _deliveryIdMeta,
+        deliveryId.isAcceptableOrUnknown(data['delivery_id']!, _deliveryIdMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_deliveryIdMeta);
+    }
+    if (data.containsKey('event_type')) {
+      context.handle(
+        _eventTypeMeta,
+        eventType.isAcceptableOrUnknown(data['event_type']!, _eventTypeMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_eventTypeMeta);
+    }
+    if (data.containsKey('payload')) {
+      context.handle(
+        _payloadMeta,
+        payload.isAcceptableOrUnknown(data['payload']!, _payloadMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_payloadMeta);
+    }
+    if (data.containsKey('status')) {
+      context.handle(
+        _statusMeta,
+        status.isAcceptableOrUnknown(data['status']!, _statusMeta),
+      );
+    }
+    if (data.containsKey('retry_count')) {
+      context.handle(
+        _retryCountMeta,
+        retryCount.isAcceptableOrUnknown(data['retry_count']!, _retryCountMeta),
+      );
+    }
+    if (data.containsKey('error_message')) {
+      context.handle(
+        _errorMessageMeta,
+        errorMessage.isAcceptableOrUnknown(
+          data['error_message']!,
+          _errorMessageMeta,
+        ),
+      );
+    }
+    if (data.containsKey('created_at')) {
+      context.handle(
+        _createdAtMeta,
+        createdAt.isAcceptableOrUnknown(data['created_at']!, _createdAtMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_createdAtMeta);
+    }
+    if (data.containsKey('updated_at')) {
+      context.handle(
+        _updatedAtMeta,
+        updatedAt.isAcceptableOrUnknown(data['updated_at']!, _updatedAtMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_updatedAtMeta);
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  DriftWebhookTask map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return DriftWebhookTask(
+      id: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}id'],
+      )!,
+      deliveryId: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}delivery_id'],
+      )!,
+      eventType: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}event_type'],
+      )!,
+      payload: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}payload'],
+      )!,
+      status: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}status'],
+      )!,
+      retryCount: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}retry_count'],
+      )!,
+      errorMessage: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}error_message'],
+      ),
+      createdAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}created_at'],
+      )!,
+      updatedAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}updated_at'],
+      )!,
+    );
+  }
+
+  @override
+  $WebhookTasksTable createAlias(String alias) {
+    return $WebhookTasksTable(attachedDatabase, alias);
+  }
+}
+
+class DriftWebhookTask extends DataClass
+    implements Insertable<DriftWebhookTask> {
+  final String id;
+  final String deliveryId;
+  final String eventType;
+  final String payload;
+  final String status;
+  final int retryCount;
+  final String? errorMessage;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+  const DriftWebhookTask({
+    required this.id,
+    required this.deliveryId,
+    required this.eventType,
+    required this.payload,
+    required this.status,
+    required this.retryCount,
+    this.errorMessage,
+    required this.createdAt,
+    required this.updatedAt,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['id'] = Variable<String>(id);
+    map['delivery_id'] = Variable<String>(deliveryId);
+    map['event_type'] = Variable<String>(eventType);
+    map['payload'] = Variable<String>(payload);
+    map['status'] = Variable<String>(status);
+    map['retry_count'] = Variable<int>(retryCount);
+    if (!nullToAbsent || errorMessage != null) {
+      map['error_message'] = Variable<String>(errorMessage);
+    }
+    map['created_at'] = Variable<DateTime>(createdAt);
+    map['updated_at'] = Variable<DateTime>(updatedAt);
+    return map;
+  }
+
+  WebhookTasksCompanion toCompanion(bool nullToAbsent) {
+    return WebhookTasksCompanion(
+      id: Value(id),
+      deliveryId: Value(deliveryId),
+      eventType: Value(eventType),
+      payload: Value(payload),
+      status: Value(status),
+      retryCount: Value(retryCount),
+      errorMessage: errorMessage == null && nullToAbsent
+          ? const Value.absent()
+          : Value(errorMessage),
+      createdAt: Value(createdAt),
+      updatedAt: Value(updatedAt),
+    );
+  }
+
+  factory DriftWebhookTask.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return DriftWebhookTask(
+      id: serializer.fromJson<String>(json['id']),
+      deliveryId: serializer.fromJson<String>(json['deliveryId']),
+      eventType: serializer.fromJson<String>(json['eventType']),
+      payload: serializer.fromJson<String>(json['payload']),
+      status: serializer.fromJson<String>(json['status']),
+      retryCount: serializer.fromJson<int>(json['retryCount']),
+      errorMessage: serializer.fromJson<String?>(json['errorMessage']),
+      createdAt: serializer.fromJson<DateTime>(json['createdAt']),
+      updatedAt: serializer.fromJson<DateTime>(json['updatedAt']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'id': serializer.toJson<String>(id),
+      'deliveryId': serializer.toJson<String>(deliveryId),
+      'eventType': serializer.toJson<String>(eventType),
+      'payload': serializer.toJson<String>(payload),
+      'status': serializer.toJson<String>(status),
+      'retryCount': serializer.toJson<int>(retryCount),
+      'errorMessage': serializer.toJson<String?>(errorMessage),
+      'createdAt': serializer.toJson<DateTime>(createdAt),
+      'updatedAt': serializer.toJson<DateTime>(updatedAt),
+    };
+  }
+
+  DriftWebhookTask copyWith({
+    String? id,
+    String? deliveryId,
+    String? eventType,
+    String? payload,
+    String? status,
+    int? retryCount,
+    Value<String?> errorMessage = const Value.absent(),
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) => DriftWebhookTask(
+    id: id ?? this.id,
+    deliveryId: deliveryId ?? this.deliveryId,
+    eventType: eventType ?? this.eventType,
+    payload: payload ?? this.payload,
+    status: status ?? this.status,
+    retryCount: retryCount ?? this.retryCount,
+    errorMessage: errorMessage.present ? errorMessage.value : this.errorMessage,
+    createdAt: createdAt ?? this.createdAt,
+    updatedAt: updatedAt ?? this.updatedAt,
+  );
+  DriftWebhookTask copyWithCompanion(WebhookTasksCompanion data) {
+    return DriftWebhookTask(
+      id: data.id.present ? data.id.value : this.id,
+      deliveryId: data.deliveryId.present
+          ? data.deliveryId.value
+          : this.deliveryId,
+      eventType: data.eventType.present ? data.eventType.value : this.eventType,
+      payload: data.payload.present ? data.payload.value : this.payload,
+      status: data.status.present ? data.status.value : this.status,
+      retryCount: data.retryCount.present
+          ? data.retryCount.value
+          : this.retryCount,
+      errorMessage: data.errorMessage.present
+          ? data.errorMessage.value
+          : this.errorMessage,
+      createdAt: data.createdAt.present ? data.createdAt.value : this.createdAt,
+      updatedAt: data.updatedAt.present ? data.updatedAt.value : this.updatedAt,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('DriftWebhookTask(')
+          ..write('id: $id, ')
+          ..write('deliveryId: $deliveryId, ')
+          ..write('eventType: $eventType, ')
+          ..write('payload: $payload, ')
+          ..write('status: $status, ')
+          ..write('retryCount: $retryCount, ')
+          ..write('errorMessage: $errorMessage, ')
+          ..write('createdAt: $createdAt, ')
+          ..write('updatedAt: $updatedAt')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    id,
+    deliveryId,
+    eventType,
+    payload,
+    status,
+    retryCount,
+    errorMessage,
+    createdAt,
+    updatedAt,
+  );
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is DriftWebhookTask &&
+          other.id == this.id &&
+          other.deliveryId == this.deliveryId &&
+          other.eventType == this.eventType &&
+          other.payload == this.payload &&
+          other.status == this.status &&
+          other.retryCount == this.retryCount &&
+          other.errorMessage == this.errorMessage &&
+          other.createdAt == this.createdAt &&
+          other.updatedAt == this.updatedAt);
+}
+
+class WebhookTasksCompanion extends UpdateCompanion<DriftWebhookTask> {
+  final Value<String> id;
+  final Value<String> deliveryId;
+  final Value<String> eventType;
+  final Value<String> payload;
+  final Value<String> status;
+  final Value<int> retryCount;
+  final Value<String?> errorMessage;
+  final Value<DateTime> createdAt;
+  final Value<DateTime> updatedAt;
+  final Value<int> rowid;
+  const WebhookTasksCompanion({
+    this.id = const Value.absent(),
+    this.deliveryId = const Value.absent(),
+    this.eventType = const Value.absent(),
+    this.payload = const Value.absent(),
+    this.status = const Value.absent(),
+    this.retryCount = const Value.absent(),
+    this.errorMessage = const Value.absent(),
+    this.createdAt = const Value.absent(),
+    this.updatedAt = const Value.absent(),
+    this.rowid = const Value.absent(),
+  });
+  WebhookTasksCompanion.insert({
+    required String id,
+    required String deliveryId,
+    required String eventType,
+    required String payload,
+    this.status = const Value.absent(),
+    this.retryCount = const Value.absent(),
+    this.errorMessage = const Value.absent(),
+    required DateTime createdAt,
+    required DateTime updatedAt,
+    this.rowid = const Value.absent(),
+  }) : id = Value(id),
+       deliveryId = Value(deliveryId),
+       eventType = Value(eventType),
+       payload = Value(payload),
+       createdAt = Value(createdAt),
+       updatedAt = Value(updatedAt);
+  static Insertable<DriftWebhookTask> custom({
+    Expression<String>? id,
+    Expression<String>? deliveryId,
+    Expression<String>? eventType,
+    Expression<String>? payload,
+    Expression<String>? status,
+    Expression<int>? retryCount,
+    Expression<String>? errorMessage,
+    Expression<DateTime>? createdAt,
+    Expression<DateTime>? updatedAt,
+    Expression<int>? rowid,
+  }) {
+    return RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (deliveryId != null) 'delivery_id': deliveryId,
+      if (eventType != null) 'event_type': eventType,
+      if (payload != null) 'payload': payload,
+      if (status != null) 'status': status,
+      if (retryCount != null) 'retry_count': retryCount,
+      if (errorMessage != null) 'error_message': errorMessage,
+      if (createdAt != null) 'created_at': createdAt,
+      if (updatedAt != null) 'updated_at': updatedAt,
+      if (rowid != null) 'rowid': rowid,
+    });
+  }
+
+  WebhookTasksCompanion copyWith({
+    Value<String>? id,
+    Value<String>? deliveryId,
+    Value<String>? eventType,
+    Value<String>? payload,
+    Value<String>? status,
+    Value<int>? retryCount,
+    Value<String?>? errorMessage,
+    Value<DateTime>? createdAt,
+    Value<DateTime>? updatedAt,
+    Value<int>? rowid,
+  }) {
+    return WebhookTasksCompanion(
+      id: id ?? this.id,
+      deliveryId: deliveryId ?? this.deliveryId,
+      eventType: eventType ?? this.eventType,
+      payload: payload ?? this.payload,
+      status: status ?? this.status,
+      retryCount: retryCount ?? this.retryCount,
+      errorMessage: errorMessage ?? this.errorMessage,
+      createdAt: createdAt ?? this.createdAt,
+      updatedAt: updatedAt ?? this.updatedAt,
+      rowid: rowid ?? this.rowid,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (id.present) {
+      map['id'] = Variable<String>(id.value);
+    }
+    if (deliveryId.present) {
+      map['delivery_id'] = Variable<String>(deliveryId.value);
+    }
+    if (eventType.present) {
+      map['event_type'] = Variable<String>(eventType.value);
+    }
+    if (payload.present) {
+      map['payload'] = Variable<String>(payload.value);
+    }
+    if (status.present) {
+      map['status'] = Variable<String>(status.value);
+    }
+    if (retryCount.present) {
+      map['retry_count'] = Variable<int>(retryCount.value);
+    }
+    if (errorMessage.present) {
+      map['error_message'] = Variable<String>(errorMessage.value);
+    }
+    if (createdAt.present) {
+      map['created_at'] = Variable<DateTime>(createdAt.value);
+    }
+    if (updatedAt.present) {
+      map['updated_at'] = Variable<DateTime>(updatedAt.value);
+    }
+    if (rowid.present) {
+      map['rowid'] = Variable<int>(rowid.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('WebhookTasksCompanion(')
+          ..write('id: $id, ')
+          ..write('deliveryId: $deliveryId, ')
+          ..write('eventType: $eventType, ')
+          ..write('payload: $payload, ')
+          ..write('status: $status, ')
+          ..write('retryCount: $retryCount, ')
+          ..write('errorMessage: $errorMessage, ')
+          ..write('createdAt: $createdAt, ')
+          ..write('updatedAt: $updatedAt, ')
+          ..write('rowid: $rowid')
+          ..write(')'))
+        .toString();
+  }
+}
+
 abstract class _$AppDatabase extends GeneratedDatabase {
   _$AppDatabase(QueryExecutor e) : super(e);
   $AppDatabaseManager get managers => $AppDatabaseManager(this);
@@ -4165,9 +4731,13 @@ abstract class _$AppDatabase extends GeneratedDatabase {
   late final $SecretsTable secrets = $SecretsTable(this);
   late final $ProcessedWebhooksTable processedWebhooks =
       $ProcessedWebhooksTable(this);
+  late final $WebhookTasksTable webhookTasks = $WebhookTasksTable(this);
   late final BuildJobDao buildJobDao = BuildJobDao(this as AppDatabase);
   late final BuildRunDao buildRunDao = BuildRunDao(this as AppDatabase);
   late final TeamDao teamDao = TeamDao(this as AppDatabase);
+  late final WebhookTaskDao webhookTaskDao = WebhookTaskDao(
+    this as AppDatabase,
+  );
   @override
   Iterable<TableInfo<Table, Object?>> get allTables =>
       allSchemaEntities.whereType<TableInfo<Table, Object?>>();
@@ -4180,6 +4750,7 @@ abstract class _$AppDatabase extends GeneratedDatabase {
     teamMembers,
     secrets,
     processedWebhooks,
+    webhookTasks,
   ];
   @override
   StreamQueryUpdateRules get streamUpdateRules => const StreamQueryUpdateRules([
@@ -6923,6 +7494,288 @@ typedef $$ProcessedWebhooksTableProcessedTableManager =
       DriftProcessedWebhook,
       PrefetchHooks Function()
     >;
+typedef $$WebhookTasksTableCreateCompanionBuilder =
+    WebhookTasksCompanion Function({
+      required String id,
+      required String deliveryId,
+      required String eventType,
+      required String payload,
+      Value<String> status,
+      Value<int> retryCount,
+      Value<String?> errorMessage,
+      required DateTime createdAt,
+      required DateTime updatedAt,
+      Value<int> rowid,
+    });
+typedef $$WebhookTasksTableUpdateCompanionBuilder =
+    WebhookTasksCompanion Function({
+      Value<String> id,
+      Value<String> deliveryId,
+      Value<String> eventType,
+      Value<String> payload,
+      Value<String> status,
+      Value<int> retryCount,
+      Value<String?> errorMessage,
+      Value<DateTime> createdAt,
+      Value<DateTime> updatedAt,
+      Value<int> rowid,
+    });
+
+class $$WebhookTasksTableFilterComposer
+    extends Composer<_$AppDatabase, $WebhookTasksTable> {
+  $$WebhookTasksTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<String> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get deliveryId => $composableBuilder(
+    column: $table.deliveryId,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get eventType => $composableBuilder(
+    column: $table.eventType,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get payload => $composableBuilder(
+    column: $table.payload,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get status => $composableBuilder(
+    column: $table.status,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get retryCount => $composableBuilder(
+    column: $table.retryCount,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get errorMessage => $composableBuilder(
+    column: $table.errorMessage,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<DateTime> get createdAt => $composableBuilder(
+    column: $table.createdAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<DateTime> get updatedAt => $composableBuilder(
+    column: $table.updatedAt,
+    builder: (column) => ColumnFilters(column),
+  );
+}
+
+class $$WebhookTasksTableOrderingComposer
+    extends Composer<_$AppDatabase, $WebhookTasksTable> {
+  $$WebhookTasksTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<String> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get deliveryId => $composableBuilder(
+    column: $table.deliveryId,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get eventType => $composableBuilder(
+    column: $table.eventType,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get payload => $composableBuilder(
+    column: $table.payload,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get status => $composableBuilder(
+    column: $table.status,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get retryCount => $composableBuilder(
+    column: $table.retryCount,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get errorMessage => $composableBuilder(
+    column: $table.errorMessage,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<DateTime> get createdAt => $composableBuilder(
+    column: $table.createdAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<DateTime> get updatedAt => $composableBuilder(
+    column: $table.updatedAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+}
+
+class $$WebhookTasksTableAnnotationComposer
+    extends Composer<_$AppDatabase, $WebhookTasksTable> {
+  $$WebhookTasksTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<String> get id =>
+      $composableBuilder(column: $table.id, builder: (column) => column);
+
+  GeneratedColumn<String> get deliveryId => $composableBuilder(
+    column: $table.deliveryId,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get eventType =>
+      $composableBuilder(column: $table.eventType, builder: (column) => column);
+
+  GeneratedColumn<String> get payload =>
+      $composableBuilder(column: $table.payload, builder: (column) => column);
+
+  GeneratedColumn<String> get status =>
+      $composableBuilder(column: $table.status, builder: (column) => column);
+
+  GeneratedColumn<int> get retryCount => $composableBuilder(
+    column: $table.retryCount,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get errorMessage => $composableBuilder(
+    column: $table.errorMessage,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<DateTime> get createdAt =>
+      $composableBuilder(column: $table.createdAt, builder: (column) => column);
+
+  GeneratedColumn<DateTime> get updatedAt =>
+      $composableBuilder(column: $table.updatedAt, builder: (column) => column);
+}
+
+class $$WebhookTasksTableTableManager
+    extends
+        RootTableManager<
+          _$AppDatabase,
+          $WebhookTasksTable,
+          DriftWebhookTask,
+          $$WebhookTasksTableFilterComposer,
+          $$WebhookTasksTableOrderingComposer,
+          $$WebhookTasksTableAnnotationComposer,
+          $$WebhookTasksTableCreateCompanionBuilder,
+          $$WebhookTasksTableUpdateCompanionBuilder,
+          (
+            DriftWebhookTask,
+            BaseReferences<_$AppDatabase, $WebhookTasksTable, DriftWebhookTask>,
+          ),
+          DriftWebhookTask,
+          PrefetchHooks Function()
+        > {
+  $$WebhookTasksTableTableManager(_$AppDatabase db, $WebhookTasksTable table)
+    : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$WebhookTasksTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$WebhookTasksTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$WebhookTasksTableAnnotationComposer($db: db, $table: table),
+          updateCompanionCallback:
+              ({
+                Value<String> id = const Value.absent(),
+                Value<String> deliveryId = const Value.absent(),
+                Value<String> eventType = const Value.absent(),
+                Value<String> payload = const Value.absent(),
+                Value<String> status = const Value.absent(),
+                Value<int> retryCount = const Value.absent(),
+                Value<String?> errorMessage = const Value.absent(),
+                Value<DateTime> createdAt = const Value.absent(),
+                Value<DateTime> updatedAt = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => WebhookTasksCompanion(
+                id: id,
+                deliveryId: deliveryId,
+                eventType: eventType,
+                payload: payload,
+                status: status,
+                retryCount: retryCount,
+                errorMessage: errorMessage,
+                createdAt: createdAt,
+                updatedAt: updatedAt,
+                rowid: rowid,
+              ),
+          createCompanionCallback:
+              ({
+                required String id,
+                required String deliveryId,
+                required String eventType,
+                required String payload,
+                Value<String> status = const Value.absent(),
+                Value<int> retryCount = const Value.absent(),
+                Value<String?> errorMessage = const Value.absent(),
+                required DateTime createdAt,
+                required DateTime updatedAt,
+                Value<int> rowid = const Value.absent(),
+              }) => WebhookTasksCompanion.insert(
+                id: id,
+                deliveryId: deliveryId,
+                eventType: eventType,
+                payload: payload,
+                status: status,
+                retryCount: retryCount,
+                errorMessage: errorMessage,
+                createdAt: createdAt,
+                updatedAt: updatedAt,
+                rowid: rowid,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ),
+      );
+}
+
+typedef $$WebhookTasksTableProcessedTableManager =
+    ProcessedTableManager<
+      _$AppDatabase,
+      $WebhookTasksTable,
+      DriftWebhookTask,
+      $$WebhookTasksTableFilterComposer,
+      $$WebhookTasksTableOrderingComposer,
+      $$WebhookTasksTableAnnotationComposer,
+      $$WebhookTasksTableCreateCompanionBuilder,
+      $$WebhookTasksTableUpdateCompanionBuilder,
+      (
+        DriftWebhookTask,
+        BaseReferences<_$AppDatabase, $WebhookTasksTable, DriftWebhookTask>,
+      ),
+      DriftWebhookTask,
+      PrefetchHooks Function()
+    >;
 
 class $AppDatabaseManager {
   final _$AppDatabase _db;
@@ -6941,4 +7794,6 @@ class $AppDatabaseManager {
       $$SecretsTableTableManager(_db, _db.secrets);
   $$ProcessedWebhooksTableTableManager get processedWebhooks =>
       $$ProcessedWebhooksTableTableManager(_db, _db.processedWebhooks);
+  $$WebhookTasksTableTableManager get webhookTasks =>
+      $$WebhookTasksTableTableManager(_db, _db.webhookTasks);
 }

--- a/apps/openci_server/lib/webhook_task/webhook_task_dao.dart
+++ b/apps/openci_server/lib/webhook_task/webhook_task_dao.dart
@@ -1,0 +1,44 @@
+import 'package:drift/drift.dart';
+import 'package:openci_server/database.dart';
+import 'package:openci_server/webhook_task/webhook_task_table.dart';
+
+part 'webhook_task_dao.g.dart';
+
+@DriftAccessor(tables: [WebhookTasks])
+class WebhookTaskDao extends DatabaseAccessor<AppDatabase>
+    with _$WebhookTaskDaoMixin {
+  WebhookTaskDao(super.attachedDatabase);
+
+  Future<DriftWebhookTask?> claimNextWebhookTask() async {
+    return db.transaction(() async {
+      const sql = '''
+        SELECT * FROM webhook_tasks
+        WHERE status = 'pending'
+        ORDER BY created_at ASC
+        LIMIT 1
+        FOR UPDATE SKIP LOCKED
+      ''';
+      final results = await db.customSelect(sql).get();
+      if (results.isEmpty) return null;
+
+      final row = results.first;
+      final task = webhookTasks.map(row.data);
+
+      final updated = task.copyWith(
+        status: 'processing',
+        updatedAt: DateTime.now().toUtc(),
+      );
+      await updateWebhookTask(updated);
+      return updated;
+    });
+  }
+
+  Future<void> insertWebhookTask(DriftWebhookTask task) =>
+      into(webhookTasks).insert(task);
+
+  Future<DriftWebhookTask?> getWebhookTask(String id) =>
+      (select(webhookTasks)..where((t) => t.id.equals(id))).getSingleOrNull();
+
+  Future<void> updateWebhookTask(DriftWebhookTask task) =>
+      update(webhookTasks).replace(task);
+}

--- a/apps/openci_server/lib/webhook_task/webhook_task_dao.g.dart
+++ b/apps/openci_server/lib/webhook_task/webhook_task_dao.g.dart
@@ -1,0 +1,16 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'webhook_task_dao.dart';
+
+// ignore_for_file: type=lint
+mixin _$WebhookTaskDaoMixin on DatabaseAccessor<AppDatabase> {
+  $WebhookTasksTable get webhookTasks => attachedDatabase.webhookTasks;
+  WebhookTaskDaoManager get managers => WebhookTaskDaoManager(this);
+}
+
+class WebhookTaskDaoManager {
+  final _$WebhookTaskDaoMixin _db;
+  WebhookTaskDaoManager(this._db);
+  $$WebhookTasksTableTableManager get webhookTasks =>
+      $$WebhookTasksTableTableManager(_db.attachedDatabase, _db.webhookTasks);
+}

--- a/apps/openci_server/lib/webhook_task/webhook_task_processor.dart
+++ b/apps/openci_server/lib/webhook_task/webhook_task_processor.dart
@@ -1,0 +1,727 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:dart_jsonwebtoken/dart_jsonwebtoken.dart';
+import 'package:github/hooks.dart';
+import 'package:http/http.dart' as http;
+import 'package:openci_server/build_job/build_job_mapper.dart';
+import 'package:openci_server/database.dart';
+import 'package:openci_shared/openci_shared.dart';
+import 'package:uuid/uuid.dart';
+import 'package:yaml/yaml.dart';
+
+Future<void> processWebhookTask(AppDatabase db, DriftWebhookTask task) async {
+  final env = Platform.environment;
+
+  http.Client? httpClient;
+  var isSelfGeneratedClient = false;
+  try {
+    final Map<String, dynamic> payload;
+    try {
+      payload = jsonDecode(task.payload) as Map<String, dynamic>;
+    } catch (e) {
+      throw FormatException('Background task error: Invalid JSON body: $e');
+    }
+
+    final eventType = task.eventType;
+    final installation = payload['installation'] as Map<String, dynamic>?;
+    if (installation == null || installation['id'] == null) {
+      throw StateError('Background task error: Missing installation ID');
+    }
+    final installationId = installation['id'] as int;
+
+    final team = await db.teamDao.getTeamByInstallationId(installationId);
+    if (team == null) {
+      throw StateError(
+        'Background task warning: No team found for installationId $installationId',
+      );
+    }
+
+    final appId = env['GITHUB_APP_ID'];
+    final privateKeyPath = env['GITHUB_PRIVATE_KEY_PATH'];
+    if (appId == null ||
+        appId.isEmpty ||
+        privateKeyPath == null ||
+        privateKeyPath.isEmpty) {
+      throw StateError(
+        'Background task error: GITHUB_APP_ID or GITHUB_PRIVATE_KEY_PATH is not configured.',
+      );
+    }
+
+    final privateKeyFile = File(privateKeyPath);
+    if (!privateKeyFile.existsSync()) {
+      throw StateError(
+        'Background task error: GITHUB_PRIVATE_KEY_PATH file does not exist: $privateKeyPath',
+      );
+    }
+    final privateKeyPem = privateKeyFile.readAsStringSync();
+
+    final jwtToken = generateGitHubAppJwt(appId, privateKeyPem);
+
+    final githubApiBaseUrl = normalizeGitHubApiBaseUrl(team.githubApiBaseUrl);
+    final githubBaseUrl = team.githubBaseUrl ?? 'https://github.com';
+
+    httpClient = http.Client();
+    isSelfGeneratedClient = true;
+
+    final tokenUrl =
+        '$githubApiBaseUrl/app/installations/$installationId/access_tokens';
+    final http.Response tokenResponse;
+    try {
+      tokenResponse = await httpClient
+          .post(
+            Uri.parse(tokenUrl),
+            headers: {
+              'Authorization': 'Bearer $jwtToken',
+              'Accept': 'application/vnd.github+json',
+              'X-GitHub-Api-Version': '2022-11-28',
+              'User-Agent': 'OpenCI-Server',
+            },
+          )
+          .timeout(const Duration(seconds: 15));
+    } catch (e) {
+      throw HttpException(
+        'Background task error: Access token request timed out or failed: $e',
+      );
+    }
+
+    if (tokenResponse.statusCode >= 300) {
+      throw HttpException(
+        'Background task error: Failed to retrieve installation token: ${tokenResponse.statusCode} ${tokenResponse.body}',
+      );
+    }
+
+    final tokenData = jsonDecode(tokenResponse.body) as Map<String, dynamic>;
+    final installationToken = tokenData['token'] as String;
+
+    final String owner;
+    final String repo;
+    final String commitSha;
+    final String branch;
+    final String? triggerBranch;
+    final int? pullRequestNumber;
+    final String triggerType;
+
+    if (eventType == 'pull_request') {
+      final event = PullRequestEvent.fromJson(payload);
+      final pr = event.pullRequest;
+      final repoMap = event.repository;
+      if (pr == null || repoMap == null) {
+        throw StateError(
+          'Background task error: Missing pull_request or repository data',
+        );
+      }
+      owner = repoMap.owner?.login ?? '';
+      repo = repoMap.name;
+      commitSha = pr.head?.sha ?? '';
+      branch = pr.head?.ref ?? '';
+      triggerBranch = pr.base?.ref;
+      pullRequestNumber = event.number;
+      triggerType = 'pull_request';
+    } else {
+      // push event
+      if (payload['deleted'] == true) {
+        return;
+      }
+      final repoMap = payload['repository'] as Map<String, dynamic>;
+      owner = repoMap['owner']['login'] as String;
+      repo = repoMap['name'] as String;
+      commitSha = (payload['head_commit']?['id'] ?? payload['after']) as String;
+      final ref = payload['ref'] as String;
+      if (ref.startsWith('refs/heads/')) {
+        branch = ref.substring(11);
+      } else {
+        branch = ref;
+      }
+      triggerBranch = branch;
+      pullRequestNumber = null;
+      triggerType = 'push';
+    }
+
+    // Fetch YAML files from .openci directory
+    final contentsUrl =
+        '$githubApiBaseUrl/repos/$owner/$repo/contents/.openci?ref=$commitSha';
+    final http.Response contentsResponse;
+    try {
+      contentsResponse = await httpClient
+          .get(
+            Uri.parse(contentsUrl),
+            headers: {
+              'Authorization': 'token $installationToken',
+              'Accept': 'application/vnd.github+json',
+              'User-Agent': 'OpenCI-Server',
+            },
+          )
+          .timeout(const Duration(seconds: 15));
+    } catch (e) {
+      throw HttpException(
+        'Background task error: Fetch contents request timed out or failed: $e',
+      );
+    }
+
+    if (contentsResponse.statusCode == 404) {
+      return;
+    }
+
+    if (contentsResponse.statusCode >= 300) {
+      throw HttpException(
+        'Background task error: Failed to fetch contents: ${contentsResponse.statusCode} ${contentsResponse.body}',
+      );
+    }
+
+    final contentsList = jsonDecode(contentsResponse.body);
+    if (contentsList is! List) {
+      throw FormatException(
+        'Background task error: .openci is not a directory',
+      );
+    }
+
+    final yamlFiles = contentsList
+        .where(
+          (item) =>
+              item is Map &&
+              item['type'] == 'file' &&
+              (item['name'].toString().endsWith('.yaml') ||
+                  item['name'].toString().endsWith('.yml')),
+        )
+        .cast<Map<dynamic, dynamic>>()
+        .toList();
+
+    if (yamlFiles.isEmpty) {
+      return;
+    }
+
+    final fetchedFiles = await fetchWorkflowFiles(
+      yamlFiles: yamlFiles,
+      githubApiBaseUrl: githubApiBaseUrl,
+      owner: owner,
+      repo: repo,
+      commitSha: commitSha,
+      installationToken: installationToken,
+      httpClient: httpClient,
+    );
+
+    final extractedJobs = parseWorkflowJobs(
+      files: fetchedFiles,
+      triggerType: triggerType,
+      triggerBranch: triggerBranch,
+    );
+
+    if (extractedJobs.isEmpty) {
+      return;
+    }
+
+    // Count jobs per workflow
+    final jobCountsByWorkflow = <String, int>{};
+    for (final job in extractedJobs) {
+      jobCountsByWorkflow[job.workflowName] =
+          (jobCountsByWorkflow[job.workflowName] ?? 0) + 1;
+    }
+
+    final workflowRunIds = <String, String>{};
+    final jobDocumentIdsByWorkflow = <String, Map<String, String>>{};
+    final jobInstanceKeysBySourceKeyByWorkflow =
+        <String, Map<String, List<String>>>{};
+
+    for (final job in extractedJobs) {
+      final wName = job.workflowFileName;
+      if (!workflowRunIds.containsKey(wName)) {
+        workflowRunIds[wName] = const Uuid().v4();
+      }
+
+      final jobDocumentIds = jobDocumentIdsByWorkflow[wName] ??= {};
+      jobDocumentIds[job.jobId] = const Uuid().v4();
+
+      final sourceKey = job.workflowJobKey ?? job.jobId;
+      final jobInstanceKeysBySourceKey =
+          jobInstanceKeysBySourceKeyByWorkflow[wName] ??= {};
+      (jobInstanceKeysBySourceKey[sourceKey] ??= []).add(job.jobId);
+    }
+
+    for (final job in extractedJobs) {
+      final wName = job.workflowFileName;
+      final documentId = jobDocumentIdsByWorkflow[wName]![job.jobId]!;
+      final workflowRunId = workflowRunIds[wName]!;
+
+      final jobInstanceKeysBySourceKey =
+          jobInstanceKeysBySourceKeyByWorkflow[wName]!;
+
+      // Resolve needs and status
+      final spec = job.spec;
+      final rawNeeds = spec['needs'];
+      final List<String> rawNeedKeys;
+      if (rawNeeds is List) {
+        rawNeedKeys = rawNeeds.map((e) => e.toString()).toList();
+      } else if (rawNeeds is String) {
+        rawNeedKeys = [rawNeeds];
+      } else {
+        rawNeedKeys = [];
+      }
+
+      final needs = rawNeedKeys
+          .flatMap((need) => jobInstanceKeysBySourceKey[need] ?? [need])
+          .toList();
+      final hasNeeds = needs.isNotEmpty;
+      final status = hasNeeds ? BuildJobStatus.WAITING : BuildJobStatus.QUEUED;
+
+      // Create Check Run on GitHub
+      final checkRunName = (jobCountsByWorkflow[job.workflowName] ?? 0) > 1
+          ? '${job.workflowName} / ${job.workflowJobKey ?? job.jobId}${job.matrixLabel != null ? " (${job.matrixLabel})" : ""}'
+          : job.workflowName;
+
+      final checkRunUrl = '$githubApiBaseUrl/repos/$owner/$repo/check-runs';
+      final http.Response checkRunResponse;
+      try {
+        checkRunResponse = await httpClient
+            .post(
+              Uri.parse(checkRunUrl),
+              headers: {
+                'Authorization': 'token $installationToken',
+                'Accept': 'application/vnd.github+json',
+                'X-GitHub-Api-Version': '2022-11-28',
+                'User-Agent': 'OpenCI-Server',
+                'Content-Type': 'application/json',
+              },
+              body: jsonEncode({
+                'name': checkRunName,
+                'head_sha': commitSha,
+                'status': 'queued',
+                'started_at': DateTime.now().toUtc().toIso8601String(),
+                'details_url': 'https://dashboard.openci.org/runs/$documentId',
+              }),
+            )
+            .timeout(const Duration(seconds: 15));
+      } catch (e) {
+        stderr.writeln(
+          'Background task error: Create check run request timed out or failed: $e',
+        );
+        continue;
+      }
+
+      if (checkRunResponse.statusCode >= 300) {
+        stderr.writeln(
+          'Background task error: Failed to create check run: ${checkRunResponse.statusCode} ${checkRunResponse.body}',
+        );
+        continue;
+      }
+
+      final checkRunData =
+          jsonDecode(checkRunResponse.body) as Map<String, dynamic>;
+      final checkRunId = checkRunData['id'].toString();
+
+      // Map Matrix to String map
+      final matrixMap = job.matrix?.map((k, v) => MapEntry(k, v));
+
+      // Save BuildJob in DB
+      final buildJob = BuildJob(
+        id: documentId,
+        status: status,
+        owner: owner,
+        repo: repo,
+        workflowName: job.workflowName,
+        teamId: team.id,
+        workflowFileName: job.workflowFileName,
+        commitSha: commitSha,
+        pullRequestNumber: pullRequestNumber,
+        runCount: 0,
+        tagName: null,
+        branch: branch,
+        jobKey: job.jobId,
+        workflowJobKey: job.workflowJobKey,
+        matrix: matrixMap,
+        matrixLabel: job.matrixLabel,
+        workflowRunId: workflowRunId,
+        needs: needs.isEmpty ? null : needs,
+        runsOn: job.spec['runs-on']?.toString(),
+        githubBaseUrl: githubBaseUrl,
+        githubApiBaseUrl: githubApiBaseUrl,
+        createdAt: DateTime.now().toUtc(),
+        updatedAt: DateTime.now().toUtc(),
+      );
+
+      await db.buildJobDao.insertBuildJob(
+        buildJob.toDrift(
+          installationId: installationId.toString(),
+          checkRunId: checkRunId,
+        ),
+      );
+    }
+  } finally {
+    if (isSelfGeneratedClient && httpClient != null) {
+      httpClient.close();
+    }
+  }
+}
+
+String generateGitHubAppJwt(String appId, String privateKeyPem) {
+  final nowSeconds = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+  final jwt = JWT({
+    'iat': nowSeconds - 60,
+    'exp': nowSeconds + 540,
+    'iss': appId.trim(),
+  });
+  return jwt.sign(
+    RSAPrivateKey(privateKeyPem),
+    algorithm: JWTAlgorithm.RS256,
+  );
+}
+
+class FetchedWorkflowFile {
+  final String name;
+  final String path;
+  final String content;
+
+  FetchedWorkflowFile({
+    required this.name,
+    required this.path,
+    required this.content,
+  });
+}
+
+Future<List<FetchedWorkflowFile>> fetchWorkflowFiles({
+  required List<Map<dynamic, dynamic>> yamlFiles,
+  required String githubApiBaseUrl,
+  required String owner,
+  required String repo,
+  required String commitSha,
+  required String installationToken,
+  required http.Client httpClient,
+}) async {
+  final fetched = <FetchedWorkflowFile>[];
+  for (final file in yamlFiles) {
+    final path = file['path'] as String;
+    final name = file['name'] as String;
+
+    final fileUrl =
+        '$githubApiBaseUrl/repos/$owner/$repo/contents/$path?ref=$commitSha';
+    final http.Response fileResponse;
+    try {
+      fileResponse = await httpClient
+          .get(
+            Uri.parse(fileUrl),
+            headers: {
+              'Authorization': 'token $installationToken',
+              'Accept': 'application/vnd.github.raw+json',
+              'User-Agent': 'OpenCI-Server',
+            },
+          )
+          .timeout(const Duration(seconds: 15));
+    } catch (e) {
+      stderr.writeln(
+        'Warning: Failed to fetch file $path due to timeout or error: $e',
+      );
+      continue;
+    }
+
+    if (fileResponse.statusCode >= 300) {
+      stderr.writeln(
+        'Warning: Failed to fetch file $path: ${fileResponse.statusCode}',
+      );
+      continue;
+    }
+
+    fetched.add(
+      FetchedWorkflowFile(
+        name: name,
+        path: path,
+        content: fileResponse.body,
+      ),
+    );
+  }
+  return fetched;
+}
+
+List<ExtractedJob> parseWorkflowJobs({
+  required List<FetchedWorkflowFile> files,
+  required String triggerType,
+  required String? triggerBranch,
+}) {
+  final extractedJobs = <ExtractedJob>[];
+  for (final file in files) {
+    try {
+      final parsed = loadYaml(file.content);
+      if (parsed is! Map) {
+        stderr.writeln('Warning: YAML at ${file.path} is not an object');
+        continue;
+      }
+
+      final workflowName = parsed['name'] is String
+          ? parsed['name'] as String
+          : file.name.replaceAll(RegExp(r'\.(yaml|yml)$'), '');
+      if (!matchesTrigger(parsed, triggerType, triggerBranch)) {
+        continue;
+      }
+
+      final jobs = parsed['jobs'];
+      if (jobs is! Map) {
+        stderr.writeln(
+          'Warning: Workflow ${file.name} does not contain a valid jobs object',
+        );
+        continue;
+      }
+
+      for (final jobEntry in jobs.entries) {
+        final jobId = jobEntry.key.toString();
+        final spec = jobEntry.value;
+        if (spec is! Map) {
+          stderr.writeln('Warning: Job $jobId is not an object');
+          continue;
+        }
+
+        final matrixCells = expandMatrix(spec);
+        if (matrixCells != null) {
+          for (
+            var matrixIndex = 0;
+            matrixIndex < matrixCells.length;
+            matrixIndex++
+          ) {
+            final matrix = matrixCells[matrixIndex];
+            final expandedJobId = matrixInstanceKey(jobId, matrix);
+            final resolvedSpec =
+                resolveMatrixExpressions(spec, matrix) as Map<dynamic, dynamic>;
+
+            extractedJobs.add(
+              ExtractedJob(
+                workflowFileName: file.name,
+                workflowName: workflowName,
+                jobId: expandedJobId,
+                workflowJobKey: jobId,
+                spec: resolvedSpec,
+                matrix: matrix,
+                matrixLabel: matrixLabel(matrix),
+                matrixIndex: matrixIndex,
+                matrixGroupKey: '${file.name}:$jobId',
+                matrixFailFast:
+                    (spec['strategy'] as Map?)?['fail-fast'] != false,
+              ),
+            );
+          }
+        } else {
+          extractedJobs.add(
+            ExtractedJob(
+              workflowFileName: file.name,
+              workflowName: workflowName,
+              jobId: jobId,
+              workflowJobKey: null,
+              spec: spec,
+            ),
+          );
+        }
+      }
+    } catch (e, s) {
+      stderr.writeln('Error parsing YAML at ${file.path}: $e\n$s');
+      continue;
+    }
+  }
+  return extractedJobs;
+}
+
+class ExtractedJob {
+  final String workflowFileName;
+  final String workflowName;
+  final String jobId;
+  final String? workflowJobKey;
+  final Map<dynamic, dynamic> spec;
+  final MatrixCell? matrix;
+  final String? matrixLabel;
+  final int? matrixIndex;
+  final String? matrixGroupKey;
+  final bool? matrixFailFast;
+
+  ExtractedJob({
+    required this.workflowFileName,
+    required this.workflowName,
+    required this.jobId,
+    required this.workflowJobKey,
+    required this.spec,
+    this.matrix,
+    this.matrixLabel,
+    this.matrixIndex,
+    this.matrixGroupKey,
+    this.matrixFailFast,
+  });
+}
+
+typedef MatrixCell = Map<String, dynamic>;
+
+List<MatrixCell>? expandMatrix(Map<dynamic, dynamic> spec) {
+  final strategy = spec['strategy'];
+  if (strategy is! Map) return null;
+  final matrix = strategy['matrix'];
+  if (matrix is! Map) return null;
+
+  final axes = <MapEntry<String, List<dynamic>>>[];
+  for (final entry in matrix.entries) {
+    final key = entry.key.toString();
+    if (key == 'include' || key == 'exclude') continue;
+    final val = entry.value;
+    if (val is! List) return null;
+    axes.add(MapEntry(key, val));
+  }
+
+  List<MatrixCell> combinations = [{}];
+  if (axes.isNotEmpty) {
+    for (final axis in axes) {
+      final next = <MatrixCell>[];
+      for (final comb in combinations) {
+        for (final val in axis.value) {
+          next.add({...comb, axis.key: val});
+        }
+      }
+      combinations = next;
+    }
+  } else {
+    combinations = [];
+  }
+
+  final excludeRaw = matrix['exclude'];
+  final excludes = <MatrixCell>[];
+  if (excludeRaw is List) {
+    for (final ex in excludeRaw) {
+      if (ex is Map) {
+        excludes.add(ex.map((k, v) => MapEntry(k.toString(), v)));
+      }
+    }
+  }
+
+  if (excludes.isNotEmpty) {
+    combinations = combinations.where((comb) {
+      return !excludes.any((ex) {
+        return ex.entries.every((e) => comb[e.key] == e.value);
+      });
+    }).toList();
+  }
+
+  final includeRaw = matrix['include'];
+  final includes = <MatrixCell>[];
+  if (includeRaw is List) {
+    for (final inc in includeRaw) {
+      if (inc is Map) {
+        includes.add(inc.map((k, v) => MapEntry(k.toString(), v)));
+      }
+    }
+  }
+
+  final axisKeys = axes.map((e) => e.key).toSet();
+  for (final inc in includes) {
+    if (axisKeys.isEmpty) {
+      combinations.add(inc);
+      continue;
+    }
+    bool didMerge = false;
+    combinations = combinations.map((comb) {
+      final canMerge = inc.entries.every((e) {
+        if (!axisKeys.contains(e.key)) return true;
+        return !comb.containsKey(e.key) || comb[e.key] == e.value;
+      });
+      if (!canMerge) return comb;
+      didMerge = true;
+      return {...comb, ...inc};
+    }).toList();
+
+    if (!didMerge) {
+      combinations.add(inc);
+    }
+  }
+
+  if (axes.isEmpty && includes.isEmpty) return null;
+  return combinations;
+}
+
+String matrixKeyValueLabel(MatrixCell cell) {
+  final entries = cell.entries.toList()..sort((a, b) => a.key.compareTo(b.key));
+  return entries.map((e) => '${e.key}=${e.value}').join(',');
+}
+
+String matrixLabel(MatrixCell cell) {
+  if (cell.containsKey('name') && cell['name'] is String) {
+    return cell['name'] as String;
+  }
+  return matrixKeyValueLabel(cell);
+}
+
+String matrixInstanceKey(String jobId, MatrixCell cell) {
+  return '$jobId[${matrixKeyValueLabel(cell)}]';
+}
+
+dynamic resolveMatrixExpressions(dynamic value, MatrixCell matrix) {
+  if (value is String) {
+    final pattern = RegExp(
+      r'\$\{\{\s*matrix\.([A-Za-z_][A-Za-z0-9_-]*)\s*\}\}',
+    );
+    return value.replaceAllMapped(pattern, (match) {
+      final key = match.group(1);
+      if (key == null) return match.group(0)!;
+      final replacement = matrix[key];
+      return replacement == null ? match.group(0)! : replacement.toString();
+    });
+  }
+  if (value is Map) {
+    return value.map(
+      (k, v) => MapEntry(k, resolveMatrixExpressions(v, matrix)),
+    );
+  }
+  if (value is List) {
+    return value.map((v) => resolveMatrixExpressions(v, matrix)).toList();
+  }
+  return value;
+}
+
+bool matchesTrigger(
+  Map<dynamic, dynamic> parsed,
+  String triggerType,
+  String? triggerBranch,
+) {
+  final on = parsed['on'];
+  if (on == null) return false;
+
+  if (on is String) {
+    return on == triggerType;
+  }
+
+  if (on is List) {
+    return on.contains(triggerType);
+  }
+
+  if (on is Map) {
+    if (!on.containsKey(triggerType)) return false;
+    final config = on[triggerType];
+    if (config == null) return true;
+    if (config is! Map) return true;
+
+    final branches = config['branches'];
+    if (branches == null || triggerBranch == null) return true;
+
+    final branchList = branches is List
+        ? branches.map((e) => e.toString()).toList()
+        : [branches.toString()];
+    return branchList.contains(triggerBranch);
+  }
+
+  return false;
+}
+
+String normalizeGitHubApiBaseUrl(String? apiBaseUrl) {
+  if (apiBaseUrl == null || apiBaseUrl.isEmpty) return 'https://api.github.com';
+  final normalized = apiBaseUrl.replaceAll(RegExp(r'/+$'), '');
+  if (normalized == 'https://api.github.com' ||
+      normalized == 'https://github.com' ||
+      normalized == 'https://api.github.com/graphql') {
+    return 'https://api.github.com';
+  }
+  if (normalized.endsWith('/api/v3')) return normalized;
+  try {
+    final uri = Uri.parse(normalized);
+    if (normalized.endsWith('/api/graphql') ||
+        normalized.endsWith('/graphql')) {
+      return '${uri.scheme}://${uri.host}/api/v3';
+    }
+    return '${uri.scheme}://${uri.host}/api/v3';
+  } catch (_) {
+    return 'https://api.github.com';
+  }
+}
+
+extension FlatMap<T> on Iterable<T> {
+  Iterable<R> flatMap<R>(Iterable<R> Function(T) f) => expand(f);
+}

--- a/apps/openci_server/lib/webhook_task/webhook_task_table.dart
+++ b/apps/openci_server/lib/webhook_task/webhook_task_table.dart
@@ -1,0 +1,19 @@
+import 'package:drift/drift.dart';
+
+@DataClassName('DriftWebhookTask')
+class WebhookTasks extends Table {
+  TextColumn get id => text()();
+  TextColumn get deliveryId => text().unique()();
+  TextColumn get eventType => text()();
+  TextColumn get payload => text()();
+  TextColumn get status => text().withDefault(
+    const Constant('pending'),
+  )();
+  IntColumn get retryCount => integer().withDefault(const Constant(0))();
+  TextColumn get errorMessage => text().nullable()();
+  DateTimeColumn get createdAt => dateTime()();
+  DateTimeColumn get updatedAt => dateTime()();
+
+  @override
+  Set<Column> get primaryKey => {id};
+}

--- a/apps/openci_server/lib/webhook_task/webhook_task_worker.dart
+++ b/apps/openci_server/lib/webhook_task/webhook_task_worker.dart
@@ -39,7 +39,10 @@ void startWebhookTaskWorker(AppDatabase db) {
     _triggerWorker(db);
   });
 
-  _triggerWorker(db);
+  // Wait 500ms for global database instantiation and server booting to complete
+  Future.delayed(const Duration(milliseconds: 500), () {
+    _triggerWorker(db);
+  });
 }
 
 void _triggerWorker(AppDatabase db) {

--- a/apps/openci_server/lib/webhook_task/webhook_task_worker.dart
+++ b/apps/openci_server/lib/webhook_task/webhook_task_worker.dart
@@ -1,0 +1,72 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:drift/drift.dart';
+import 'package:openci_server/database.dart';
+import 'package:openci_server/webhook_task/webhook_task_processor.dart';
+
+final webhookTaskController = StreamController<void>.broadcast();
+
+class SimplePool {
+  SimplePool(this.maxConcurrency);
+  final int maxConcurrency;
+  int _activeCount = 0;
+  final List<Completer<void>> _waiting = [];
+
+  Future<void> run(Future<void> Function() task) async {
+    while (_activeCount >= maxConcurrency) {
+      final completer = Completer<void>();
+      _waiting.add(completer);
+      await completer.future;
+    }
+    _activeCount++;
+    try {
+      await task();
+    } finally {
+      _activeCount--;
+      if (_waiting.isNotEmpty) {
+        final next = _waiting.removeAt(0);
+        next.complete();
+      }
+    }
+  }
+}
+
+final _pool = SimplePool(3); // Concurrency limit of 3 tasks
+
+void startWebhookTaskWorker(AppDatabase db) {
+  webhookTaskController.stream.listen((_) {
+    _triggerWorker(db);
+  });
+
+  _triggerWorker(db);
+}
+
+void _triggerWorker(AppDatabase db) {
+  _pool.run(() async {
+    while (true) {
+      final task = await db.webhookTaskDao.claimNextWebhookTask();
+      if (task == null) break;
+
+      try {
+        await processWebhookTask(db, task);
+
+        final completedTask = task.copyWith(
+          status: 'completed',
+          updatedAt: DateTime.now().toUtc(),
+        );
+        await db.webhookTaskDao.updateWebhookTask(completedTask);
+      } catch (e, stack) {
+        stderr.writeln('Webhook task processing failed: $e\n$stack');
+
+        final failedTask = task.copyWith(
+          status: 'failed',
+          retryCount: task.retryCount + 1,
+          errorMessage: Value('$e\n$stack'),
+          updatedAt: DateTime.now().toUtc(),
+        );
+        await db.webhookTaskDao.updateWebhookTask(failedTask);
+      }
+    }
+  });
+}

--- a/apps/openci_server/routes/_middleware.dart
+++ b/apps/openci_server/routes/_middleware.dart
@@ -3,8 +3,13 @@ import 'dart:io';
 import 'package:dart_frog/dart_frog.dart';
 import 'package:firebase_admin_sdk/firebase_admin_sdk.dart';
 import 'package:openci_server/database.dart';
+import 'package:openci_server/webhook_task/webhook_task_worker.dart';
 
-final _db = AppDatabase();
+final _db = () {
+  final db = AppDatabase();
+  startWebhookTaskWorker(db);
+  return db;
+}();
 final FirebaseApp _firebaseApp = FirebaseApp.initializeApp();
 
 Handler middleware(Handler handler) {

--- a/apps/openci_server/routes/webhook.dart
+++ b/apps/openci_server/routes/webhook.dart
@@ -1,17 +1,11 @@
-import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
 import 'package:crypto/crypto.dart';
 import 'package:dart_frog/dart_frog.dart';
-import 'package:dart_jsonwebtoken/dart_jsonwebtoken.dart';
-import 'package:github/hooks.dart';
-import 'package:http/http.dart' as http;
-import 'package:openci_server/build_job/build_job_mapper.dart';
 import 'package:openci_server/database.dart';
-import 'package:openci_shared/openci_shared.dart';
+import 'package:openci_server/webhook_task/webhook_task_worker.dart';
 import 'package:uuid/uuid.dart';
-import 'package:yaml/yaml.dart';
 
 Future<Response> onRequest(RequestContext context) async {
   if (context.request.method != HttpMethod.post) {
@@ -75,6 +69,40 @@ Future<Response> onRequest(RequestContext context) async {
     );
   }
 
+  final eventType = context.request.headers['x-github-event'] ?? '';
+  if (eventType != 'pull_request' && eventType != 'push') {
+    return Response.json(
+      body: {
+        'success': true,
+        'message': 'Ignored event type: $eventType',
+      },
+    );
+  }
+
+  // PR action filtering
+  if (eventType == 'pull_request') {
+    try {
+      final payload = jsonDecode(rawBody) as Map<String, dynamic>;
+      final action = payload['action'] as String?;
+      if (action != 'opened' &&
+          action != 'synchronize' &&
+          action != 'reopened') {
+        return Response.json(
+          body: {
+            'success': true,
+            'message': 'Ignored pull_request action: $action',
+          },
+        );
+      }
+    } catch (_) {
+      return Response.json(
+        statusCode: HttpStatus.badRequest,
+        body: {'success': false, 'error': 'Invalid JSON body'},
+      );
+    }
+  }
+
+  // 1. Record in processed webhooks table (idempotency check)
   await db
       .into(db.processedWebhooks)
       .insert(
@@ -84,396 +112,39 @@ Future<Response> onRequest(RequestContext context) async {
         ),
       );
 
-  // We process the rest of the webhook asynchronously to avoid GitHub timeouts (10s)
-  unawaited(() async {
-    http.Client? httpClient;
-    var isSelfGeneratedClient = false;
-    try {
-      final Map<String, dynamic> payload;
-      try {
-        payload = jsonDecode(rawBody) as Map<String, dynamic>;
-      } catch (e) {
-        stderr.writeln('Background webhook error: Invalid JSON body');
-        return;
-      }
+  // 2. Insert into the queue table
+  final taskId = const Uuid().v4();
+  final task = DriftWebhookTask(
+    id: taskId,
+    deliveryId: deliveryId,
+    eventType: eventType,
+    payload: rawBody,
+    status: 'pending',
+    retryCount: 0,
+    createdAt: DateTime.now().toUtc(),
+    updatedAt: DateTime.now().toUtc(),
+  );
 
-      final eventType = context.request.headers['x-github-event'];
-      if (eventType != 'pull_request' && eventType != 'push') {
-        return;
-      }
+  try {
+    await db.webhookTaskDao.insertWebhookTask(task);
+  } catch (e) {
+    // Unique constraint violation (duplicate webhook task)
+    return Response.json(
+      body: {
+        'success': true,
+        'message': 'Webhook delivery already processed (via task check)',
+      },
+    );
+  }
 
-      final installation = payload['installation'] as Map<String, dynamic>?;
-      if (installation == null || installation['id'] == null) {
-        stderr.writeln('Background webhook error: Missing installation ID');
-        return;
-      }
-      final installationId = installation['id'] as int;
-
-      final team = await db.teamDao.getTeamByInstallationId(installationId);
-      if (team == null) {
-        stderr.writeln(
-          'Background webhook warning: No team found for installationId $installationId',
-        );
-        return;
-      }
-
-      final appId = env['GITHUB_APP_ID'];
-      final privateKeyPath = env['GITHUB_PRIVATE_KEY_PATH'];
-      if (appId == null ||
-          appId.isEmpty ||
-          privateKeyPath == null ||
-          privateKeyPath.isEmpty) {
-        stderr.writeln(
-          'Background webhook error: GITHUB_APP_ID or GITHUB_PRIVATE_KEY_PATH is not configured.',
-        );
-        return;
-      }
-
-      final privateKeyFile = File(privateKeyPath);
-      if (!privateKeyFile.existsSync()) {
-        stderr.writeln(
-          'Background webhook error: GITHUB_PRIVATE_KEY_PATH file does not exist: $privateKeyPath',
-        );
-        return;
-      }
-      final privateKeyPem = privateKeyFile.readAsStringSync();
-
-      final jwtToken = generateGitHubAppJwt(appId, privateKeyPem);
-
-      final githubApiBaseUrl = normalizeGitHubApiBaseUrl(team.githubApiBaseUrl);
-      final githubBaseUrl = team.githubBaseUrl ?? 'https://github.com';
-
-      try {
-        httpClient = context.read<http.Client>();
-      } catch (_) {
-        httpClient = http.Client();
-        isSelfGeneratedClient = true;
-      }
-
-      final tokenUrl =
-          '$githubApiBaseUrl/app/installations/$installationId/access_tokens';
-      final http.Response tokenResponse;
-      try {
-        tokenResponse = await httpClient
-            .post(
-              Uri.parse(tokenUrl),
-              headers: {
-                'Authorization': 'Bearer $jwtToken',
-                'Accept': 'application/vnd.github+json',
-                'X-GitHub-Api-Version': '2022-11-28',
-                'User-Agent': 'OpenCI-Server',
-              },
-            )
-            .timeout(const Duration(seconds: 15));
-      } catch (e) {
-        stderr.writeln(
-          'Background webhook error: Access token request timed out or failed: $e',
-        );
-        return;
-      }
-
-      if (tokenResponse.statusCode >= 300) {
-        stderr.writeln(
-          'Background webhook error: Failed to retrieve installation token: ${tokenResponse.statusCode} ${tokenResponse.body}',
-        );
-        return;
-      }
-
-      final tokenData = jsonDecode(tokenResponse.body) as Map<String, dynamic>;
-      final installationToken = tokenData['token'] as String;
-
-      // Extract git event metadata
-      final String owner;
-      final String repo;
-      final String commitSha;
-      final String branch;
-      final String? triggerBranch;
-      final int? pullRequestNumber;
-      final String triggerType;
-
-      if (eventType == 'pull_request') {
-        final action = payload['action'] as String?;
-        if (action != 'opened' &&
-            action != 'synchronize' &&
-            action != 'reopened') {
-          return;
-        }
-        final event = PullRequestEvent.fromJson(payload);
-        final pr = event.pullRequest;
-        final repoMap = event.repository;
-        if (pr == null || repoMap == null) {
-          stderr.writeln(
-            'Background webhook error: Missing pull_request or repository data',
-          );
-          return;
-        }
-        owner = repoMap.owner?.login ?? '';
-        repo = repoMap.name;
-        commitSha = pr.head?.sha ?? '';
-        branch = pr.head?.ref ?? '';
-        triggerBranch = pr.base?.ref;
-        pullRequestNumber = event.number;
-        triggerType = 'pull_request';
-      } else {
-        // push event
-        if (payload['deleted'] == true) {
-          return;
-        }
-        final repoMap = payload['repository'] as Map<String, dynamic>;
-        owner = repoMap['owner']['login'] as String;
-        repo = repoMap['name'] as String;
-        commitSha =
-            (payload['head_commit']?['id'] ?? payload['after']) as String;
-        final ref = payload['ref'] as String;
-        if (ref.startsWith('refs/heads/')) {
-          branch = ref.substring(11);
-        } else {
-          branch = ref;
-        }
-        triggerBranch = branch;
-        pullRequestNumber = null;
-        triggerType = 'push';
-      }
-
-      // Fetch YAML files from .openci directory
-      final contentsUrl =
-          '$githubApiBaseUrl/repos/$owner/$repo/contents/.openci?ref=$commitSha';
-      final http.Response contentsResponse;
-      try {
-        contentsResponse = await httpClient
-            .get(
-              Uri.parse(contentsUrl),
-              headers: {
-                'Authorization': 'token $installationToken',
-                'Accept': 'application/vnd.github+json',
-                'User-Agent': 'OpenCI-Server',
-              },
-            )
-            .timeout(const Duration(seconds: 15));
-      } catch (e) {
-        stderr.writeln(
-          'Background webhook error: Fetch contents request timed out or failed: $e',
-        );
-        return;
-      }
-
-      if (contentsResponse.statusCode == 404) {
-        return;
-      }
-
-      if (contentsResponse.statusCode >= 300) {
-        stderr.writeln(
-          'Background webhook error: Failed to fetch contents: ${contentsResponse.statusCode} ${contentsResponse.body}',
-        );
-        return;
-      }
-
-      final contentsList = jsonDecode(contentsResponse.body);
-      if (contentsList is! List) {
-        stderr.writeln('Background webhook error: .openci is not a directory');
-        return;
-      }
-
-      final yamlFiles = contentsList
-          .where(
-            (item) =>
-                item is Map &&
-                item['type'] == 'file' &&
-                (item['name'].toString().endsWith('.yaml') ||
-                    item['name'].toString().endsWith('.yml')),
-          )
-          .cast<Map<dynamic, dynamic>>()
-          .toList();
-
-      if (yamlFiles.isEmpty) {
-        return;
-      }
-
-      final fetchedFiles = await fetchWorkflowFiles(
-        yamlFiles: yamlFiles,
-        githubApiBaseUrl: githubApiBaseUrl,
-        owner: owner,
-        repo: repo,
-        commitSha: commitSha,
-        installationToken: installationToken,
-        httpClient: httpClient,
-      );
-
-      final extractedJobs = parseWorkflowJobs(
-        files: fetchedFiles,
-        triggerType: triggerType,
-        triggerBranch: triggerBranch,
-      );
-
-      if (extractedJobs.isEmpty) {
-        return;
-      }
-
-      // Count jobs per workflow
-      final jobCountsByWorkflow = <String, int>{};
-      for (final job in extractedJobs) {
-        jobCountsByWorkflow[job.workflowName] =
-            (jobCountsByWorkflow[job.workflowName] ?? 0) + 1;
-      }
-
-      final workflowRunIds = <String, String>{};
-      final jobDocumentIdsByWorkflow = <String, Map<String, String>>{};
-      final jobInstanceKeysBySourceKeyByWorkflow =
-          <String, Map<String, List<String>>>{};
-
-      for (final job in extractedJobs) {
-        final wName = job.workflowFileName;
-        if (!workflowRunIds.containsKey(wName)) {
-          workflowRunIds[wName] = const Uuid().v4();
-        }
-
-        final jobDocumentIds = jobDocumentIdsByWorkflow[wName] ??= {};
-        jobDocumentIds[job.jobId] = const Uuid().v4();
-
-        final sourceKey = job.workflowJobKey ?? job.jobId;
-        final jobInstanceKeysBySourceKey =
-            jobInstanceKeysBySourceKeyByWorkflow[wName] ??= {};
-        (jobInstanceKeysBySourceKey[sourceKey] ??= []).add(job.jobId);
-      }
-
-      for (final job in extractedJobs) {
-        final wName = job.workflowFileName;
-        final documentId = jobDocumentIdsByWorkflow[wName]![job.jobId]!;
-        final workflowRunId = workflowRunIds[wName]!;
-
-        final jobInstanceKeysBySourceKey =
-            jobInstanceKeysBySourceKeyByWorkflow[wName]!;
-
-        // Resolve needs and status
-        final spec = job.spec;
-        final rawNeeds = spec['needs'];
-        final List<String> rawNeedKeys;
-        if (rawNeeds is List) {
-          rawNeedKeys = rawNeeds.map((e) => e.toString()).toList();
-        } else if (rawNeeds is String) {
-          rawNeedKeys = [rawNeeds];
-        } else {
-          rawNeedKeys = [];
-        }
-
-        final needs = rawNeedKeys
-            .flatMap((need) => jobInstanceKeysBySourceKey[need] ?? [need])
-            .toList();
-        final hasNeeds = needs.isNotEmpty;
-        final status = hasNeeds
-            ? BuildJobStatus.WAITING
-            : BuildJobStatus.QUEUED;
-
-        // Create Check Run on GitHub
-        final checkRunName = (jobCountsByWorkflow[job.workflowName] ?? 0) > 1
-            ? '${job.workflowName} / ${job.workflowJobKey ?? job.jobId}${job.matrixLabel != null ? " (${job.matrixLabel})" : ""}'
-            : job.workflowName;
-
-        final checkRunUrl = '$githubApiBaseUrl/repos/$owner/$repo/check-runs';
-        final http.Response checkRunResponse;
-        try {
-          checkRunResponse = await httpClient
-              .post(
-                Uri.parse(checkRunUrl),
-                headers: {
-                  'Authorization': 'token $installationToken',
-                  'Accept': 'application/vnd.github+json',
-                  'X-GitHub-Api-Version': '2022-11-28',
-                  'User-Agent': 'OpenCI-Server',
-                  'Content-Type': 'application/json',
-                },
-                body: jsonEncode({
-                  'name': checkRunName,
-                  'head_sha': commitSha,
-                  'status': 'queued',
-                  'started_at': DateTime.now().toUtc().toIso8601String(),
-                  'details_url':
-                      'https://dashboard.openci.org/runs/$documentId',
-                }),
-              )
-              .timeout(const Duration(seconds: 15));
-        } catch (e) {
-          stderr.writeln(
-            'Background webhook error: Create check run request timed out or failed: $e',
-          );
-          continue;
-        }
-
-        if (checkRunResponse.statusCode >= 300) {
-          stderr.writeln(
-            'Background webhook error: Failed to create check run: ${checkRunResponse.statusCode} ${checkRunResponse.body}',
-          );
-          continue;
-        }
-
-        final checkRunData =
-            jsonDecode(checkRunResponse.body) as Map<String, dynamic>;
-        final checkRunId = checkRunData['id'].toString();
-
-        // Map Matrix to String map
-        final matrixMap = job.matrix?.map((k, v) => MapEntry(k, v));
-
-        // Save BuildJob in DB
-        final buildJob = BuildJob(
-          id: documentId,
-          status: status,
-          owner: owner,
-          repo: repo,
-          workflowName: job.workflowName,
-          teamId: team.id,
-          workflowFileName: job.workflowFileName,
-          commitSha: commitSha,
-          pullRequestNumber: pullRequestNumber,
-          runCount: 0,
-          tagName: null,
-          branch: branch,
-          jobKey: job.jobId,
-          workflowJobKey: job.workflowJobKey,
-          matrix: matrixMap,
-          matrixLabel: job.matrixLabel,
-          workflowRunId: workflowRunId,
-          needs: needs.isEmpty ? null : needs,
-          runsOn: job.spec['runs-on']?.toString(),
-          githubBaseUrl: githubBaseUrl,
-          githubApiBaseUrl: githubApiBaseUrl,
-          createdAt: DateTime.now().toUtc(),
-          updatedAt: DateTime.now().toUtc(),
-        );
-
-        await db.buildJobDao.insertBuildJob(
-          buildJob.toDrift(
-            installationId: installationId.toString(),
-            checkRunId: checkRunId,
-          ),
-        );
-      }
-    } catch (e, s) {
-      stderr.writeln('Background webhook error: $e\n$s');
-    } finally {
-      if (isSelfGeneratedClient && httpClient != null) {
-        httpClient.close();
-      }
-    }
-  }());
+  // 3. Ping the background worker stream
+  webhookTaskController.add(null);
 
   return Response.json(
     body: {
       'success': true,
-      'message': 'Webhook received and processing started in background.',
+      'message': 'Webhook received and queued.',
     },
-  );
-}
-
-String generateGitHubAppJwt(String appId, String privateKeyPem) {
-  final nowSeconds = DateTime.now().millisecondsSinceEpoch ~/ 1000;
-  final jwt = JWT({
-    'iat': nowSeconds - 60,
-    'exp': nowSeconds + 540,
-    'iss': appId.trim(),
-  });
-  return jwt.sign(
-    RSAPrivateKey(privateKeyPem),
-    algorithm: JWTAlgorithm.RS256,
   );
 }
 
@@ -509,368 +180,4 @@ bool verifyWebhookSignature({
   final expectedSignatureBytes = utf8.encode(expectedSignature);
 
   return constantTimeCompare(computedSignatureBytes, expectedSignatureBytes);
-}
-
-class FetchedWorkflowFile {
-  final String name;
-  final String path;
-  final String content;
-
-  FetchedWorkflowFile({
-    required this.name,
-    required this.path,
-    required this.content,
-  });
-}
-
-Future<List<FetchedWorkflowFile>> fetchWorkflowFiles({
-  required List<Map<dynamic, dynamic>> yamlFiles,
-  required String githubApiBaseUrl,
-  required String owner,
-  required String repo,
-  required String commitSha,
-  required String installationToken,
-  required http.Client httpClient,
-}) async {
-  final fetched = <FetchedWorkflowFile>[];
-  for (final file in yamlFiles) {
-    final path = file['path'] as String;
-    final name = file['name'] as String;
-
-    final fileUrl =
-        '$githubApiBaseUrl/repos/$owner/$repo/contents/$path?ref=$commitSha';
-    final http.Response fileResponse;
-    try {
-      fileResponse = await httpClient
-          .get(
-            Uri.parse(fileUrl),
-            headers: {
-              'Authorization': 'token $installationToken',
-              'Accept': 'application/vnd.github.raw+json',
-              'User-Agent': 'OpenCI-Server',
-            },
-          )
-          .timeout(const Duration(seconds: 15));
-    } catch (e) {
-      stderr.writeln(
-        'Warning: Failed to fetch file $path due to timeout or error: $e',
-      );
-      continue;
-    }
-
-    if (fileResponse.statusCode >= 300) {
-      stderr.writeln(
-        'Warning: Failed to fetch file $path: ${fileResponse.statusCode}',
-      );
-      continue;
-    }
-
-    fetched.add(
-      FetchedWorkflowFile(
-        name: name,
-        path: path,
-        content: fileResponse.body,
-      ),
-    );
-  }
-  return fetched;
-}
-
-List<ExtractedJob> parseWorkflowJobs({
-  required List<FetchedWorkflowFile> files,
-  required String triggerType,
-  required String? triggerBranch,
-}) {
-  final extractedJobs = <ExtractedJob>[];
-  for (final file in files) {
-    try {
-      final parsed = loadYaml(file.content);
-      if (parsed is! Map) {
-        stderr.writeln('Warning: YAML at ${file.path} is not an object');
-        continue;
-      }
-
-      final workflowName = parsed['name'] is String
-          ? parsed['name'] as String
-          : file.name.replaceAll(RegExp(r'\.(yaml|yml)$'), '');
-      if (!matchesTrigger(parsed, triggerType, triggerBranch)) {
-        continue;
-      }
-
-      final jobs = parsed['jobs'];
-      if (jobs is! Map) {
-        stderr.writeln(
-          'Warning: Workflow ${file.name} does not contain a valid jobs object',
-        );
-        continue;
-      }
-
-      for (final jobEntry in jobs.entries) {
-        final jobId = jobEntry.key.toString();
-        final spec = jobEntry.value;
-        if (spec is! Map) {
-          stderr.writeln('Warning: Job $jobId is not an object');
-          continue;
-        }
-
-        final matrixCells = expandMatrix(spec);
-        if (matrixCells != null) {
-          for (
-            var matrixIndex = 0;
-            matrixIndex < matrixCells.length;
-            matrixIndex++
-          ) {
-            final matrix = matrixCells[matrixIndex];
-            final expandedJobId = matrixInstanceKey(jobId, matrix);
-            final resolvedSpec =
-                resolveMatrixExpressions(spec, matrix) as Map<dynamic, dynamic>;
-
-            extractedJobs.add(
-              ExtractedJob(
-                workflowFileName: file.name,
-                workflowName: workflowName,
-                jobId: expandedJobId,
-                workflowJobKey: jobId,
-                spec: resolvedSpec,
-                matrix: matrix,
-                matrixLabel: matrixLabel(matrix),
-                matrixIndex: matrixIndex,
-                matrixGroupKey: '${file.name}:$jobId',
-                matrixFailFast:
-                    (spec['strategy'] as Map?)?['fail-fast'] != false,
-              ),
-            );
-          }
-        } else {
-          extractedJobs.add(
-            ExtractedJob(
-              workflowFileName: file.name,
-              workflowName: workflowName,
-              jobId: jobId,
-              workflowJobKey: null,
-              spec: spec,
-            ),
-          );
-        }
-      }
-    } catch (e, s) {
-      stderr.writeln('Error parsing YAML at ${file.path}: $e\n$s');
-      continue;
-    }
-  }
-  return extractedJobs;
-}
-
-// Extracted Job DTO
-class ExtractedJob {
-  final String workflowFileName;
-  final String workflowName;
-  final String jobId;
-  final String? workflowJobKey;
-  final Map<dynamic, dynamic> spec;
-  final MatrixCell? matrix;
-  final String? matrixLabel;
-  final int? matrixIndex;
-  final String? matrixGroupKey;
-  final bool? matrixFailFast;
-
-  ExtractedJob({
-    required this.workflowFileName,
-    required this.workflowName,
-    required this.jobId,
-    required this.workflowJobKey,
-    required this.spec,
-    this.matrix,
-    this.matrixLabel,
-    this.matrixIndex,
-    this.matrixGroupKey,
-    this.matrixFailFast,
-  });
-}
-
-// Matrix helper methods
-typedef MatrixCell = Map<String, dynamic>;
-
-List<MatrixCell>? expandMatrix(Map<dynamic, dynamic> spec) {
-  final strategy = spec['strategy'];
-  if (strategy is! Map) return null;
-  final matrix = strategy['matrix'];
-  if (matrix is! Map) return null;
-
-  final axes = <MapEntry<String, List<dynamic>>>[];
-  for (final entry in matrix.entries) {
-    final key = entry.key.toString();
-    if (key == 'include' || key == 'exclude') continue;
-    final val = entry.value;
-    if (val is! List) return null;
-    axes.add(MapEntry(key, val));
-  }
-
-  List<MatrixCell> combinations = [{}];
-  if (axes.isNotEmpty) {
-    for (final axis in axes) {
-      final next = <MatrixCell>[];
-      for (final comb in combinations) {
-        for (final val in axis.value) {
-          next.add({...comb, axis.key: val});
-        }
-      }
-      combinations = next;
-    }
-  } else {
-    combinations = [];
-  }
-
-  // exclude
-  final excludeRaw = matrix['exclude'];
-  final excludes = <MatrixCell>[];
-  if (excludeRaw is List) {
-    for (final ex in excludeRaw) {
-      if (ex is Map) {
-        excludes.add(ex.map((k, v) => MapEntry(k.toString(), v)));
-      }
-    }
-  }
-
-  if (excludes.isNotEmpty) {
-    combinations = combinations.where((comb) {
-      return !excludes.any((ex) {
-        return ex.entries.every((e) => comb[e.key] == e.value);
-      });
-    }).toList();
-  }
-
-  // include
-  final includeRaw = matrix['include'];
-  final includes = <MatrixCell>[];
-  if (includeRaw is List) {
-    for (final inc in includeRaw) {
-      if (inc is Map) {
-        includes.add(inc.map((k, v) => MapEntry(k.toString(), v)));
-      }
-    }
-  }
-
-  final axisKeys = axes.map((e) => e.key).toSet();
-  for (final inc in includes) {
-    if (axisKeys.isEmpty) {
-      combinations.add(inc);
-      continue;
-    }
-    bool didMerge = false;
-    combinations = combinations.map((comb) {
-      final canMerge = inc.entries.every((e) {
-        if (!axisKeys.contains(e.key)) return true;
-        return !comb.containsKey(e.key) || comb[e.key] == e.value;
-      });
-      if (!canMerge) return comb;
-      didMerge = true;
-      return {...comb, ...inc};
-    }).toList();
-
-    if (!didMerge) {
-      combinations.add(inc);
-    }
-  }
-
-  if (axes.isEmpty && includes.isEmpty) return null;
-  return combinations;
-}
-
-String matrixKeyValueLabel(MatrixCell cell) {
-  final entries = cell.entries.toList()..sort((a, b) => a.key.compareTo(b.key));
-  return entries.map((e) => '${e.key}=${e.value}').join(',');
-}
-
-String matrixLabel(MatrixCell cell) {
-  if (cell.containsKey('name') && cell['name'] is String) {
-    return cell['name'] as String;
-  }
-  return matrixKeyValueLabel(cell);
-}
-
-String matrixInstanceKey(String jobId, MatrixCell cell) {
-  return '$jobId[${matrixKeyValueLabel(cell)}]';
-}
-
-dynamic resolveMatrixExpressions(dynamic value, MatrixCell matrix) {
-  if (value is String) {
-    final pattern = RegExp(
-      r'\$\{\{\s*matrix\.([A-Za-z_][A-Za-z0-9_-]*)\s*\}\}',
-    );
-    return value.replaceAllMapped(pattern, (match) {
-      final key = match.group(1);
-      if (key == null) return match.group(0)!;
-      final replacement = matrix[key];
-      return replacement == null ? match.group(0)! : replacement.toString();
-    });
-  }
-  if (value is List) {
-    return value.map((e) => resolveMatrixExpressions(e, matrix)).toList();
-  }
-  if (value is Map) {
-    return value.map(
-      (k, v) => MapEntry(k, resolveMatrixExpressions(v, matrix)),
-    );
-  }
-  return value;
-}
-
-bool matchesTrigger(
-  Map<dynamic, dynamic> parsed,
-  String triggerType,
-  String? triggerBranch,
-) {
-  final on = parsed['on'];
-  if (on == null) return false;
-
-  if (on is String) {
-    return on == triggerType;
-  }
-
-  if (on is List) {
-    return on.contains(triggerType);
-  }
-
-  if (on is Map) {
-    if (!on.containsKey(triggerType)) return false;
-    final config = on[triggerType];
-    if (config == null) return true;
-    if (config is! Map) return true;
-
-    final branches = config['branches'];
-    if (branches == null || triggerBranch == null) return true;
-
-    final branchList = branches is List
-        ? branches.map((e) => e.toString()).toList()
-        : [branches.toString()];
-    return branchList.contains(triggerBranch);
-  }
-
-  return false;
-}
-
-String normalizeGitHubApiBaseUrl(String? apiBaseUrl) {
-  if (apiBaseUrl == null || apiBaseUrl.isEmpty) return 'https://api.github.com';
-  final normalized = apiBaseUrl.replaceAll(RegExp(r'/+$'), '');
-  if (normalized == 'https://api.github.com' ||
-      normalized == 'https://github.com' ||
-      normalized == 'https://api.github.com/graphql') {
-    return 'https://api.github.com';
-  }
-  if (normalized.endsWith('/api/v3')) return normalized;
-  try {
-    final uri = Uri.parse(normalized);
-    if (normalized.endsWith('/api/graphql') ||
-        normalized.endsWith('/graphql')) {
-      return '${uri.scheme}://${uri.host}/api/v3';
-    }
-    return '${uri.scheme}://${uri.host}/api/v3';
-  } catch (_) {
-    return 'https://api.github.com';
-  }
-}
-
-extension FlatMap<T> on Iterable<T> {
-  Iterable<R> flatMap<R>(Iterable<R> Function(T) f) => expand(f);
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * Webhook受信を永続化したキューに登録し、非同期で処理できるようにしました（重複は冪等に扱います）
  * ワーカーが最大3並列で実行し、失敗時は状態更新と再試行を行います
  * Webhookの応答時間を短縮（対象イベントのみキュー投入し、即時レスポンス）

* **リファクタリング**
  * Webhookの実処理をワーカー側へ移譲し、起動時にワーカーを開始するよう変更しました
<!-- end of auto-generated comment: release notes by coderabbit.ai -->