### PR TITLE
feat: implement shared_preferences Riverpod provider and inject via ProviderScope override

### DIFF
--- a/apps/dashboard/lib/main.dart
+++ b/apps/dashboard/lib/main.dart
@@ -3,12 +3,14 @@ import 'package:dashboard/firebase_options.dart';
 import 'package:dashboard/macos_updater_initializer.dart';
 import 'package:dashboard/revenue_cat/revenue_cat.dart';
 import 'package:dashboard/root.dart';
+import 'package:dashboard/shared_preferences_provider.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_web_plugins/url_strategy.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 Future<void> main() async {
   try {
@@ -42,7 +44,14 @@ Future<void> main() async {
 
     await initializeMacosUpdater();
 
-    final app = ProviderScope(child: Root());
+    final sharedPreferences = await SharedPreferences.getInstance();
+
+    final app = ProviderScope(
+      overrides: [
+        sharedPreferencesProvider.overrideWithValue(sharedPreferences),
+      ],
+      child: Root(),
+    );
 
     if (kDebugMode) {
       runApp(app);

--- a/apps/dashboard/lib/shared_preferences_provider.dart
+++ b/apps/dashboard/lib/shared_preferences_provider.dart
@@ -1,0 +1,11 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+part 'shared_preferences_provider.g.dart';
+
+@riverpod
+SharedPreferences sharedPreferences(Ref ref) {
+  throw UnimplementedError(
+    'sharedPreferencesProvider must be overridden in ProviderScope',
+  );
+}

--- a/apps/dashboard/lib/shared_preferences_provider.g.dart
+++ b/apps/dashboard/lib/shared_preferences_provider.g.dart
@@ -1,0 +1,57 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'shared_preferences_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(sharedPreferences)
+final sharedPreferencesProvider = SharedPreferencesProvider._();
+
+final class SharedPreferencesProvider
+    extends
+        $FunctionalProvider<
+          SharedPreferences,
+          SharedPreferences,
+          SharedPreferences
+        >
+    with $Provider<SharedPreferences> {
+  SharedPreferencesProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'sharedPreferencesProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$sharedPreferencesHash();
+
+  @$internal
+  @override
+  $ProviderElement<SharedPreferences> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  SharedPreferences create(Ref ref) {
+    return sharedPreferences(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(SharedPreferences value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<SharedPreferences>(value),
+    );
+  }
+}
+
+String _$sharedPreferencesHash() => r'e0d62a967dea277361f998f2b3253e0fa568eae4';


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 起動時の設定ストレージをアプリ全体で利用できるようになりました。

* **バグ修正**
  * 設定の読み込み・保存がより安定し、起動時の状態反映が改善されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->