### PR TITLE
feat: make deviceProduct and deviceOsVersion non-nullable and add helper methods to DeviceDao

### DIFF
--- a/apps/openci_server/lib/database.dart
+++ b/apps/openci_server/lib/database.dart
@@ -49,7 +49,7 @@ class AppDatabase extends _$AppDatabase {
   AppDatabase([QueryExecutor? executor]) : super(executor ?? _openConnection());
 
   @override
-  int get schemaVersion => 13;
+  int get schemaVersion => 14;
 
   @override
   MigrationStrategy get migration {
@@ -69,6 +69,20 @@ class AppDatabase extends _$AppDatabase {
         }
         if (from < 13) {
           await m.createTable(userDevices);
+        }
+        if (from < 14) {
+          await customStatement(
+            "UPDATE user_devices SET device_product = 'Unknown' WHERE device_product IS NULL;",
+          );
+          await customStatement(
+            "UPDATE user_devices SET device_os_version = 'Unknown' WHERE device_os_version IS NULL;",
+          );
+          await customStatement(
+            "ALTER TABLE user_devices ALTER COLUMN device_product SET NOT NULL;",
+          );
+          await customStatement(
+            "ALTER TABLE user_devices ALTER COLUMN device_os_version SET NOT NULL;",
+          );
         }
       },
     );

--- a/apps/openci_server/lib/database.dart
+++ b/apps/openci_server/lib/database.dart
@@ -49,7 +49,7 @@ class AppDatabase extends _$AppDatabase {
   AppDatabase([QueryExecutor? executor]) : super(executor ?? _openConnection());
 
   @override
-  int get schemaVersion => 14;
+  int get schemaVersion => 15;
 
   @override
   MigrationStrategy get migration {
@@ -82,6 +82,11 @@ class AppDatabase extends _$AppDatabase {
           );
           await customStatement(
             "ALTER TABLE user_devices ALTER COLUMN device_os_version SET NOT NULL;",
+          );
+        }
+        if (from < 15) {
+          await customStatement(
+            'CREATE UNIQUE INDEX IF NOT EXISTS user_devices_user_id_team_id_udid_idx ON user_devices (user_id, team_id, udid);',
           );
         }
       },

--- a/apps/openci_server/lib/database.g.dart
+++ b/apps/openci_server/lib/database.g.dart
@@ -5033,9 +5033,9 @@ class $UserDevicesTable extends UserDevices
   late final GeneratedColumn<String> deviceProduct = GeneratedColumn<String>(
     'device_product',
     aliasedName,
-    true,
+    false,
     type: DriftSqlType.string,
-    requiredDuringInsert: false,
+    requiredDuringInsert: true,
   );
   static const VerificationMeta _deviceOsVersionMeta = const VerificationMeta(
     'deviceOsVersion',
@@ -5044,9 +5044,9 @@ class $UserDevicesTable extends UserDevices
   late final GeneratedColumn<String> deviceOsVersion = GeneratedColumn<String>(
     'device_os_version',
     aliasedName,
-    true,
+    false,
     type: DriftSqlType.string,
-    requiredDuringInsert: false,
+    requiredDuringInsert: true,
   );
   static const VerificationMeta _createdAtMeta = const VerificationMeta(
     'createdAt',
@@ -5130,6 +5130,8 @@ class $UserDevicesTable extends UserDevices
           _deviceProductMeta,
         ),
       );
+    } else if (isInserting) {
+      context.missing(_deviceProductMeta);
     }
     if (data.containsKey('device_os_version')) {
       context.handle(
@@ -5139,6 +5141,8 @@ class $UserDevicesTable extends UserDevices
           _deviceOsVersionMeta,
         ),
       );
+    } else if (isInserting) {
+      context.missing(_deviceOsVersionMeta);
     }
     if (data.containsKey('created_at')) {
       context.handle(
@@ -5184,11 +5188,11 @@ class $UserDevicesTable extends UserDevices
       deviceProduct: attachedDatabase.typeMapping.read(
         DriftSqlType.string,
         data['${effectivePrefix}device_product'],
-      ),
+      )!,
       deviceOsVersion: attachedDatabase.typeMapping.read(
         DriftSqlType.string,
         data['${effectivePrefix}device_os_version'],
-      ),
+      )!,
       createdAt: attachedDatabase.typeMapping.read(
         DriftSqlType.dateTime,
         data['${effectivePrefix}created_at'],
@@ -5211,8 +5215,8 @@ class UserDevicesCompanion extends UpdateCompanion<DriftUserDevice> {
   final Value<String> userId;
   final Value<String> teamId;
   final Value<String> udid;
-  final Value<String?> deviceProduct;
-  final Value<String?> deviceOsVersion;
+  final Value<String> deviceProduct;
+  final Value<String> deviceOsVersion;
   final Value<DateTime> createdAt;
   final Value<DateTime> updatedAt;
   final Value<int> rowid;
@@ -5232,8 +5236,8 @@ class UserDevicesCompanion extends UpdateCompanion<DriftUserDevice> {
     required String userId,
     required String teamId,
     required String udid,
-    this.deviceProduct = const Value.absent(),
-    this.deviceOsVersion = const Value.absent(),
+    required String deviceProduct,
+    required String deviceOsVersion,
     required DateTime createdAt,
     required DateTime updatedAt,
     this.rowid = const Value.absent(),
@@ -5241,6 +5245,8 @@ class UserDevicesCompanion extends UpdateCompanion<DriftUserDevice> {
        userId = Value(userId),
        teamId = Value(teamId),
        udid = Value(udid),
+       deviceProduct = Value(deviceProduct),
+       deviceOsVersion = Value(deviceOsVersion),
        createdAt = Value(createdAt),
        updatedAt = Value(updatedAt);
   static Insertable<DriftUserDevice> custom({
@@ -5272,8 +5278,8 @@ class UserDevicesCompanion extends UpdateCompanion<DriftUserDevice> {
     Value<String>? userId,
     Value<String>? teamId,
     Value<String>? udid,
-    Value<String?>? deviceProduct,
-    Value<String?>? deviceOsVersion,
+    Value<String>? deviceProduct,
+    Value<String>? deviceOsVersion,
     Value<DateTime>? createdAt,
     Value<DateTime>? updatedAt,
     Value<int>? rowid,
@@ -8693,8 +8699,8 @@ typedef $$UserDevicesTableCreateCompanionBuilder =
       required String userId,
       required String teamId,
       required String udid,
-      Value<String?> deviceProduct,
-      Value<String?> deviceOsVersion,
+      required String deviceProduct,
+      required String deviceOsVersion,
       required DateTime createdAt,
       required DateTime updatedAt,
       Value<int> rowid,
@@ -8705,8 +8711,8 @@ typedef $$UserDevicesTableUpdateCompanionBuilder =
       Value<String> userId,
       Value<String> teamId,
       Value<String> udid,
-      Value<String?> deviceProduct,
-      Value<String?> deviceOsVersion,
+      Value<String> deviceProduct,
+      Value<String> deviceOsVersion,
       Value<DateTime> createdAt,
       Value<DateTime> updatedAt,
       Value<int> rowid,
@@ -8961,8 +8967,8 @@ class $$UserDevicesTableTableManager
                 Value<String> userId = const Value.absent(),
                 Value<String> teamId = const Value.absent(),
                 Value<String> udid = const Value.absent(),
-                Value<String?> deviceProduct = const Value.absent(),
-                Value<String?> deviceOsVersion = const Value.absent(),
+                Value<String> deviceProduct = const Value.absent(),
+                Value<String> deviceOsVersion = const Value.absent(),
                 Value<DateTime> createdAt = const Value.absent(),
                 Value<DateTime> updatedAt = const Value.absent(),
                 Value<int> rowid = const Value.absent(),
@@ -8983,8 +8989,8 @@ class $$UserDevicesTableTableManager
                 required String userId,
                 required String teamId,
                 required String udid,
-                Value<String?> deviceProduct = const Value.absent(),
-                Value<String?> deviceOsVersion = const Value.absent(),
+                required String deviceProduct,
+                required String deviceOsVersion,
                 required DateTime createdAt,
                 required DateTime updatedAt,
                 Value<int> rowid = const Value.absent(),

--- a/apps/openci_server/lib/database.g.dart
+++ b/apps/openci_server/lib/database.g.dart
@@ -5166,6 +5166,10 @@ class $UserDevicesTable extends UserDevices
   @override
   Set<GeneratedColumn> get $primaryKey => {id};
   @override
+  List<Set<GeneratedColumn>> get uniqueKeys => [
+    {userId, teamId, udid},
+  ];
+  @override
   DriftUserDevice map(Map<String, dynamic> data, {String? tablePrefix}) {
     final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
     return DriftUserDevice(

--- a/apps/openci_server/lib/device/device_dao.dart
+++ b/apps/openci_server/lib/device/device_dao.dart
@@ -82,7 +82,12 @@ class DeviceDao extends DatabaseAccessor<AppDatabase> with _$DeviceDaoMixin {
       createdAt: existing.createdAt,
       updatedAt: now,
     );
-    await update(userDevices).replace(updated);
+    final success = await update(userDevices).replace(updated);
+    if (!success) {
+      throw StateError(
+        'Failed to update device: device with id ${existing.id} not found.',
+      );
+    }
     return updated;
   }
 }

--- a/apps/openci_server/lib/device/device_dao.dart
+++ b/apps/openci_server/lib/device/device_dao.dart
@@ -40,6 +40,17 @@ class DeviceDao extends DatabaseAccessor<AppDatabase> with _$DeviceDaoMixin {
     required String deviceProduct,
     required String deviceOsVersion,
   }) async {
+    final existing = await findDevice(
+      userId: userId,
+      teamId: teamId,
+      udid: udid,
+    );
+    if (existing != null) {
+      throw DeviceAlreadyExistsException(
+        'Device with UDID $udid is already registered for this user and team.',
+      );
+    }
+
     final now = DateTime.now().toUtc();
     final newDevice = DriftUserDevice(
       id: const Uuid().v4(),
@@ -74,4 +85,12 @@ class DeviceDao extends DatabaseAccessor<AppDatabase> with _$DeviceDaoMixin {
     await update(userDevices).replace(updated);
     return updated;
   }
+}
+
+class DeviceAlreadyExistsException implements Exception {
+  final String message;
+  DeviceAlreadyExistsException(this.message);
+
+  @override
+  String toString() => 'DeviceAlreadyExistsException: $message';
 }

--- a/apps/openci_server/lib/device/device_dao.dart
+++ b/apps/openci_server/lib/device/device_dao.dart
@@ -1,6 +1,7 @@
 import 'package:drift/drift.dart';
 import 'package:openci_server/database.dart';
 import 'package:openci_server/device/device_table.dart';
+import 'package:uuid/uuid.dart';
 
 part 'device_dao.g.dart';
 
@@ -16,5 +17,61 @@ class DeviceDao extends DatabaseAccessor<AppDatabase> with _$DeviceDaoMixin {
     return (delete(
       userDevices,
     )..where((d) => d.id.equals(id) & d.userId.equals(userId))).go();
+  }
+
+  Future<DriftUserDevice?> findDevice({
+    required String userId,
+    required String teamId,
+    required String udid,
+  }) {
+    return (select(userDevices)..where(
+          (d) =>
+              d.userId.equals(userId) &
+              d.teamId.equals(teamId) &
+              d.udid.equals(udid),
+        ))
+        .getSingleOrNull();
+  }
+
+  Future<DriftUserDevice> createDevice({
+    required String userId,
+    required String teamId,
+    required String udid,
+    required String deviceProduct,
+    required String deviceOsVersion,
+  }) async {
+    final now = DateTime.now().toUtc();
+    final newDevice = DriftUserDevice(
+      id: const Uuid().v4(),
+      userId: userId,
+      teamId: teamId,
+      udid: udid,
+      deviceProduct: deviceProduct,
+      deviceOsVersion: deviceOsVersion,
+      createdAt: now,
+      updatedAt: now,
+    );
+    await into(userDevices).insert(newDevice);
+    return newDevice;
+  }
+
+  Future<DriftUserDevice> updateDevice({
+    required DriftUserDevice existing,
+    required String deviceProduct,
+    required String deviceOsVersion,
+  }) async {
+    final now = DateTime.now().toUtc();
+    final updated = DriftUserDevice(
+      id: existing.id,
+      userId: existing.userId,
+      teamId: existing.teamId,
+      udid: existing.udid,
+      deviceProduct: deviceProduct,
+      deviceOsVersion: deviceOsVersion,
+      createdAt: existing.createdAt,
+      updatedAt: now,
+    );
+    await update(userDevices).replace(updated);
+    return updated;
   }
 }

--- a/apps/openci_server/lib/device/device_table.dart
+++ b/apps/openci_server/lib/device/device_table.dart
@@ -15,6 +15,11 @@ class UserDevices extends Table {
 
   @override
   Set<Column> get primaryKey => {id};
+
+  @override
+  List<Set<Column>> get uniqueKeys => [
+    {userId, teamId, udid},
+  ];
 }
 
 class DriftUserDevice implements Insertable<DriftUserDevice> {

--- a/apps/openci_server/lib/device/device_table.dart
+++ b/apps/openci_server/lib/device/device_table.dart
@@ -8,8 +8,8 @@ class UserDevices extends Table {
   TextColumn get teamId =>
       text().references(Teams, #id, onDelete: KeyAction.cascade)();
   TextColumn get udid => text().withLength(min: 25, max: 40)();
-  TextColumn get deviceProduct => text().nullable()();
-  TextColumn get deviceOsVersion => text().nullable()();
+  TextColumn get deviceProduct => text()();
+  TextColumn get deviceOsVersion => text()();
   DateTimeColumn get createdAt => dateTime()();
   DateTimeColumn get updatedAt => dateTime()();
 
@@ -22,8 +22,8 @@ class DriftUserDevice implements Insertable<DriftUserDevice> {
   final String userId;
   final String teamId;
   final String udid;
-  final String? deviceProduct;
-  final String? deviceOsVersion;
+  final String deviceProduct;
+  final String deviceOsVersion;
   final DateTime createdAt;
   final DateTime updatedAt;
 
@@ -32,8 +32,8 @@ class DriftUserDevice implements Insertable<DriftUserDevice> {
     required this.userId,
     required this.teamId,
     required this.udid,
-    this.deviceProduct,
-    this.deviceOsVersion,
+    required this.deviceProduct,
+    required this.deviceOsVersion,
     required this.createdAt,
     required this.updatedAt,
   });

--- a/apps/openci_server/test/db/device_dao_test.dart
+++ b/apps/openci_server/test/db/device_dao_test.dart
@@ -101,6 +101,8 @@ void main() {
             userId: 'user-123',
             teamId: 'team-123',
             udid: '00008101-000A12345678901E',
+            deviceProduct: 'iPhone 15 Pro',
+            deviceOsVersion: '17.4',
             createdAt: now,
             updatedAt: now,
           );
@@ -127,6 +129,8 @@ void main() {
             userId: 'user-123',
             teamId: 'team-123',
             udid: '00008101-000A12345678901E',
+            deviceProduct: 'iPhone 15 Pro',
+            deviceOsVersion: '17.4',
             createdAt: now,
             updatedAt: now,
           );
@@ -142,6 +146,144 @@ void main() {
           expect(devices, hasLength(1));
         },
       );
+    });
+
+    group('findDevice', () {
+      test('returns the device if it exists', () async {
+        final now = DateTime.now().toUtc();
+        final device = DriftUserDevice(
+          id: 'device-1',
+          userId: 'user-123',
+          teamId: 'team-123',
+          udid: '00008101-000A12345678901E',
+          deviceProduct: 'iPhone 15 Pro',
+          deviceOsVersion: '17.4',
+          createdAt: now,
+          updatedAt: now,
+        );
+        await db.into(db.userDevices).insert(device);
+
+        final found = await db.deviceDao.findDevice(
+          userId: 'user-123',
+          teamId: 'team-123',
+          udid: '00008101-000A12345678901E',
+        );
+
+        expect(found, isNotNull);
+        expect(found!.id, equals('device-1'));
+      });
+
+      test('returns null if the device does not exist', () async {
+        final found = await db.deviceDao.findDevice(
+          userId: 'user-123',
+          teamId: 'team-123',
+          udid: 'unknown-udid',
+        );
+
+        expect(found, isNull);
+      });
+
+      test(
+        'returns null if the device with different criteria does not exist but other devices do',
+        () async {
+          final now = DateTime.now().toUtc();
+          final device = DriftUserDevice(
+            id: 'device-1',
+            userId: 'user-123',
+            teamId: 'team-123',
+            udid: '00008101-000A12345678901E',
+            deviceProduct: 'iPhone 15 Pro',
+            deviceOsVersion: '17.4',
+            createdAt: now,
+            updatedAt: now,
+          );
+          await db.into(db.userDevices).insert(device);
+
+          final foundByUdid = await db.deviceDao.findDevice(
+            userId: 'user-123',
+            teamId: 'team-123',
+            udid: '00008101-000B12345678901F',
+          );
+          expect(foundByUdid, isNull);
+
+          final foundByUserId = await db.deviceDao.findDevice(
+            userId: 'user-456',
+            teamId: 'team-123',
+            udid: '00008101-000A12345678901E',
+          );
+          expect(foundByUserId, isNull);
+
+          final foundByTeamId = await db.deviceDao.findDevice(
+            userId: 'user-123',
+            teamId: 'team-456',
+            udid: '00008101-000A12345678901E',
+          );
+          expect(foundByTeamId, isNull);
+        },
+      );
+    });
+
+    group('createDevice', () {
+      test('successfully inserts a new device', () async {
+        final device = await db.deviceDao.createDevice(
+          userId: 'user-123',
+          teamId: 'team-123',
+          udid: '00008101-000A12345678901E',
+          deviceProduct: 'iPhone 15 Pro',
+          deviceOsVersion: '17.4',
+        );
+
+        expect(device.id, isNotEmpty);
+        expect(device.userId, equals('user-123'));
+        expect(device.teamId, equals('team-123'));
+        expect(device.udid, equals('00008101-000A12345678901E'));
+        expect(device.deviceProduct, equals('iPhone 15 Pro'));
+        expect(device.deviceOsVersion, equals('17.4'));
+
+        final found = await db.deviceDao.findDevice(
+          userId: 'user-123',
+          teamId: 'team-123',
+          udid: '00008101-000A12345678901E',
+        );
+        expect(found, isNotNull);
+        expect(found!.id, equals(device.id));
+      });
+    });
+
+    group('updateDevice', () {
+      test('successfully updates device fields', () async {
+        final now = DateTime.now().toUtc();
+        final existing = DriftUserDevice(
+          id: 'existing-id',
+          userId: 'user-123',
+          teamId: 'team-123',
+          udid: '00008101-000A12345678901E',
+          deviceProduct: 'iPhone 14',
+          deviceOsVersion: '16.5',
+          createdAt: now.subtract(const Duration(days: 1)),
+          updatedAt: now.subtract(const Duration(days: 1)),
+        );
+        await db.into(db.userDevices).insert(existing);
+
+        final updated = await db.deviceDao.updateDevice(
+          existing: existing,
+          deviceProduct: 'iPhone 15 Pro',
+          deviceOsVersion: '17.4',
+        );
+
+        expect(updated.id, equals('existing-id'));
+        expect(updated.deviceProduct, equals('iPhone 15 Pro'));
+        expect(updated.deviceOsVersion, equals('17.4'));
+
+        final found = await db.deviceDao.findDevice(
+          userId: 'user-123',
+          teamId: 'team-123',
+          udid: '00008101-000A12345678901E',
+        );
+        expect(found, isNotNull);
+        expect(found!.deviceProduct, equals('iPhone 15 Pro'));
+        expect(found.deviceOsVersion, equals('17.4'));
+      });
     });
   });
 }

--- a/apps/openci_server/test/db/device_dao_test.dart
+++ b/apps/openci_server/test/db/device_dao_test.dart
@@ -333,6 +333,32 @@ void main() {
         expect(found!.deviceProduct, equals('iPhone 15 Pro'));
         expect(found.deviceOsVersion, equals('17.4'));
       });
+
+      test(
+        'throws StateError when trying to update a non-existent device',
+        () async {
+          final now = DateTime.now().toUtc();
+          final nonExistent = DriftUserDevice(
+            id: 'non-existent-id',
+            userId: 'user-123',
+            teamId: 'team-123',
+            udid: '00008101-000A12345678901E',
+            deviceProduct: 'iPhone 14',
+            deviceOsVersion: '16.5',
+            createdAt: now,
+            updatedAt: now,
+          );
+
+          expect(
+            () => db.deviceDao.updateDevice(
+              existing: nonExistent,
+              deviceProduct: 'iPhone 15 Pro',
+              deviceOsVersion: '17.4',
+            ),
+            throwsA(isA<StateError>()),
+          );
+        },
+      );
     });
   });
 }

--- a/apps/openci_server/test/db/device_dao_test.dart
+++ b/apps/openci_server/test/db/device_dao_test.dart
@@ -1,5 +1,6 @@
 import 'package:drift/native.dart';
 import 'package:openci_server/database.dart';
+import 'package:openci_server/device/device_dao.dart';
 import 'package:openci_server/device/device_table.dart';
 import 'package:test/test.dart';
 
@@ -248,6 +249,54 @@ void main() {
         expect(found, isNotNull);
         expect(found!.id, equals(device.id));
       });
+
+      test(
+        'throws DeviceAlreadyExistsException when registering a device with same userId, teamId, and udid',
+        () async {
+          await db.deviceDao.createDevice(
+            userId: 'user-123',
+            teamId: 'team-123',
+            udid: '00008101-000A12345678901E',
+            deviceProduct: 'iPhone 15 Pro',
+            deviceOsVersion: '17.4',
+          );
+
+          expect(
+            () => db.deviceDao.createDevice(
+              userId: 'user-123',
+              teamId: 'team-123',
+              udid: '00008101-000A12345678901E',
+              deviceProduct: 'iPhone 15 Pro',
+              deviceOsVersion: '17.4',
+            ),
+            throwsA(isA<DeviceAlreadyExistsException>()),
+          );
+        },
+      );
+
+      test(
+        'throws DeviceAlreadyExistsException when registering a device with same userId, teamId, and udid but different OS version',
+        () async {
+          await db.deviceDao.createDevice(
+            userId: 'user-123',
+            teamId: 'team-123',
+            udid: '00008101-000A12345678901E',
+            deviceProduct: 'iPhone 15 Pro',
+            deviceOsVersion: '17.4',
+          );
+
+          expect(
+            () => db.deviceDao.createDevice(
+              userId: 'user-123',
+              teamId: 'team-123',
+              udid: '00008101-000A12345678901E',
+              deviceProduct: 'iPhone 15 Pro',
+              deviceOsVersion: '18.0',
+            ),
+            throwsA(isA<DeviceAlreadyExistsException>()),
+          );
+        },
+      );
     });
 
     group('updateDevice', () {

--- a/apps/openci_server/test/routes/devices/[id]_test.dart
+++ b/apps/openci_server/test/routes/devices/[id]_test.dart
@@ -84,6 +84,8 @@ void main() {
           userId: 'user-other',
           teamId: 'team-123',
           udid: '00008101-000A12345678901E',
+          deviceProduct: 'iPhone 15 Pro',
+          deviceOsVersion: '17.4',
           createdAt: now,
           updatedAt: now,
         );
@@ -128,6 +130,8 @@ void main() {
           userId: 'user-123',
           teamId: 'team-123',
           udid: '00008101-000A12345678901E',
+          deviceProduct: 'iPhone 15 Pro',
+          deviceOsVersion: '17.4',
           createdAt: now,
           updatedAt: now,
         );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * デバイスの 取得 / 作成 / 更新 に対応し、条件に一致する デバイス を 確認 できます。存在しない 場合 は null になります。
  * 登録時に 自動で デバイスID を発行し、作成・更新日時 も適切に 記録します。
* **不具合修正 / 仕様変更**
  * 製品名 と OSバージョン を 必須化 し、未指定の 既存データは 自動補完 されます。
  * 同一の識別情報での 重複登録 を 受付できないようにしました。
* **テスト**
  * デバイス関連 API と DAO の 結果 を 追加検証 しました。削除 API の テストデータにも 製品名とOSバージョンを 追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->