### PR TITLE
fix: conditionally include conclusion field in GitHub check run updates

### DIFF
--- a/apps/openci_server/lib/github/github_service.dart
+++ b/apps/openci_server/lib/github/github_service.dart
@@ -104,7 +104,8 @@ class GitHubService {
 
     final patchBody = <String, dynamic>{
       'status': runStatus,
-      'conclusion': conclusion,
+      if (runStatus == 'completed' && conclusion != null)
+        'conclusion': conclusion,
       if (runStatus == 'completed')
         'completed_at': DateTime.now().toUtc().toIso8601String(),
     };

--- a/apps/openci_server/test/github/github_service_test.dart
+++ b/apps/openci_server/test/github/github_service_test.dart
@@ -232,7 +232,7 @@ void main() {
 
             final body = jsonDecode(request.body) as Map<String, dynamic>;
             expect(body['status'], equals('in_progress'));
-            expect(body['conclusion'], isNull);
+            expect(body.containsKey('conclusion'), isFalse);
             expect(body.containsKey('completed_at'), isFalse);
 
             return http.Response(jsonEncode({'id': 99999}), 200);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * GitHub Check Run更新時の処理を改善し、結論フィールドが適切な条件下でのみ送信されるように修正しました。これにより、チェック実行ステータスが完了していない場合や結論が設定されていない場合の更新処理がより正確になります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->