### PR TITLE
feat: implement GET /builds/<id>/artifacts endpoint with mime-type resolution and presigned URL support

### DIFF
--- a/apps/openci_server/lib/request/mime.dart
+++ b/apps/openci_server/lib/request/mime.dart
@@ -1,0 +1,10 @@
+String getContentType(String filename) {
+  final ext = filename.split('.').last.toLowerCase();
+  return switch (ext) {
+    'ipa' => 'application/octet-stream',
+    'zip' => 'application/zip',
+    'xml' => 'application/xml',
+    'plist' => 'application/xml',
+    _ => 'application/octet-stream',
+  };
+}

--- a/apps/openci_server/routes/builds/[id]/artifacts.dart
+++ b/apps/openci_server/routes/builds/[id]/artifacts.dart
@@ -3,13 +3,68 @@ import 'dart:typed_data';
 
 import 'package:dart_frog/dart_frog.dart';
 import 'package:openci_server/request/error_handler.dart';
+import 'package:openci_server/request/mime.dart';
 import 'package:openci_server/storage.dart';
 
 Future<Response> onRequest(RequestContext context, String id) async {
   return switch (context.request.method) {
     HttpMethod.post => _post(context, id),
+    HttpMethod.get => _get(context, id),
     _ => Response(statusCode: HttpStatus.methodNotAllowed),
   };
+}
+
+Future<Response> _get(RequestContext context, String id) async {
+  try {
+    final storage = context.read<StorageManager>();
+    final queryParams = context.request.uri.queryParameters;
+    final name = queryParams['name'];
+
+    if (name == null || name.isEmpty) {
+      return Response.json(
+        statusCode: HttpStatus.badRequest,
+        body: {'success': false, 'error': 'name parameter is required'},
+      );
+    }
+
+    final objectName = 'artifacts/buildJobs/$id/$name';
+    final presignStr = queryParams['presign'];
+    final isPresign = presignStr == 'true';
+
+    if (isPresign) {
+      final url = await storage.getPresignedUrl(
+        objectName,
+        expires: const Duration(minutes: 15),
+      );
+      return Response.json(
+        body: {
+          'success': true,
+          'url': url,
+        },
+      );
+    } else {
+      final stream = await storage.downloadObject(objectName);
+      final contentType = getContentType(name);
+      return Response.stream(
+        body: stream,
+        headers: {
+          HttpHeaders.contentTypeHeader: contentType,
+        },
+      );
+    }
+  } catch (e, s) {
+    if (e.toString().contains('NoSuchKey') || e.toString().contains('404')) {
+      return Response.json(
+        statusCode: HttpStatus.notFound,
+        body: {'success': false, 'error': 'Artifact not found'},
+      );
+    }
+    return handleRouteException(
+      e,
+      s,
+      logMessage: 'Failed to download artifact for build $id',
+    );
+  }
 }
 
 Future<Response> _post(RequestContext context, String id) async {

--- a/apps/openci_server/test/request/mime_test.dart
+++ b/apps/openci_server/test/request/mime_test.dart
@@ -1,0 +1,18 @@
+import 'package:openci_server/request/mime.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('getContentType', () {
+    test('resolves correct mime-types for known extensions', () {
+      expect(getContentType('test.ipa'), equals('application/octet-stream'));
+      expect(getContentType('test.zip'), equals('application/zip'));
+      expect(getContentType('test.xml'), equals('application/xml'));
+      expect(getContentType('test.plist'), equals('application/xml'));
+      expect(
+        getContentType('test.unknown'),
+        equals('application/octet-stream'),
+      );
+      expect(getContentType('TEST.ZIP'), equals('application/zip'));
+    });
+  });
+}

--- a/apps/openci_server/test/routes/builds/[id]/artifacts_test.dart
+++ b/apps/openci_server/test/routes/builds/[id]/artifacts_test.dart
@@ -16,6 +16,7 @@ void main() {
 
   setUpAll(() {
     registerFallbackValue(Stream<Uint8List>.value(Uint8List(0)));
+    registerFallbackValue(Duration.zero);
   });
 
   setUp(() {
@@ -81,13 +82,117 @@ void main() {
         expect(body['error'], contains('name parameter is required'));
       },
     );
+  });
 
+  group('GET /builds/<id>/artifacts', () {
+    test(
+      'responds with 200 OK and file stream on successful download',
+      () async {
+        final dummyData = [100, 117, 109, 109, 121];
+        when(
+          () => storage.downloadObject(any()),
+        ).thenAnswer((_) async => Stream<List<int>>.value(dummyData));
+
+        final context = TestRequestContext(
+          path: '/builds/job-123/artifacts?name=app.ipa',
+          method: HttpMethod.get,
+        );
+        context.provide<StorageManager>(storage);
+
+        final response = await route.onRequest(context.context, 'job-123');
+
+        expect(response.statusCode, equals(HttpStatus.ok));
+        expect(
+          response.headers[HttpHeaders.contentTypeHeader],
+          equals('application/octet-stream'),
+        );
+
+        final responseBytes = await response.bytes().expand((b) => b).toList();
+        expect(responseBytes, equals(dummyData));
+
+        verify(
+          () => storage.downloadObject('artifacts/buildJobs/job-123/app.ipa'),
+        ).called(1);
+      },
+    );
+
+    test('responds with 200 OK and presigned url when presign=true', () async {
+      when(
+        () => storage.getPresignedUrl(any(), expires: any(named: 'expires')),
+      ).thenAnswer((_) async => 'https://signed-url.example.com');
+
+      final context = TestRequestContext(
+        path: '/builds/job-123/artifacts?name=app.ipa&presign=true',
+        method: HttpMethod.get,
+      );
+      context.provide<StorageManager>(storage);
+
+      final response = await route.onRequest(context.context, 'job-123');
+
+      expect(response.statusCode, equals(HttpStatus.ok));
+
+      final body = await response.json() as Map<String, dynamic>;
+      expect(body['success'], isTrue);
+      expect(body['url'], equals('https://signed-url.example.com'));
+
+      verify(
+        () => storage.getPresignedUrl(
+          'artifacts/buildJobs/job-123/app.ipa',
+          expires: const Duration(minutes: 15),
+        ),
+      ).called(1);
+    });
+
+    test(
+      'responds with 400 Bad Request when name query parameter is missing',
+      () async {
+        final context = TestRequestContext(
+          path: '/builds/job-123/artifacts',
+          method: HttpMethod.get,
+        );
+        context.provide<StorageManager>(storage);
+
+        final response = await route.onRequest(context.context, 'job-123');
+
+        expect(response.statusCode, equals(HttpStatus.badRequest));
+
+        final body = await response.json() as Map<String, dynamic>;
+        expect(body['success'], isFalse);
+        expect(body['error'], contains('name parameter is required'));
+      },
+    );
+
+    test(
+      'responds with 404 Not Found when storage throws NoSuchKey error',
+      () async {
+        when(() => storage.downloadObject(any())).thenThrow(
+          const HttpException('NoSuchKey: The specified key does not exist.'),
+        );
+
+        final context = TestRequestContext(
+          path: '/builds/job-123/artifacts?name=non-existent.ipa',
+          method: HttpMethod.get,
+        );
+        context.provide<StorageManager>(storage);
+
+        final response = await route.onRequest(context.context, 'job-123');
+
+        expect(response.statusCode, equals(HttpStatus.notFound));
+
+        final body = await response.json() as Map<String, dynamic>;
+        expect(body['success'], isFalse);
+        expect(body['error'], contains('Artifact not found'));
+      },
+    );
+  });
+
+  group('Unsupported methods', () {
     test(
       'responds with 405 Method Not Allowed for unsupported methods',
       () async {
         final context = TestRequestContext(
           path: '/builds/job-123/artifacts?name=app.ipa',
-          method: HttpMethod.get,
+          method: HttpMethod.put,
         );
         context.provide<StorageManager>(storage);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * アーティファクトの取得に対応し、ファイルのダウンロードまたは署名付きURLの取得を選べるようになりました。
  * ファイル拡張子に応じて適切な Content-Type が返されるようになりました。

* **Bug Fixes**
  * `name` が未指定の場合は、わかりやすいエラーを返すようになりました。
  * 対象ファイルが見つからない場合のエラー応答を改善しました。

* **Tests**
  * MIME type 判定と、アーティファクト取得の主要な成功・失敗ケースを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->