### PR TITLE
feat: implement CRUD routes for encrypted team secrets with accompanying tests

### DIFF
--- a/apps/openci_server/routes/teams/[id]/secrets/[name].dart
+++ b/apps/openci_server/routes/teams/[id]/secrets/[name].dart
@@ -1,0 +1,143 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:dart_frog/dart_frog.dart';
+import 'package:openci_server/auth/worker_auth.dart';
+import 'package:openci_server/database.dart';
+import 'package:openci_server/secret/secret_crypter.dart';
+
+FutureOr<Response> onRequest(RequestContext context, String id, String name) {
+  return switch (context.request.method) {
+    HttpMethod.get => _get(context, id, name),
+    HttpMethod.delete => _delete(context, id, name),
+    _ => Response(statusCode: HttpStatus.methodNotAllowed),
+  };
+}
+
+Future<Response> _get(
+  RequestContext context,
+  String teamId,
+  String name,
+) async {
+  try {
+    final db = context.read<AppDatabase>();
+    final uid = context.read<String?>();
+    if (uid == null) {
+      return Response.json(
+        statusCode: HttpStatus.unauthorized,
+        body: {'success': false, 'error': 'Authentication required'},
+      );
+    }
+
+    final isMember = await db.teamDao.isTeamMember(uid, teamId);
+    if (!isMember) {
+      final workerAuthError = verifyWorkerAuth(context, uid);
+      if (workerAuthError != null) {
+        return Response.json(
+          statusCode: HttpStatus.forbidden,
+          body: {'success': false, 'error': 'Forbidden'},
+        );
+      }
+    }
+
+    final secret = await db.secretDao.getSecret(teamId, name);
+    if (secret == null) {
+      return Response.json(
+        statusCode: HttpStatus.notFound,
+        body: {'success': false, 'error': 'Secret not found'},
+      );
+    }
+
+    Map<String, String> env;
+    try {
+      env = context.read<Map<String, String>>();
+    } catch (_) {
+      env = Platform.environment;
+    }
+
+    final encryptionKey = env['SECRET_ENCRYPTION_KEY'];
+    if (encryptionKey == null || encryptionKey.trim().isEmpty) {
+      stderr.writeln('SECRET_ENCRYPTION_KEY environment variable is not set');
+      return Response.json(
+        statusCode: HttpStatus.internalServerError,
+        body: {
+          'success': false,
+          'error': 'Encryption key is not configured on the server',
+        },
+      );
+    }
+
+    final SecretCrypter crypter;
+    try {
+      crypter = SecretCrypter(encryptionKey);
+    } catch (e) {
+      stderr.writeln('Failed to initialize SecretCrypter: $e');
+      return Response.json(
+        statusCode: HttpStatus.internalServerError,
+        body: {
+          'success': false,
+          'error': 'Invalid encryption key configuration',
+        },
+      );
+    }
+
+    final decryptedValue = await crypter.decrypt(secret.encryptedValue);
+
+    return Response.json(
+      body: {
+        'success': true,
+        'value': decryptedValue,
+      },
+    );
+  } catch (e, s) {
+    stderr.writeln('Failed to get secret $name for team $teamId: $e\n$s');
+    return Response.json(
+      statusCode: HttpStatus.internalServerError,
+      body: {'success': false, 'error': 'Internal server error'},
+    );
+  }
+}
+
+Future<Response> _delete(
+  RequestContext context,
+  String teamId,
+  String name,
+) async {
+  try {
+    final db = context.read<AppDatabase>();
+    final uid = context.read<String?>();
+    if (uid == null) {
+      return Response.json(
+        statusCode: HttpStatus.unauthorized,
+        body: {'success': false, 'error': 'Authentication required'},
+      );
+    }
+
+    // Only team members can delete secrets
+    final isMember = await db.teamDao.isTeamMember(uid, teamId);
+    if (!isMember) {
+      return Response.json(
+        statusCode: HttpStatus.forbidden,
+        body: {'success': false, 'error': 'Forbidden'},
+      );
+    }
+
+    final deletedCount = await db.secretDao.deleteSecret(teamId, name);
+    if (deletedCount == 0) {
+      return Response.json(
+        statusCode: HttpStatus.notFound,
+        body: {'success': false, 'error': 'Secret not found'},
+      );
+    }
+
+    return Response.json(
+      body: {'success': true},
+    );
+  } catch (e, s) {
+    stderr.writeln('Failed to delete secret $name for team $teamId: $e\n$s');
+    return Response.json(
+      statusCode: HttpStatus.internalServerError,
+      body: {'success': false, 'error': 'Internal server error'},
+    );
+  }
+}

--- a/apps/openci_server/routes/teams/[id]/secrets/index.dart
+++ b/apps/openci_server/routes/teams/[id]/secrets/index.dart
@@ -1,0 +1,158 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:dart_frog/dart_frog.dart';
+import 'package:openci_server/auth/worker_auth.dart';
+import 'package:openci_server/database.dart';
+import 'package:openci_server/request/request_extension.dart';
+import 'package:openci_server/secret/secret_crypter.dart';
+import 'package:openci_server/secret/secret_table.dart';
+
+FutureOr<Response> onRequest(RequestContext context, String id) {
+  return switch (context.request.method) {
+    HttpMethod.get => _get(context, id),
+    HttpMethod.post => _post(context, id),
+    _ => Response(statusCode: HttpStatus.methodNotAllowed),
+  };
+}
+
+Future<Response> _get(RequestContext context, String teamId) async {
+  try {
+    final db = context.read<AppDatabase>();
+    final uid = context.read<String?>();
+    if (uid == null) {
+      return Response.json(
+        statusCode: HttpStatus.unauthorized,
+        body: {'success': false, 'error': 'Authentication required'},
+      );
+    }
+
+    final isMember = await db.teamDao.isTeamMember(uid, teamId);
+    if (!isMember) {
+      final workerAuthError = verifyWorkerAuth(context, uid);
+      if (workerAuthError != null) {
+        return Response.json(
+          statusCode: HttpStatus.forbidden,
+          body: {'success': false, 'error': 'Forbidden'},
+        );
+      }
+    }
+
+    final driftSecrets = await db.secretDao.getSecretsForTeam(teamId);
+    final jsonList = driftSecrets.map((s) => s.toJson()).toList();
+
+    return Response.json(
+      body: {'success': true, 'secrets': jsonList},
+    );
+  } catch (e, s) {
+    stderr.writeln('Failed to get secrets for team $teamId: $e\n$s');
+    return Response.json(
+      statusCode: HttpStatus.internalServerError,
+      body: {'success': false, 'error': 'Internal server error'},
+    );
+  }
+}
+
+Future<Response> _post(RequestContext context, String teamId) async {
+  try {
+    final db = context.read<AppDatabase>();
+    final uid = context.read<String?>();
+    if (uid == null) {
+      return Response.json(
+        statusCode: HttpStatus.unauthorized,
+        body: {'success': false, 'error': 'Authentication required'},
+      );
+    }
+
+    final isMember = await db.teamDao.isTeamMember(uid, teamId);
+    if (!isMember) {
+      return Response.json(
+        statusCode: HttpStatus.forbidden,
+        body: {'success': false, 'error': 'Forbidden'},
+      );
+    }
+
+    final Map<String, dynamic> payload;
+    try {
+      payload = await context.jsonBody();
+    } on BadRequestException catch (e) {
+      return Response.json(
+        statusCode: HttpStatus.badRequest,
+        body: {'success': false, 'error': e.message},
+      );
+    }
+
+    final name = payload['name'];
+    final value = payload['value'];
+
+    if (name is! String || name.trim().isEmpty) {
+      return Response.json(
+        statusCode: HttpStatus.badRequest,
+        body: {'success': false, 'error': 'name must be a non-empty string'},
+      );
+    }
+
+    if (value is! String || value.trim().isEmpty) {
+      return Response.json(
+        statusCode: HttpStatus.badRequest,
+        body: {'success': false, 'error': 'value must be a non-empty string'},
+      );
+    }
+
+    Map<String, String> env;
+    try {
+      env = context.read<Map<String, String>>();
+    } catch (_) {
+      env = Platform.environment;
+    }
+
+    final encryptionKey = env['SECRET_ENCRYPTION_KEY'];
+    if (encryptionKey == null || encryptionKey.trim().isEmpty) {
+      stderr.writeln('SECRET_ENCRYPTION_KEY environment variable is not set');
+      return Response.json(
+        statusCode: HttpStatus.internalServerError,
+        body: {
+          'success': false,
+          'error': 'Encryption key is not configured on the server',
+        },
+      );
+    }
+
+    final SecretCrypter crypter;
+    try {
+      crypter = SecretCrypter(encryptionKey);
+    } catch (e) {
+      stderr.writeln('Failed to initialize SecretCrypter: $e');
+      return Response.json(
+        statusCode: HttpStatus.internalServerError,
+        body: {
+          'success': false,
+          'error': 'Invalid encryption key configuration',
+        },
+      );
+    }
+
+    final encryptedValue = await crypter.encrypt(value.trim());
+    final now = DateTime.now().toUtc();
+
+    final driftSecret = DriftSecret(
+      name: name.trim(),
+      teamId: teamId,
+      encryptedValue: encryptedValue,
+      createdAt: now,
+      updatedAt: now,
+    );
+
+    await db.secretDao.insertOrUpdateSecret(driftSecret);
+
+    return Response.json(
+      body: {'success': true},
+    );
+  } catch (e, s) {
+    stderr.writeln('Failed to create secret for team $teamId: $e\n$s');
+    return Response.json(
+      statusCode: HttpStatus.internalServerError,
+      body: {'success': false, 'error': 'Internal server error'},
+    );
+  }
+}

--- a/apps/openci_server/test/routes/teams/secrets_test.dart
+++ b/apps/openci_server/test/routes/teams/secrets_test.dart
@@ -1,0 +1,312 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:dart_frog/dart_frog.dart';
+import 'package:dart_frog_test/dart_frog_test.dart';
+import 'package:drift/native.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openci_server/database.dart';
+import 'package:openci_server/secret/secret_table.dart';
+import 'package:test/test.dart';
+
+import '../../../routes/teams/[id]/secrets/[name].dart' as name_route;
+import '../../../routes/teams/[id]/secrets/index.dart' as index_route;
+
+class MockAppDatabase extends Mock implements AppDatabase {}
+
+void main() {
+  const encryptionKey = 'A9hs566HtB6B0ZEB2aKkAZpC81VGQxKMlFspt+vA5F4=';
+  final env = {
+    'SECRET_ENCRYPTION_KEY': encryptionKey,
+    'ALLOWED_WORKER_UIDS': 'worker-1',
+  };
+
+  late AppDatabase db;
+
+  setUp(() async {
+    db = AppDatabase(NativeDatabase.memory());
+    await db
+        .into(db.teams)
+        .insert(
+          DriftTeam(
+            id: 'team-123',
+            name: 'Test Team',
+            installationIds: const [],
+            aiEnabled: false,
+            runNumber: 1,
+            createdAt: DateTime.now().toUtc(),
+            updatedAt: DateTime.now().toUtc(),
+          ),
+        );
+  });
+
+  tearDown(() async {
+    await db.close();
+  });
+
+  group('Secrets Endpoints', () {
+    group('POST /teams/<id>/secrets', () {
+      test('responds with 401 Unauthorized when uid is null', () async {
+        final context = TestRequestContext(
+          path: '/teams/team-123/secrets',
+          method: HttpMethod.post,
+          body: jsonEncode({'name': 'MY_SECRET', 'value': 'my-value'}),
+        );
+        context.provide<AppDatabase>(db);
+        context.provide<String?>(null);
+        context.provide<Map<String, String>>(env);
+
+        final response = await index_route.onRequest(
+          context.context,
+          'team-123',
+        );
+        expect(response.statusCode, equals(HttpStatus.unauthorized));
+      });
+
+      test(
+        'responds with 403 Forbidden when user is not team member',
+        () async {
+          final context = TestRequestContext(
+            path: '/teams/team-123/secrets',
+            method: HttpMethod.post,
+            body: jsonEncode({'name': 'MY_SECRET', 'value': 'my-value'}),
+          );
+          context.provide<AppDatabase>(db);
+          context.provide<String?>('non-member-user');
+          context.provide<Map<String, String>>(env);
+
+          final response = await index_route.onRequest(
+            context.context,
+            'team-123',
+          );
+          expect(response.statusCode, equals(HttpStatus.forbidden));
+        },
+      );
+
+      test(
+        'responds with 200 OK and encrypts and stores secret in database',
+        () async {
+          await db
+              .into(db.teamMembers)
+              .insert(
+                TeamMembersCompanion.insert(
+                  teamId: 'team-123',
+                  userId: 'user-1',
+                ),
+              );
+
+          final context = TestRequestContext(
+            path: '/teams/team-123/secrets',
+            method: HttpMethod.post,
+            body: jsonEncode({'name': 'MY_SECRET', 'value': 'my-value'}),
+          );
+          context.provide<AppDatabase>(db);
+          context.provide<String?>('user-1');
+          context.provide<Map<String, String>>(env);
+
+          final response = await index_route.onRequest(
+            context.context,
+            'team-123',
+          );
+          expect(response.statusCode, equals(HttpStatus.ok));
+
+          final body = await response.json() as Map<String, dynamic>;
+          expect(body['success'], isTrue);
+
+          final retrieved = await db.secretDao.getSecret(
+            'team-123',
+            'MY_SECRET',
+          );
+          expect(retrieved, isNotNull);
+          expect(retrieved!.encryptedValue, isNot(equals('my-value')));
+        },
+      );
+    });
+
+    group('GET /teams/<id>/secrets', () {
+      test(
+        'responds with 200 OK and lists redacted secrets for members',
+        () async {
+          await db
+              .into(db.teamMembers)
+              .insert(
+                TeamMembersCompanion.insert(
+                  teamId: 'team-123',
+                  userId: 'user-1',
+                ),
+              );
+
+          final now = DateTime.now().toUtc();
+          await db.secretDao.insertOrUpdateSecret(
+            DriftSecret(
+              name: 'API_KEY',
+              teamId: 'team-123',
+              encryptedValue: 'super-secret-ciphertext',
+              createdAt: now,
+              updatedAt: now,
+            ),
+          );
+
+          final context = TestRequestContext(
+            path: '/teams/team-123/secrets',
+            method: HttpMethod.get,
+          );
+          context.provide<AppDatabase>(db);
+          context.provide<String?>('user-1');
+          context.provide<Map<String, String>>(env);
+
+          final response = await index_route.onRequest(
+            context.context,
+            'team-123',
+          );
+          expect(response.statusCode, equals(HttpStatus.ok));
+
+          final body = await response.json() as Map<String, dynamic>;
+          expect(body['success'], isTrue);
+
+          final secrets = body['secrets'] as List<dynamic>;
+          expect(secrets, hasLength(1));
+          expect(secrets[0]['name'], equals('API_KEY'));
+          expect(secrets[0]['encryptedValue'], equals('[REDACTED]'));
+        },
+      );
+
+      test(
+        'responds with 200 OK and lists redacted secrets for authorized workers',
+        () async {
+          final now = DateTime.now().toUtc();
+          await db.secretDao.insertOrUpdateSecret(
+            DriftSecret(
+              name: 'API_KEY',
+              teamId: 'team-123',
+              encryptedValue: 'super-secret-ciphertext',
+              createdAt: now,
+              updatedAt: now,
+            ),
+          );
+
+          final context = TestRequestContext(
+            path: '/teams/team-123/secrets',
+            method: HttpMethod.get,
+          );
+          context.provide<AppDatabase>(db);
+          context.provide<String?>('worker-1');
+          context.provide<Map<String, String>>(env);
+
+          final response = await index_route.onRequest(
+            context.context,
+            'team-123',
+          );
+          expect(response.statusCode, equals(HttpStatus.ok));
+        },
+      );
+    });
+
+    group('GET /teams/<id>/secrets/<name>', () {
+      test(
+        'responds with 200 OK and decrypted value for authorized worker',
+        () async {
+          await db
+              .into(db.teamMembers)
+              .insert(
+                TeamMembersCompanion.insert(
+                  teamId: 'team-123',
+                  userId: 'user-1',
+                ),
+              );
+
+          final postContext = TestRequestContext(
+            path: '/teams/team-123/secrets',
+            method: HttpMethod.post,
+            body: jsonEncode({
+              'name': 'DB_PASSWORD',
+              'value': 'secret-pass-99',
+            }),
+          );
+          postContext.provide<AppDatabase>(db);
+          postContext.provide<String?>('user-1');
+          postContext.provide<Map<String, String>>(env);
+          await index_route.onRequest(postContext.context, 'team-123');
+
+          final getContext = TestRequestContext(
+            path: '/teams/team-123/secrets/DB_PASSWORD',
+            method: HttpMethod.get,
+          );
+          getContext.provide<AppDatabase>(db);
+          getContext.provide<String?>('worker-1');
+          getContext.provide<Map<String, String>>(env);
+
+          final response = await name_route.onRequest(
+            getContext.context,
+            'team-123',
+            'DB_PASSWORD',
+          );
+          expect(response.statusCode, equals(HttpStatus.ok));
+
+          final body = await response.json() as Map<String, dynamic>;
+          expect(body['success'], isTrue);
+          expect(body['value'], equals('secret-pass-99'));
+        },
+      );
+
+      test('responds with 404 when secret is not found', () async {
+        final getContext = TestRequestContext(
+          path: '/teams/team-123/secrets/NOT_FOUND',
+          method: HttpMethod.get,
+        );
+        getContext.provide<AppDatabase>(db);
+        getContext.provide<String?>('worker-1');
+        getContext.provide<Map<String, String>>(env);
+
+        final response = await name_route.onRequest(
+          getContext.context,
+          'team-123',
+          'NOT_FOUND',
+        );
+        expect(response.statusCode, equals(HttpStatus.notFound));
+      });
+    });
+
+    group('DELETE /teams/<id>/secrets/<name>', () {
+      test('responds with 200 OK and deletes secret for member', () async {
+        await db
+            .into(db.teamMembers)
+            .insert(
+              TeamMembersCompanion.insert(
+                teamId: 'team-123',
+                userId: 'user-1',
+              ),
+            );
+
+        final now = DateTime.now().toUtc();
+        await db.secretDao.insertOrUpdateSecret(
+          DriftSecret(
+            name: 'API_KEY',
+            teamId: 'team-123',
+            encryptedValue: 'super-secret-ciphertext',
+            createdAt: now,
+            updatedAt: now,
+          ),
+        );
+
+        final context = TestRequestContext(
+          path: '/teams/team-123/secrets/API_KEY',
+          method: HttpMethod.delete,
+        );
+        context.provide<AppDatabase>(db);
+        context.provide<String?>('user-1');
+        context.provide<Map<String, String>>(env);
+
+        final response = await name_route.onRequest(
+          context.context,
+          'team-123',
+          'API_KEY',
+        );
+        expect(response.statusCode, equals(HttpStatus.ok));
+
+        final retrieved = await db.secretDao.getSecret('team-123', 'API_KEY');
+        expect(retrieved, isNull);
+      });
+    });
+  });
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * チームシークレット管理機能を追加しました。チームメンバーはシークレットの作成、一覧表示、取得、削除が可能になります。
  * シークレット値は安全に保護されます。

* **テスト**
  * シークレット管理機能の包括的なテストスイートを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->