### PR TITLE
refactor: migrate secret management from Firebase Firestore to custom API and add encryption key configuration

### DIFF
--- a/apps/dashboard/lib/secret_manager/secret_manager_provider.dart
+++ b/apps/dashboard/lib/secret_manager/secret_manager_provider.dart
@@ -1,7 +1,11 @@
+import 'dart:convert';
+
+import 'package:dashboard/auth/auth_provider.dart';
 import 'package:dashboard/firebase/firestore.dart';
 import 'package:dashboard/firebase/functions.dart';
 import 'package:dashboard/team/team_provider.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:http/http.dart' as http;
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'secret_manager_provider.freezed.dart';
@@ -10,41 +14,91 @@ part 'secret_manager_provider.g.dart';
 @riverpod
 class SecretManager extends _$SecretManager {
   @override
-  Stream<List<Secret>> build() {
-    return secretsStream();
+  Stream<List<Secret>> build() async* {
+    const serverUrl = String.fromEnvironment('OPENCI_SERVER_URL');
+    if (serverUrl.isEmpty) {
+      throw UnimplementedError('OPENCI_SERVER_URL is not set');
+    }
+
+    final teamId = ref.watch(teamStateProvider).value?.id;
+    if (teamId == null) {
+      yield const [];
+      return;
+    }
+
+    yield await _fetchSecrets(serverUrl, teamId);
+
+    yield* Stream.periodic(const Duration(seconds: 5)).asyncMap((_) async {
+      return _fetchSecrets(serverUrl, teamId);
+    });
   }
 
-  Stream<List<Secret>> secretsStream() {
-    final teamId = ref.watch(teamStateProvider).value?.id;
-    if (teamId == null) return Stream.value([]);
-    return firestore
-        .collection(secretsCollection)
-        .where('teamId', isEqualTo: teamId)
-        .orderBy('name')
-        .snapshots()
-        .map(
-          (result) => result.docs.map((doc) {
-            final data = doc.data();
-            return Secret(
-              id: doc.id,
-              name: data['name'] as String? ?? '',
-              teamId: data['teamId'] as String? ?? '',
-              createdAt: dateTimeFromFirestore(data['createdAt']),
-              updatedAt: dateTimeFromFirestore(data['updatedAt']),
-            );
-          }).toList(),
+  Future<List<Secret>> _fetchSecrets(String serverUrl, String teamId) async {
+    try {
+      final url = Uri.parse('$serverUrl/teams/$teamId/secrets');
+      final token = await ref.watch(firebaseIdTokenProvider.future);
+      if (token == null) return const [];
+
+      final response = await http
+          .get(
+            url,
+            headers: {
+              'Authorization': 'Bearer $token',
+            },
+          )
+          .timeout(const Duration(seconds: 5));
+
+      if (response.statusCode != 200) return const [];
+
+      final data = jsonDecode(response.body) as Map<String, dynamic>;
+      final list = data['secrets'] as List<dynamic>;
+
+      return list.map((item) {
+        final map = Map<String, dynamic>.from(item as Map);
+        final name = map['name'] as String? ?? '';
+        return Secret(
+          id: name, // UIとの互換性のために、idにはnameを割り当てます
+          name: name,
+          teamId: map['teamId'] as String? ?? '',
+          createdAt: DateTime.parse(map['createdAt'] as String).toLocal(),
+          updatedAt: DateTime.parse(map['updatedAt'] as String).toLocal(),
         );
+      }).toList();
+    } catch (e) {
+      return const [];
+    }
   }
 
   Future<void> addSecret(String name, String value) async {
-    final functions = firebaseFunctions;
+    const serverUrl = String.fromEnvironment('OPENCI_SERVER_URL');
+    if (serverUrl.isEmpty) throw StateError('OPENCI_SERVER_URL is not set');
+
     final teamId = ref.read(teamStateProvider).value?.id;
     if (teamId == null) throw StateError('team is not loaded yet');
-    await functions.httpsCallable('createSecretV1').call({
-      'name': name,
-      'value': value,
-      'teamId': teamId,
-    });
+
+    final url = Uri.parse('$serverUrl/teams/$teamId/secrets');
+    final token = await ref.read(firebaseIdTokenProvider.future);
+    if (token == null) throw StateError('User is not authenticated');
+
+    final response = await http
+        .post(
+          url,
+          headers: {
+            'Authorization': 'Bearer $token',
+            'Content-Type': 'application/json',
+          },
+          body: jsonEncode({
+            'name': name,
+            'value': value,
+          }),
+        )
+        .timeout(const Duration(seconds: 5));
+
+    if (response.statusCode != 200) {
+      throw StateError(
+        'Failed to add secret: ${response.statusCode} ${response.body}',
+      );
+    }
   }
 
   Future<void> updateSecret({
@@ -52,40 +106,80 @@ class SecretManager extends _$SecretManager {
     required String name,
     String? value,
   }) async {
-    final functions = firebaseFunctions;
-    final teamId = ref.read(teamStateProvider).value?.id;
-    if (teamId == null) throw StateError('team is not loaded yet');
-    await functions.httpsCallable('updateSecretV1').call({
-      'documentId': documentId,
-      'name': name,
-      if (value != null && value.isNotEmpty) 'value': value,
-      'teamId': teamId,
-    });
+    final nameChanged = documentId != name;
+
+    // 1. 名前が変更されており、新しい値が入力されていない場合は、古いシークレットの値を読み込む
+    String? effectiveValue = value;
+    if (nameChanged && (effectiveValue == null || effectiveValue.isEmpty)) {
+      effectiveValue = await readSecret(documentId: documentId);
+    }
+
+    // 2. 新しい名前（または同じ名前）でシークレットを新規追加・上書き更新
+    if (effectiveValue != null && effectiveValue.isNotEmpty) {
+      await addSecret(name, effectiveValue);
+    }
+
+    // 3. 名前が変更されていた場合は、古いシークレットを削除
+    if (nameChanged) {
+      await deleteSecret(documentId: documentId);
+    }
   }
 
   Future<String> readSecret({required String documentId}) async {
-    final functions = firebaseFunctions;
+    const serverUrl = String.fromEnvironment('OPENCI_SERVER_URL');
+    if (serverUrl.isEmpty) throw StateError('OPENCI_SERVER_URL is not set');
+
     final teamId = ref.read(teamStateProvider).value?.id;
     if (teamId == null) throw StateError('team is not loaded yet');
-    final result = await functions.httpsCallable('readSecretV1').call({
-      'documentId': documentId,
-      'teamId': teamId,
-    });
-    final data = result.data;
-    if (data is Map) {
-      return data['value'] as String? ?? '';
+
+    final url = Uri.parse('$serverUrl/teams/$teamId/secrets/$documentId');
+    final token = await ref.read(firebaseIdTokenProvider.future);
+    if (token == null) throw StateError('User is not authenticated');
+
+    final response = await http
+        .get(
+          url,
+          headers: {
+            'Authorization': 'Bearer $token',
+          },
+        )
+        .timeout(const Duration(seconds: 5));
+
+    if (response.statusCode != 200) {
+      throw StateError(
+        'Failed to read secret: ${response.statusCode} ${response.body}',
+      );
     }
-    return '';
+
+    final data = jsonDecode(response.body) as Map<String, dynamic>;
+    return data['value'] as String? ?? '';
   }
 
   Future<void> deleteSecret({required String documentId}) async {
-    final functions = firebaseFunctions;
+    const serverUrl = String.fromEnvironment('OPENCI_SERVER_URL');
+    if (serverUrl.isEmpty) throw StateError('OPENCI_SERVER_URL is not set');
+
     final teamId = ref.read(teamStateProvider).value?.id;
     if (teamId == null) throw StateError('team is not loaded yet');
-    await functions.httpsCallable('deleteSecretV1').call({
-      'documentId': documentId,
-      'teamId': teamId,
-    });
+
+    final url = Uri.parse('$serverUrl/teams/$teamId/secrets/$documentId');
+    final token = await ref.read(firebaseIdTokenProvider.future);
+    if (token == null) throw StateError('User is not authenticated');
+
+    final response = await http
+        .delete(
+          url,
+          headers: {
+            'Authorization': 'Bearer $token',
+          },
+        )
+        .timeout(const Duration(seconds: 5));
+
+    if (response.statusCode != 200) {
+      throw StateError(
+        'Failed to delete secret: ${response.statusCode} ${response.body}',
+      );
+    }
   }
 
   Future<void> generateCertificateKey() async {

--- a/apps/dashboard/lib/secret_manager/secret_manager_provider.g.dart
+++ b/apps/dashboard/lib/secret_manager/secret_manager_provider.g.dart
@@ -53,7 +53,7 @@ final class SecretManagerProvider
   SecretManager create() => SecretManager();
 }
 
-String _$secretManagerHash() => r'44d4c5d413e5cfdae1078ee9dc7d5c7db1a2b756';
+String _$secretManagerHash() => r'6b95de9476808188a6649ca574d2c8efb406c66f';
 
 abstract class _$SecretManager extends $StreamNotifier<List<Secret>> {
   Stream<List<Secret>> build();

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,7 @@ services:
       - GITHUB_APP_ID=${GITHUB_APP_ID}
       - GITHUB_PRIVATE_KEY_PATH=/app/credentials/github-private-key.pem
       - ALLOWED_WORKER_UIDS=${ALLOWED_WORKER_UIDS}
+      - SECRET_ENCRYPTION_KEY=${SECRET_ENCRYPTION_KEY}
     volumes:
       - ./firebase-service-account.json:/app/credentials/firebase-service-account.json:ro
       - ./github-private-key.pem:/app/credentials/github-private-key.pem:ro


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **シークレット管理の更新**
  * シークレット取得・管理プロセスを更新

* **環境設定**
  * 暗号化キーの環境変数設定に対応

<!-- end of auto-generated comment: release notes by coderabbit.ai -->