### PR TITLE
feat: implement device registration route and add integration tests

### DIFF
--- a/apps/openci_server/routes/devices/register.dart
+++ b/apps/openci_server/routes/devices/register.dart
@@ -24,20 +24,42 @@ Future<Response> _post(RequestContext context) async {
       );
     }
 
-    final body = await context.request.json() as Map<String, dynamic>;
-    final teamId = body['teamId'] as String?;
-    final udid = body['udid'] as String?;
-    final deviceProduct = body['deviceProduct'] as String?;
-    final deviceOsVersion = body['deviceOsVersion'] as String?;
+    late final Map<String, dynamic> body;
+    try {
+      final raw = await context.request.json();
+      if (raw is! Map<String, dynamic>) {
+        return Response.json(
+          statusCode: HttpStatus.badRequest,
+          body: {
+            'success': false,
+            'error': 'Request body must be a JSON object',
+          },
+        );
+      }
+      body = raw;
+    } on FormatException {
+      return Response.json(
+        statusCode: HttpStatus.badRequest,
+        body: {
+          'success': false,
+          'error': 'Malformed JSON body',
+        },
+      );
+    }
 
-    if (teamId == null ||
-        teamId.isEmpty ||
-        udid == null ||
-        udid.isEmpty ||
-        deviceProduct == null ||
-        deviceProduct.isEmpty ||
-        deviceOsVersion == null ||
-        deviceOsVersion.isEmpty) {
+    final teamId = body['teamId'];
+    final udid = body['udid'];
+    final deviceProduct = body['deviceProduct'];
+    final deviceOsVersion = body['deviceOsVersion'];
+
+    if (teamId is! String ||
+        udid is! String ||
+        deviceProduct is! String ||
+        deviceOsVersion is! String ||
+        teamId.trim().isEmpty ||
+        udid.trim().isEmpty ||
+        deviceProduct.trim().isEmpty ||
+        deviceOsVersion.trim().isEmpty) {
       return Response.json(
         statusCode: HttpStatus.badRequest,
         body: {

--- a/apps/openci_server/routes/devices/register.dart
+++ b/apps/openci_server/routes/devices/register.dart
@@ -1,0 +1,81 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:dart_frog/dart_frog.dart';
+import 'package:openci_server/database.dart';
+import 'package:openci_server/device/device_table.dart';
+import 'package:openci_server/request/error_handler.dart';
+
+FutureOr<Response> onRequest(RequestContext context) {
+  return switch (context.request.method) {
+    HttpMethod.post => _post(context),
+    _ => Response(statusCode: HttpStatus.methodNotAllowed),
+  };
+}
+
+Future<Response> _post(RequestContext context) async {
+  try {
+    final db = context.read<AppDatabase>();
+    final uid = context.read<String?>();
+    if (uid == null) {
+      return Response.json(
+        statusCode: HttpStatus.unauthorized,
+        body: {'success': false, 'error': 'Authentication required'},
+      );
+    }
+
+    final body = await context.request.json() as Map<String, dynamic>;
+    final teamId = body['teamId'] as String?;
+    final udid = body['udid'] as String?;
+    final deviceProduct = body['deviceProduct'] as String?;
+    final deviceOsVersion = body['deviceOsVersion'] as String?;
+
+    if (teamId == null ||
+        teamId.isEmpty ||
+        udid == null ||
+        udid.isEmpty ||
+        deviceProduct == null ||
+        deviceProduct.isEmpty ||
+        deviceOsVersion == null ||
+        deviceOsVersion.isEmpty) {
+      return Response.json(
+        statusCode: HttpStatus.badRequest,
+        body: {
+          'success': false,
+          'error':
+              'Missing or empty required parameters: '
+              'teamId, udid, deviceProduct, deviceOsVersion',
+        },
+      );
+    }
+
+    final existing = await db.deviceDao.findDevice(
+      userId: uid,
+      teamId: teamId,
+      udid: udid,
+    );
+
+    final DriftUserDevice device;
+    if (existing != null) {
+      device = await db.deviceDao.updateDevice(
+        existing: existing,
+        deviceProduct: deviceProduct,
+        deviceOsVersion: deviceOsVersion,
+      );
+    } else {
+      device = await db.deviceDao.createDevice(
+        userId: uid,
+        teamId: teamId,
+        udid: udid,
+        deviceProduct: deviceProduct,
+        deviceOsVersion: deviceOsVersion,
+      );
+    }
+
+    return Response.json(
+      body: device.toJson(),
+    );
+  } catch (e, s) {
+    return handleRouteException(e, s, logMessage: 'Failed to register device');
+  }
+}

--- a/apps/openci_server/test/routes/devices/register_test.dart
+++ b/apps/openci_server/test/routes/devices/register_test.dart
@@ -1,0 +1,167 @@
+import 'dart:io';
+
+import 'package:dart_frog/dart_frog.dart';
+import 'package:dart_frog_test/dart_frog_test.dart';
+import 'package:drift/native.dart';
+import 'package:openci_server/database.dart';
+import 'package:openci_server/device/device_table.dart';
+import 'package:test/test.dart';
+
+import '../../../routes/devices/register.dart' as route;
+
+void main() {
+  late AppDatabase db;
+
+  setUp(() async {
+    db = AppDatabase(NativeDatabase.memory());
+
+    await db
+        .into(db.teams)
+        .insert(
+          DriftTeam(
+            id: 'team-123',
+            name: 'Test Team',
+            installationIds: const [],
+            aiEnabled: false,
+            runNumber: 1,
+            createdAt: DateTime.now().toUtc(),
+            updatedAt: DateTime.now().toUtc(),
+          ),
+        );
+  });
+
+  tearDown(() async {
+    await db.close();
+  });
+
+  group('POST /devices/register (integration with memory DB)', () {
+    test(
+      'responds with 401 Unauthorized when unauthorized (uid is null)',
+      () async {
+        final context = TestRequestContext(
+          path: '/devices/register',
+          method: HttpMethod.post,
+        );
+
+        context.provide<AppDatabase>(db);
+        context.provide<String?>(null);
+
+        final response = await route.onRequest(context.context);
+
+        expect(response.statusCode, equals(HttpStatus.unauthorized));
+
+        final body = await response.json() as Map<String, dynamic>;
+        expect(body['success'], isFalse);
+        expect(body['error'], equals('Authentication required'));
+      },
+    );
+
+    test(
+      'responds with 400 Bad Request when parameters are missing or empty',
+      () async {
+        final context = TestRequestContext(
+          path: '/devices/register',
+          method: HttpMethod.post,
+          body: '{"teamId": "", "udid": "00008101-000A12345678901E"}',
+        );
+
+        context.provide<AppDatabase>(db);
+        context.provide<String?>('user-123');
+
+        final response = await route.onRequest(context.context);
+
+        expect(response.statusCode, equals(HttpStatus.badRequest));
+
+        final body = await response.json() as Map<String, dynamic>;
+        expect(body['success'], isFalse);
+        expect(
+          body['error'],
+          contains('Missing or empty required parameters'),
+        );
+      },
+    );
+
+    test(
+      'responds with 200 and registers a new device successfully',
+      () async {
+        final context = TestRequestContext(
+          path: '/devices/register',
+          method: HttpMethod.post,
+          body:
+              '{"teamId": "team-123", "udid": "00008101-000A12345678901E", "deviceProduct": "iPhone 15 Pro", "deviceOsVersion": "17.4"}',
+        );
+
+        context.provide<AppDatabase>(db);
+        context.provide<String?>('user-123');
+
+        final response = await route.onRequest(context.context);
+
+        expect(response.statusCode, equals(HttpStatus.ok));
+
+        final body = await response.json() as Map<String, dynamic>;
+        expect(body['id'], isNotEmpty);
+        expect(body['userId'], equals('user-123'));
+        expect(body['teamId'], equals('team-123'));
+        expect(body['udid'], equals('00008101-000A12345678901E'));
+        expect(body['deviceProduct'], equals('iPhone 15 Pro'));
+        expect(body['deviceOsVersion'], equals('17.4'));
+
+        // DBに存在することを確認
+        final found = await db.deviceDao.findDevice(
+          userId: 'user-123',
+          teamId: 'team-123',
+          udid: '00008101-000A12345678901E',
+        );
+        expect(found, isNotNull);
+        expect(found!.id, equals(body['id']));
+      },
+    );
+
+    test(
+      'responds with 200 and updates the existing device when it already exists',
+      () async {
+        final now = DateTime.now().toUtc();
+        final existingDevice = DriftUserDevice(
+          id: 'existing-device-id',
+          userId: 'user-123',
+          teamId: 'team-123',
+          udid: '00008101-000A12345678901E',
+          deviceProduct: 'iPhone 14',
+          deviceOsVersion: '16.5',
+          createdAt: now.subtract(const Duration(days: 1)),
+          updatedAt: now.subtract(const Duration(days: 1)),
+        );
+        await db.into(db.userDevices).insert(existingDevice);
+
+        final context = TestRequestContext(
+          path: '/devices/register',
+          method: HttpMethod.post,
+          body:
+              '{"teamId": "team-123", "udid": "00008101-000A12345678901E", "deviceProduct": "iPhone 15 Pro", "deviceOsVersion": "17.4"}',
+        );
+
+        context.provide<AppDatabase>(db);
+        context.provide<String?>('user-123');
+
+        final response = await route.onRequest(context.context);
+
+        expect(response.statusCode, equals(HttpStatus.ok));
+
+        final body = await response.json() as Map<String, dynamic>;
+        expect(body['id'], equals('existing-device-id'));
+        expect(body['deviceProduct'], equals('iPhone 15 Pro'));
+        expect(body['deviceOsVersion'], equals('17.4'));
+
+        final found = await db.deviceDao.findDevice(
+          userId: 'user-123',
+          teamId: 'team-123',
+          udid: '00008101-000A12345678901E',
+        );
+        expect(found, isNotNull);
+        expect(found!.deviceProduct, equals('iPhone 15 Pro'));
+        expect(found.deviceOsVersion, equals('17.4'));
+        expect(found.updatedAt.isAfter(existingDevice.updatedAt), isTrue);
+      },
+    );
+  });
+}

--- a/apps/openci_server/test/routes/devices/register_test.dart
+++ b/apps/openci_server/test/routes/devices/register_test.dart
@@ -82,6 +82,50 @@ void main() {
     );
 
     test(
+      'responds with 400 Bad Request when JSON is malformed',
+      () async {
+        final context = TestRequestContext(
+          path: '/devices/register',
+          method: HttpMethod.post,
+          body: '{"teamId": "team-123", ',
+        );
+
+        context.provide<AppDatabase>(db);
+        context.provide<String?>('user-123');
+
+        final response = await route.onRequest(context.context);
+
+        expect(response.statusCode, equals(HttpStatus.badRequest));
+
+        final body = await response.json() as Map<String, dynamic>;
+        expect(body['success'], isFalse);
+        expect(body['error'], equals('Malformed JSON body'));
+      },
+    );
+
+    test(
+      'responds with 400 Bad Request when request body is not a JSON object',
+      () async {
+        final context = TestRequestContext(
+          path: '/devices/register',
+          method: HttpMethod.post,
+          body: '["not", "an", "object"]',
+        );
+
+        context.provide<AppDatabase>(db);
+        context.provide<String?>('user-123');
+
+        final response = await route.onRequest(context.context);
+
+        expect(response.statusCode, equals(HttpStatus.badRequest));
+
+        final body = await response.json() as Map<String, dynamic>;
+        expect(body['success'], isFalse);
+        expect(body['error'], equals('Request body must be a JSON object'));
+      },
+    );
+
+    test(
       'responds with 200 and registers a new device successfully',
       () async {
         final context = TestRequestContext(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * デバイス登録API（POST /devices/register）を追加し、認証済みユーザーのデバイス新規作成・既存更新に対応しました。
  * 未認証は `401`、不正なJSONや必須項目不足は `400`、対象外メソッドは `405` を返します。
* **Tests**
  * メモリDBを用いた統合テストを追加し、未認証・バリデーション・JSON形式エラー、そして新規登録/更新時の保存内容と更新日時を検証します。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->