### PR TITLE
feat: add mobileconfig generation route to enroll iOS device UDIDs and update dashboard to use it

### DIFF
--- a/apps/dashboard/lib/build_logs/app_distributions_page.dart
+++ b/apps/dashboard/lib/build_logs/app_distributions_page.dart
@@ -2,6 +2,7 @@ import 'package:app_minimizer_plus/app_minimizer_plus.dart';
 import 'package:dashboard/app_strings.dart';
 import 'package:dashboard/build_logs/build_jobs_provider.dart';
 import 'package:dashboard/firebase/firestore.dart';
+import 'package:dashboard/openci_server_url_provider.dart';
 import 'package:dashboard/team/selected_team_provider.dart';
 import 'package:dashboard/theme/app_colors.dart';
 import 'package:dashboard/users/user_provider.dart';
@@ -215,6 +216,7 @@ class _DeviceEnrollmentHeader extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final serverUrl = ref.watch(openciServerUrlProvider);
     final selectedTeamId = ref.watch(selectedTeamIdProvider).value;
     final userUdid = user.currentTeamUdid(selectedTeamId);
     final hasUdid = userUdid != null && userUdid.isNotEmpty;
@@ -300,7 +302,7 @@ class _DeviceEnrollmentHeader extends HookConsumerWidget {
                     ? Uri.base.origin
                     : 'https://dashboard.openci.org';
                 final enrollUrl =
-                    '$origin/enroll-udid?userId=${user.id}&teamId=${selectedTeamId ?? ''}';
+                    '$serverUrl/devices/mobile-config?userId=${user.id}&teamId=$selectedTeamId&redirectOrigin=${Uri.encodeComponent(origin)}';
                 final uri = Uri.parse(enrollUrl);
                 try {
                   await launchUrl(uri, mode: LaunchMode.externalApplication);

--- a/apps/openci_server/pubspec.yaml
+++ b/apps/openci_server/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
   firebase_admin_sdk: ^0.5.3
   github: ^9.25.1
   http: ^1.6.0
+  meta: ^1.17.0
   minio: ^3.5.8
   openci_shared: ^1.0.1
   postgres: ^3.5.11

--- a/apps/openci_server/routes/devices/mobile-config.dart
+++ b/apps/openci_server/routes/devices/mobile-config.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:dart_frog/dart_frog.dart';
+import 'package:meta/meta.dart';
 import 'package:openci_server/request/error_handler.dart';
 import 'package:uuid/uuid.dart';
 
@@ -74,6 +75,7 @@ Future<Response> _get(RequestContext context) async {
         .toString();
 
     final profileUuid = const Uuid().v4();
+    final escapedCallbackUrl = escapeXml(callbackUrl);
 
     final configXml =
         '''
@@ -84,7 +86,7 @@ Future<Response> _get(RequestContext context) async {
   <key>PayloadContent</key>
   <dict>
     <key>URL</key>
-    <string>$callbackUrl</string>
+    <string>$escapedCallbackUrl</string>
     <key>DeviceAttributes</key>
     <array>
       <string>UDID</string>
@@ -126,4 +128,14 @@ Future<Response> _get(RequestContext context) async {
       logMessage: 'Failed to generate mobileconfig',
     );
   }
+}
+
+@visibleForTesting
+String escapeXml(String input) {
+  return input
+      .replaceAll('&', '&amp;')
+      .replaceAll('<', '&lt;')
+      .replaceAll('>', '&gt;')
+      .replaceAll('"', '&quot;')
+      .replaceAll("'", '&apos;');
 }

--- a/apps/openci_server/routes/devices/mobile-config.dart
+++ b/apps/openci_server/routes/devices/mobile-config.dart
@@ -1,0 +1,97 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:dart_frog/dart_frog.dart';
+import 'package:openci_server/request/error_handler.dart';
+import 'package:uuid/uuid.dart';
+
+FutureOr<Response> onRequest(RequestContext context) {
+  return switch (context.request.method) {
+    HttpMethod.get => _get(context),
+    _ => Response(statusCode: HttpStatus.methodNotAllowed),
+  };
+}
+
+Future<Response> _get(RequestContext context) async {
+  try {
+    final queryParams = context.request.uri.queryParameters;
+    final userId = queryParams['userId'];
+    final teamId = queryParams['teamId'];
+    final redirectOrigin = queryParams['redirectOrigin'];
+
+    if (userId == null ||
+        userId.isEmpty ||
+        teamId == null ||
+        teamId.isEmpty ||
+        redirectOrigin == null ||
+        redirectOrigin.isEmpty) {
+      return Response.json(
+        statusCode: HttpStatus.badRequest,
+        body: {
+          'success': false,
+          'error':
+              'Missing required parameters: userId, teamId, redirectOrigin',
+        },
+      );
+    }
+
+    final callbackUrl =
+        '$redirectOrigin/register-device'
+        '?userId=${Uri.encodeComponent(userId)}'
+        '&teamId=${Uri.encodeComponent(teamId)}'
+        '&redirectOrigin=${Uri.encodeComponent(redirectOrigin)}';
+
+    final profileUuid = const Uuid().v4();
+
+    final configXml =
+        '''
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>PayloadContent</key>
+  <dict>
+    <key>URL</key>
+    <string>$callbackUrl</string>
+    <key>DeviceAttributes</key>
+    <array>
+      <string>UDID</string>
+      <string>IMEI</string>
+      <string>ICCID</string>
+      <string>VERSION</string>
+      <string>PRODUCT</string>
+    </array>
+  </dict>
+  <key>PayloadDescription</key>
+  <string>Profile to register your iOS device UDID for OpenCI App Distribution.</string>
+  <key>PayloadDisplayName</key>
+  <string>OpenCI Device UDID Enrollment</string>
+  <key>PayloadIdentifier</key>
+  <string>org.openci.profile-service</string>
+  <key>PayloadOrganization</key>
+  <string>OpenCI</string>
+  <key>PayloadType</key>
+  <string>Profile Service</string>
+  <key>PayloadUUID</key>
+  <string>$profileUuid</string>
+  <key>PayloadVersion</key>
+  <integer>1</integer>
+</dict>
+</plist>''';
+
+    return Response(
+      body: configXml,
+      headers: {
+        'Content-Type': 'application/x-apple-aspen-config; charset=utf-8',
+        'Content-Disposition':
+            'attachment; filename="openci-udid.mobileconfig"',
+      },
+    );
+  } catch (e, s) {
+    return handleRouteException(
+      e,
+      s,
+      logMessage: 'Failed to generate mobileconfig',
+    );
+  }
+}

--- a/apps/openci_server/routes/devices/mobile-config.dart
+++ b/apps/openci_server/routes/devices/mobile-config.dart
@@ -12,34 +12,66 @@ FutureOr<Response> onRequest(RequestContext context) {
   };
 }
 
+Set<String> allowedRedirectOrigins = () {
+  final origins = Platform.environment['ALLOWED_ORIGINS'];
+  if (origins == null || origins.trim().isEmpty) {
+    throw StateError('ALLOWED_ORIGINS environment variable is not set');
+  }
+  final list = origins
+      .split(',')
+      .map((o) => o.trim().replaceAll(RegExp(r'/$'), ''))
+      .where((o) => o.isNotEmpty)
+      .toList();
+  return {
+    ...list,
+  };
+}();
+
 Future<Response> _get(RequestContext context) async {
   try {
     final queryParams = context.request.uri.queryParameters;
     final userId = queryParams['userId'];
     final teamId = queryParams['teamId'];
     final redirectOrigin = queryParams['redirectOrigin'];
+    final redirectUri = redirectOrigin == null
+        ? null
+        : Uri.tryParse(redirectOrigin);
 
-    if (userId == null ||
-        userId.isEmpty ||
-        teamId == null ||
-        teamId.isEmpty ||
-        redirectOrigin == null ||
-        redirectOrigin.isEmpty) {
+    if (userId == null || userId.isEmpty || teamId == null || teamId.isEmpty) {
       return Response.json(
         statusCode: HttpStatus.badRequest,
         body: {
           'success': false,
-          'error':
-              'Missing required parameters: userId, teamId, redirectOrigin',
+          'error': 'Missing required parameters: userId, teamId',
         },
       );
     }
 
-    final callbackUrl =
-        '$redirectOrigin/register-device'
-        '?userId=${Uri.encodeComponent(userId)}'
-        '&teamId=${Uri.encodeComponent(teamId)}'
-        '&redirectOrigin=${Uri.encodeComponent(redirectOrigin)}';
+    if (redirectOrigin == null ||
+        redirectOrigin.isEmpty ||
+        redirectUri == null ||
+        redirectUri.scheme != 'https' ||
+        redirectUri.host.isEmpty ||
+        !allowedRedirectOrigins.contains(redirectUri.origin)) {
+      return Response.json(
+        statusCode: HttpStatus.badRequest,
+        body: {
+          'success': false,
+          'error': 'Invalid redirectOrigin',
+        },
+      );
+    }
+
+    final callbackUrl = redirectUri
+        .resolve('/register-device')
+        .replace(
+          queryParameters: {
+            'userId': userId,
+            'teamId': teamId,
+            'redirectOrigin': redirectUri.origin,
+          },
+        )
+        .toString();
 
     final profileUuid = const Uuid().v4();
 

--- a/apps/openci_server/test/routes/devices/mobile-config_test.dart
+++ b/apps/openci_server/test/routes/devices/mobile-config_test.dart
@@ -54,8 +54,8 @@ void main() {
           contains(
             'https://dashboard.openci.org/register-device'
             '?userId=user-123'
-            '&teamId=team-123'
-            '&redirectOrigin=https%3A%2F%2Fdashboard.openci.org',
+            '&amp;teamId=team-123'
+            '&amp;redirectOrigin=https%3A%2F%2Fdashboard.openci.org',
           ),
         );
       },
@@ -113,6 +113,23 @@ void main() {
       final response = await route.onRequest(context.context);
 
       expect(response.statusCode, equals(HttpStatus.methodNotAllowed));
+    });
+  });
+
+  group('escapeXml', () {
+    test('escapes XML special characters correctly', () {
+      expect(route.escapeXml('hello & world'), equals('hello &amp; world'));
+      expect(route.escapeXml('a < b > c'), equals('a &lt; b &gt; c'));
+      expect(route.escapeXml('say "hello"'), equals('say &quot;hello&quot;'));
+      expect(route.escapeXml("it's test"), equals('it&apos;s test'));
+      expect(
+        route.escapeXml('nested & "special" <chars>'),
+        equals('nested &amp; &quot;special&quot; &lt;chars&gt;'),
+      );
+    });
+
+    test('returns the same string when there are no special characters', () {
+      expect(route.escapeXml('hello world 123'), equals('hello world 123'));
     });
   });
 }

--- a/apps/openci_server/test/routes/devices/mobile-config_test.dart
+++ b/apps/openci_server/test/routes/devices/mobile-config_test.dart
@@ -1,0 +1,99 @@
+import 'dart:io';
+
+import 'package:dart_frog/dart_frog.dart';
+import 'package:dart_frog_test/dart_frog_test.dart';
+import 'package:test/test.dart';
+
+import '../../../routes/devices/mobile-config.dart' as route;
+
+void main() {
+  group('GET /devices/mobile-config', () {
+    test('returns 400 Bad Request when userId or teamId is missing', () async {
+      final context = TestRequestContext(
+        path: '/devices/mobile-config',
+        method: HttpMethod.get,
+      );
+
+      final response = await route.onRequest(context.context);
+
+      expect(response.statusCode, equals(HttpStatus.badRequest));
+      final body = await response.json() as Map<String, dynamic>;
+      expect(body['success'], isFalse);
+      expect(body['error'], contains('Missing required parameters'));
+    });
+
+    test(
+      'returns 200 and mobileconfig XML with callback URL pointing to redirectOrigin/register-device',
+      () async {
+        final context = TestRequestContext(
+          path:
+              '/devices/mobile-config?userId=user-123&teamId=team-123&redirectOrigin=https://dashboard.openci.org',
+          method: HttpMethod.get,
+        );
+
+        final response = await route.onRequest(context.context);
+
+        expect(response.statusCode, equals(HttpStatus.ok));
+        expect(
+          response.headers['Content-Type'],
+          equals('application/x-apple-aspen-config; charset=utf-8'),
+        );
+        expect(
+          response.headers['Content-Disposition'],
+          equals('attachment; filename="openci-udid.mobileconfig"'),
+        );
+
+        final xml = await response.body();
+        expect(xml, contains('<key>URL</key>'));
+        expect(
+          xml,
+          contains(
+            'https://dashboard.openci.org/register-device'
+            '?userId=user-123'
+            '&teamId=team-123'
+            '&redirectOrigin=https%3A%2F%2Fdashboard.openci.org',
+          ),
+        );
+      },
+    );
+
+    test('returns 400 Bad Request when redirectOrigin is missing', () async {
+      final context = TestRequestContext(
+        path: '/devices/mobile-config?userId=user-123&teamId=team-123',
+        method: HttpMethod.get,
+      );
+
+      final response = await route.onRequest(context.context);
+
+      expect(response.statusCode, equals(HttpStatus.badRequest));
+      final body = await response.json() as Map<String, dynamic>;
+      expect(body['success'], isFalse);
+      expect(body['error'], contains('Missing required parameters'));
+    });
+  });
+
+  group('Other methods', () {
+    test('returns 405 Method Not Allowed for POST', () async {
+      final context = TestRequestContext(
+        path: '/devices/mobile-config',
+        method: HttpMethod.post,
+        body: 'dummy',
+      );
+
+      final response = await route.onRequest(context.context);
+
+      expect(response.statusCode, equals(HttpStatus.methodNotAllowed));
+    });
+
+    test('returns 405 Method Not Allowed for DELETE', () async {
+      final context = TestRequestContext(
+        path: '/devices/mobile-config',
+        method: HttpMethod.delete,
+      );
+
+      final response = await route.onRequest(context.context);
+
+      expect(response.statusCode, equals(HttpStatus.methodNotAllowed));
+    });
+  });
+}

--- a/apps/openci_server/test/routes/devices/mobile-config_test.dart
+++ b/apps/openci_server/test/routes/devices/mobile-config_test.dart
@@ -7,6 +7,10 @@ import 'package:test/test.dart';
 import '../../../routes/devices/mobile-config.dart' as route;
 
 void main() {
+  setUp(() {
+    route.allowedRedirectOrigins = {'https://dashboard.openci.org'};
+  });
+
   group('GET /devices/mobile-config', () {
     test('returns 400 Bad Request when userId or teamId is missing', () async {
       final context = TestRequestContext(
@@ -68,7 +72,22 @@ void main() {
       expect(response.statusCode, equals(HttpStatus.badRequest));
       final body = await response.json() as Map<String, dynamic>;
       expect(body['success'], isFalse);
-      expect(body['error'], contains('Missing required parameters'));
+      expect(body['error'], contains('Invalid redirectOrigin'));
+    });
+
+    test('returns 400 Bad Request when redirectOrigin is not allowed', () async {
+      final context = TestRequestContext(
+        path:
+            '/devices/mobile-config?userId=user-123&teamId=team-123&redirectOrigin=https://malicious.com',
+        method: HttpMethod.get,
+      );
+
+      final response = await route.onRequest(context.context);
+
+      expect(response.statusCode, equals(HttpStatus.badRequest));
+      final body = await response.json() as Map<String, dynamic>;
+      expect(body['success'], isFalse);
+      expect(body['error'], contains('Invalid redirectOrigin'));
     });
   });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * デバイス登録・再登録用のリンク／設定ファイル生成を、サーバー基準の新しい登録フローに対応しました（ダッシュボードの誘導先も更新）。
  * `mobile-config` をダウンロードできるようになり、指定した `redirectOrigin` に基づいて設定内容を生成します。
* **Bug Fixes**
  * 必須パラメータ不足や無効な `redirectOrigin`、未対応メソッドに対して適切なエラー／ステータスを返すよう改善しました。
* **Tests**
  * `mobile-config` のレスポンス内容、ヘッダー、エラー条件のテストを追加しました。
* **Chores**
  * 依存関係に `meta` を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->