### PR TITLE
feat: implement DeviceDao and GET /devices route to retrieve user-specific devices

### DIFF
--- a/apps/openci_server/lib/database.dart
+++ b/apps/openci_server/lib/database.dart
@@ -6,6 +6,7 @@ import 'package:openci_server/build_job/build_job.dart';
 import 'package:openci_server/build_job/build_job_dao.dart';
 import 'package:openci_server/build_run/build_run.dart';
 import 'package:openci_server/build_run/build_run_dao.dart';
+import 'package:openci_server/device/device_dao.dart';
 import 'package:openci_server/device/device_table.dart';
 import 'package:openci_server/processed_webhook/processed_webhook_table.dart';
 import 'package:openci_server/secret/secret_dao.dart';
@@ -41,6 +42,7 @@ part 'database.g.dart';
     WebhookTaskDao,
     SecretDao,
     WorkerHeartbeatDao,
+    DeviceDao,
   ],
 )
 class AppDatabase extends _$AppDatabase {

--- a/apps/openci_server/lib/database.g.dart
+++ b/apps/openci_server/lib/database.g.dart
@@ -5367,6 +5367,7 @@ abstract class _$AppDatabase extends GeneratedDatabase {
   late final WorkerHeartbeatDao workerHeartbeatDao = WorkerHeartbeatDao(
     this as AppDatabase,
   );
+  late final DeviceDao deviceDao = DeviceDao(this as AppDatabase);
   @override
   Iterable<TableInfo<Table, Object?>> get allTables =>
       allSchemaEntities.whereType<TableInfo<Table, Object?>>();

--- a/apps/openci_server/lib/device/device_dao.dart
+++ b/apps/openci_server/lib/device/device_dao.dart
@@ -1,0 +1,14 @@
+import 'package:drift/drift.dart';
+import 'package:openci_server/database.dart';
+import 'package:openci_server/device/device_table.dart';
+
+part 'device_dao.g.dart';
+
+@DriftAccessor(tables: [UserDevices])
+class DeviceDao extends DatabaseAccessor<AppDatabase> with _$DeviceDaoMixin {
+  DeviceDao(super.attachedDatabase);
+
+  Future<List<DriftUserDevice>> getDevicesByUserId(String uid) {
+    return (select(userDevices)..where((d) => d.userId.equals(uid))).get();
+  }
+}

--- a/apps/openci_server/lib/device/device_dao.g.dart
+++ b/apps/openci_server/lib/device/device_dao.g.dart
@@ -1,0 +1,19 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'device_dao.dart';
+
+// ignore_for_file: type=lint
+mixin _$DeviceDaoMixin on DatabaseAccessor<AppDatabase> {
+  $TeamsTable get teams => attachedDatabase.teams;
+  $UserDevicesTable get userDevices => attachedDatabase.userDevices;
+  DeviceDaoManager get managers => DeviceDaoManager(this);
+}
+
+class DeviceDaoManager {
+  final _$DeviceDaoMixin _db;
+  DeviceDaoManager(this._db);
+  $$TeamsTableTableManager get teams =>
+      $$TeamsTableTableManager(_db.attachedDatabase, _db.teams);
+  $$UserDevicesTableTableManager get userDevices =>
+      $$UserDevicesTableTableManager(_db.attachedDatabase, _db.userDevices);
+}

--- a/apps/openci_server/routes/devices/index.dart
+++ b/apps/openci_server/routes/devices/index.dart
@@ -1,0 +1,34 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:dart_frog/dart_frog.dart';
+import 'package:openci_server/database.dart';
+import 'package:openci_server/request/error_handler.dart';
+
+FutureOr<Response> onRequest(RequestContext context) {
+  return switch (context.request.method) {
+    HttpMethod.get => _get(context),
+    _ => Response(statusCode: HttpStatus.methodNotAllowed),
+  };
+}
+
+Future<Response> _get(RequestContext context) async {
+  try {
+    final db = context.read<AppDatabase>();
+    final uid = context.read<String?>();
+    if (uid == null) {
+      return Response.json(
+        statusCode: HttpStatus.unauthorized,
+        body: {'success': false, 'error': 'Authentication required'},
+      );
+    }
+
+    final devices = await db.deviceDao.getDevicesByUserId(uid);
+
+    return Response.json(
+      body: devices.map((d) => d.toJson()).toList(),
+    );
+  } catch (e, s) {
+    return handleRouteException(e, s, logMessage: 'Failed to get devices');
+  }
+}

--- a/apps/openci_server/test/db/device_dao_test.dart
+++ b/apps/openci_server/test/db/device_dao_test.dart
@@ -1,0 +1,91 @@
+import 'package:drift/native.dart';
+import 'package:openci_server/database.dart';
+import 'package:openci_server/device/device_table.dart';
+import 'package:test/test.dart';
+
+void main() {
+  late AppDatabase db;
+
+  setUp(() async {
+    db = AppDatabase(NativeDatabase.memory());
+
+    await db
+        .into(db.teams)
+        .insert(
+          DriftTeam(
+            id: 'team-123',
+            name: 'Test Team',
+            installationIds: const [],
+            aiEnabled: false,
+            runNumber: 1,
+            createdAt: DateTime.now().toUtc(),
+            updatedAt: DateTime.now().toUtc(),
+          ),
+        );
+  });
+
+  tearDown(() async {
+    await db.close();
+  });
+
+  group('DeviceDao Tests', () {
+    test(
+      'getDevicesByUserId retrieves only devices belonging to the specific user',
+      () async {
+        final now = DateTime.now().toUtc();
+
+        final device1 = DriftUserDevice(
+          id: 'device-1',
+          userId: 'user-123',
+          teamId: 'team-123',
+          udid: '00008101-000A12345678901E',
+          deviceProduct: 'iPhone 15 Pro',
+          deviceOsVersion: '17.4',
+          createdAt: now,
+          updatedAt: now,
+        );
+        final device2 = DriftUserDevice(
+          id: 'device-2',
+          userId: 'user-123',
+          teamId: 'team-123',
+          udid: '00008101-000B12345678901F',
+          deviceProduct: 'iPad Pro',
+          deviceOsVersion: '17.3',
+          createdAt: now,
+          updatedAt: now,
+        );
+        final otherUserDevice = DriftUserDevice(
+          id: 'device-3',
+          userId: 'user-other',
+          teamId: 'team-123',
+          udid: '00008101-000C12345678901G',
+          deviceProduct: 'iPhone SE',
+          deviceOsVersion: '16.0',
+          createdAt: now,
+          updatedAt: now,
+        );
+
+        await db.into(db.userDevices).insert(device1);
+        await db.into(db.userDevices).insert(device2);
+        await db.into(db.userDevices).insert(otherUserDevice);
+
+        final userDevices = await db.deviceDao.getDevicesByUserId('user-123');
+        expect(userDevices, hasLength(2));
+
+        final ids = userDevices.map((d) => d.id).toList();
+        expect(ids, containsAll(['device-1', 'device-2']));
+        expect(ids, isNot(contains('device-3')));
+      },
+    );
+
+    test(
+      'getDevicesByUserId returns empty list if user has no devices',
+      () async {
+        final userDevices = await db.deviceDao.getDevicesByUserId(
+          'user-unknown',
+        );
+        expect(userDevices, isEmpty);
+      },
+    );
+  });
+}

--- a/apps/openci_server/test/routes/devices/index_test.dart
+++ b/apps/openci_server/test/routes/devices/index_test.dart
@@ -1,0 +1,144 @@
+import 'dart:io';
+
+import 'package:dart_frog/dart_frog.dart';
+import 'package:dart_frog_test/dart_frog_test.dart';
+import 'package:drift/native.dart';
+import 'package:openci_server/database.dart';
+import 'package:openci_server/device/device_table.dart';
+import 'package:test/test.dart';
+
+import '../../../routes/devices/index.dart' as route;
+
+void main() {
+  late AppDatabase db;
+
+  setUp(() {
+    db = AppDatabase(NativeDatabase.memory());
+  });
+
+  tearDown(() async {
+    await db.close();
+  });
+
+  group('GET /devices (integration with memory DB)', () {
+    test(
+      'responds with 401 Unauthorized when unauthorized (uid is null)',
+      () async {
+        final context = TestRequestContext(
+          path: '/devices',
+          method: HttpMethod.get,
+        );
+
+        context.provide<AppDatabase>(db);
+        context.provide<String?>(null);
+
+        final response = await route.onRequest(context.context);
+
+        expect(response.statusCode, equals(HttpStatus.unauthorized));
+
+        final body = await response.json() as Map<String, dynamic>;
+        expect(body['success'], isFalse);
+        expect(body['error'], equals('Authentication required'));
+      },
+    );
+
+    test(
+      'responds with 200 and empty list when user has no registered devices',
+      () async {
+        final context = TestRequestContext(
+          path: '/devices',
+          method: HttpMethod.get,
+        );
+
+        context.provide<AppDatabase>(db);
+        context.provide<String?>('user-123');
+
+        final response = await route.onRequest(context.context);
+
+        expect(response.statusCode, equals(HttpStatus.ok));
+
+        final body = await response.json() as List<dynamic>;
+        expect(body, isEmpty);
+      },
+    );
+
+    test(
+      'responds with 200 and devices list when user has registered devices',
+      () async {
+        final now = DateTime.now().toUtc();
+
+        final team = DriftTeam(
+          id: 'team-123',
+          name: 'Test Team',
+          installationIds: const [],
+          aiEnabled: true,
+          runNumber: 1,
+          createdAt: now,
+          updatedAt: now,
+        );
+        await db.into(db.teams).insert(team);
+
+        final device1 = DriftUserDevice(
+          id: 'device-1',
+          userId: 'user-123',
+          teamId: 'team-123',
+          udid: '00008101-000A12345678901E',
+          deviceProduct: 'iPhone 15 Pro',
+          deviceOsVersion: '17.4',
+          createdAt: now,
+          updatedAt: now,
+        );
+        final device2 = DriftUserDevice(
+          id: 'device-2',
+          userId: 'user-123',
+          teamId: 'team-123',
+          udid: '00008101-000B12345678901F',
+          deviceProduct: 'iPad Pro',
+          deviceOsVersion: '17.3',
+          createdAt: now,
+          updatedAt: now,
+        );
+        final otherUserDevice = DriftUserDevice(
+          id: 'device-3',
+          userId: 'user-other',
+          teamId: 'team-123',
+          udid: '00008101-000C12345678901G',
+          deviceProduct: 'iPhone SE',
+          deviceOsVersion: '16.0',
+          createdAt: now,
+          updatedAt: now,
+        );
+
+        await db.into(db.userDevices).insert(device1);
+        await db.into(db.userDevices).insert(device2);
+        await db.into(db.userDevices).insert(otherUserDevice);
+
+        final context = TestRequestContext(
+          path: '/devices',
+          method: HttpMethod.get,
+        );
+
+        context.provide<AppDatabase>(db);
+        context.provide<String?>('user-123');
+
+        final response = await route.onRequest(context.context);
+
+        expect(response.statusCode, equals(HttpStatus.ok));
+
+        final body = await response.json() as List<dynamic>;
+        expect(body, hasLength(2));
+
+        final resultIds = body.map((d) => d['id'] as String).toList();
+        expect(resultIds, containsAll(['device-1', 'device-2']));
+        expect(resultIds, isNot(contains('device-3')));
+
+        final device1Data = body.firstWhere((d) => d['id'] == 'device-1');
+        expect(device1Data['userId'], equals('user-123'));
+        expect(device1Data['teamId'], equals('team-123'));
+        expect(device1Data['udid'], equals('00008101-000A12345678901E'));
+        expect(device1Data['deviceProduct'], equals('iPhone 15 Pro'));
+        expect(device1Data['deviceOsVersion'], equals('17.4'));
+      },
+    );
+  });
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * デバイス一覧を取得するAPIが追加され、認証済みユーザーの端末情報を返せるようになりました。
  * データベースからユーザーごとのデバイスを取得する機能が追加されました。

* **テスト**
  * デバイス取得処理の単体テストを追加しました。
  * デバイス一覧APIの統合テストを追加し、未認証・空結果・取得成功のケースを確認しています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->