### PR TITLE
feat: add SentryProviderObserver to ProviderScope to capture Riverpod provider errors

### DIFF
--- a/apps/dashboard/lib/main.dart
+++ b/apps/dashboard/lib/main.dart
@@ -4,6 +4,7 @@ import 'package:dashboard/macos_updater_initializer.dart';
 import 'package:dashboard/revenue_cat/revenue_cat.dart';
 import 'package:dashboard/root.dart';
 import 'package:dashboard/shared_preferences_provider.dart';
+import 'package:dashboard/utilities/sentry_provider_observer.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -47,6 +48,9 @@ Future<void> main() async {
     final sharedPreferences = await SharedPreferences.getInstance();
 
     final app = ProviderScope(
+      observers: [
+        SentryProviderObserver(),
+      ],
       overrides: [
         sharedPreferencesProvider.overrideWithValue(sharedPreferences),
       ],

--- a/apps/dashboard/lib/utilities/sentry_provider_observer.dart
+++ b/apps/dashboard/lib/utilities/sentry_provider_observer.dart
@@ -1,0 +1,23 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
+
+final class SentryProviderObserver extends ProviderObserver {
+  @override
+  void providerDidFail(
+    ProviderObserverContext context,
+    Object error,
+    StackTrace stackTrace,
+  ) {
+    Sentry.captureException(
+      error,
+      stackTrace: stackTrace,
+      withScope: (scope) {
+        scope.setTag(
+          'provider',
+          context.provider.name ?? context.provider.runtimeType.toString(),
+        );
+      },
+    );
+    super.providerDidFail(context, error, stackTrace);
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * アプリ内で発生した例外を自動収集し、障害調査に役立つ情報をより確実に記録するようになりました。
  * 状態管理まわりのエラー発生時に、関連する情報を付与して送信するよう改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->