### PR TITLE
feat: implement endpoint to list GitHub repositories for team installations

### DIFF
--- a/apps/dashboard/lib/workflow/list/github_repository_provider.dart
+++ b/apps/dashboard/lib/workflow/list/github_repository_provider.dart
@@ -1,7 +1,12 @@
+import 'dart:convert';
+
+import 'package:dashboard/auth/auth_provider.dart';
 import 'package:dashboard/firebase/firestore.dart';
 import 'package:dashboard/firebase/functions.dart';
+import 'package:dashboard/openci_server_url_provider.dart';
 import 'package:dashboard/team/team_provider.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:http/http.dart' as http;
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'github_repository_provider.freezed.dart';
@@ -25,20 +30,34 @@ abstract class GitHubRepo with _$GitHubRepo {
 Future<List<GitHubRepo>> gitHubRepositories(Ref ref) async {
   final team = ref.watch(teamStateProvider).value;
   if (team == null) return [];
-  final functions = firebaseFunctions;
 
-  final result = await functions.httpsCallable('listRepositories').call({
-    'teamId': team.id,
-  });
+  final serverUrl = ref.watch(openciServerUrlProvider);
+  final token = await ref.watch(authedFirebaseIdTokenProvider.future);
 
-  final data = result.data as Map<String, dynamic>;
-  final repos = (data['repositories'] as List<dynamic>)
-      .map(
+  final url = Uri.parse('$serverUrl/teams/${team.id}/github/repositories');
+  final response = await http
+      .get(
+        url,
+        headers: {
+          'Authorization': 'Bearer $token',
+        },
+      )
+      .timeout(const Duration(seconds: 15));
+
+  if (response.statusCode != 200) {
+    throw StateError(
+      'Failed to load repositories: ${response.statusCode} ${response.body}',
+    );
+  }
+
+  final data = jsonDecode(response.body) as Map<String, dynamic>;
+  final repos = (data['repositories'] as List<dynamic>?)
+      ?.map(
         (e) => GitHubRepo.fromJson(Map<String, Object?>.from(e as Map)),
       )
       .toList();
 
-  return repos;
+  return repos ?? const [];
 }
 
 @riverpod

--- a/apps/dashboard/lib/workflow/list/github_repository_provider.g.dart
+++ b/apps/dashboard/lib/workflow/list/github_repository_provider.g.dart
@@ -68,7 +68,7 @@ final class GitHubRepositoriesProvider
 }
 
 String _$gitHubRepositoriesHash() =>
-    r'ec53b08bebccb3f6e5c5f0df4a944478d6d7efa5';
+    r'fff01951fede874be84259811f98fd366e31acbb';
 
 @ProviderFor(gitHubBranches)
 final gitHubBranchesProvider = GitHubBranchesFamily._();

--- a/apps/openci_server/lib/github/github_service.dart
+++ b/apps/openci_server/lib/github/github_service.dart
@@ -136,4 +136,57 @@ class GitHubService {
       );
     }
   }
+
+  static Future<List<Map<String, dynamic>>> listRepositories({
+    required String installationIdStr,
+    Map<String, String>? environment,
+    http.Client? client,
+  }) async {
+    final token = await getInstallationToken(
+      installationIdStr: installationIdStr,
+      environment: environment,
+      client: client,
+    );
+
+    final env = environment ?? Platform.environment;
+    final githubApiBaseUrlStr = env['GITHUB_API_BASE_URL'];
+    if (githubApiBaseUrlStr == null || githubApiBaseUrlStr.isEmpty) {
+      throw StateError(
+        'GITHUB_API_BASE_URL environment variable is not configured',
+      );
+    }
+
+    final url = '$githubApiBaseUrlStr/installation/repositories';
+    final headers = {
+      'Authorization': 'Bearer $token',
+      'Accept': 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+      'User-Agent': 'OpenCI-Server',
+    };
+
+    final response = client != null
+        ? await client.get(Uri.parse(url), headers: headers)
+        : await http.get(Uri.parse(url), headers: headers);
+
+    if (response.statusCode >= 300) {
+      throw HttpException(
+        'Failed to list repositories from GitHub: ${response.statusCode} ${response.body}',
+      );
+    }
+
+    final data = jsonDecode(response.body) as Map<String, dynamic>;
+    final repositories = data['repositories'] as List<dynamic>? ?? [];
+
+    return repositories.map((item) {
+      final map = item as Map<String, dynamic>;
+      final owner = map['owner'] as Map<String, dynamic>?;
+      return {
+        'fullName': map['full_name'] as String? ?? '',
+        'name': map['name'] as String? ?? '',
+        'owner': owner?['login'] as String? ?? '',
+        'private': map['private'] as bool? ?? false,
+        'defaultBranch': map['default_branch'] as String? ?? 'main',
+      };
+    }).toList();
+  }
 }

--- a/apps/openci_server/lib/team/team_dao.dart
+++ b/apps/openci_server/lib/team/team_dao.dart
@@ -54,4 +54,8 @@ class TeamDao extends DatabaseAccessor<AppDatabase> with _$TeamDaoMixin {
     }
     return null;
   }
+
+  Future<DriftTeam?> getTeam(String teamId) {
+    return (select(teams)..where((t) => t.id.equals(teamId))).getSingleOrNull();
+  }
 }

--- a/apps/openci_server/routes/teams/[id]/github/repositories.dart
+++ b/apps/openci_server/routes/teams/[id]/github/repositories.dart
@@ -1,0 +1,106 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:dart_frog/dart_frog.dart';
+import 'package:http/http.dart' as http;
+import 'package:openci_server/database.dart';
+import 'package:openci_server/github/github_service.dart';
+import 'package:openci_server/request/error_handler.dart';
+
+FutureOr<Response> onRequest(RequestContext context, String id) {
+  return switch (context.request.method) {
+    HttpMethod.get => _get(context, id),
+    _ => Response(statusCode: HttpStatus.methodNotAllowed),
+  };
+}
+
+Future<Response> _get(RequestContext context, String teamId) async {
+  try {
+    final db = context.read<AppDatabase>();
+    final uid = context.read<String?>();
+    if (uid == null) {
+      return Response.json(
+        statusCode: HttpStatus.unauthorized,
+        body: {'success': false, 'error': 'Authentication required'},
+      );
+    }
+
+    final isMember = await db.teamDao.isTeamMember(uid, teamId);
+    if (!isMember) {
+      return Response.json(
+        statusCode: HttpStatus.forbidden,
+        body: {'success': false, 'error': 'Forbidden'},
+      );
+    }
+
+    final driftTeam = await db.teamDao.getTeam(teamId);
+
+    if (driftTeam == null) {
+      return Response.json(
+        statusCode: HttpStatus.notFound,
+        body: {'success': false, 'error': 'Team not found'},
+      );
+    }
+
+    final installationIds = driftTeam.installationIds;
+    if (installationIds.isEmpty) {
+      return Response.json(
+        statusCode: HttpStatus.badRequest,
+        body: {
+          'success': false,
+          'error': 'GitHub App is not installed for this team',
+        },
+      );
+    }
+
+    Map<String, String> env;
+    try {
+      env = context.read<Map<String, String>>();
+    } catch (_) {
+      env = Platform.environment;
+    }
+
+    http.Client client;
+    try {
+      client = context.read<http.Client>();
+    } catch (_) {
+      client = http.Client();
+    }
+
+    final allRepos = <String, Map<String, dynamic>>{};
+    Object? lastError;
+
+    for (final installationId in installationIds) {
+      try {
+        final repos = await GitHubService.listRepositories(
+          installationIdStr: installationId.toString(),
+          environment: env,
+          client: client,
+        );
+        for (final repo in repos) {
+          final fullName = repo['fullName'] as String;
+          allRepos[fullName] = repo;
+        }
+      } catch (e) {
+        lastError = e;
+      }
+    }
+
+    if (allRepos.isEmpty && lastError != null) {
+      throw lastError;
+    }
+
+    return Response.json(
+      body: {
+        'success': true,
+        'repositories': allRepos.values.toList(),
+      },
+    );
+  } catch (e, s) {
+    return handleRouteException(
+      e,
+      s,
+      logMessage: 'Failed to list repositories for team $teamId',
+    );
+  }
+}

--- a/apps/openci_server/test/routes/teams/repositories_test.dart
+++ b/apps/openci_server/test/routes/teams/repositories_test.dart
@@ -1,0 +1,239 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:dart_frog/dart_frog.dart';
+import 'package:dart_frog_test/dart_frog_test.dart';
+import 'package:drift/native.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:openci_server/database.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+import '../../../routes/teams/[id]/github/repositories.dart'
+    as repositories_route;
+
+const testRsaPrivateKey = '''
+-----BEGIN PRIVATE KEY-----
+MIICdwIBADANBgkqhkiG9w0BAQEFAASCAmEwggJdAgEAAoGBANiAAR187atVXowj
+f+vCsYaoXkXkaxt1TPYiEa6r8NY1no2sQUa1X281FhNdYFlsCjAot4OBgGKe6GHx
+R/qL2ifaSReCAf8DpqDi6SMMOjg+Owrya44E0Ld/SEVHyDy8PnLTmI2ijydhptjK
+slf33COCWnIE88OQutWM3/OyMkrRAgMBAAECgYEAg/2OMH8gmusiCEgATijVeGYf
+i3bVwdjCwfBFXXtgCgiIkJDq/wPGmhMAUXAFNJ9EmtXIA/mo3vdIb6XdHyeyKKi9
+LRly8gHlowdJ5HTbjrBCJlpPTG/Hxo1+3Q+W50240LyuZLByOy7AABr86bIq8Xxo
+F4U13aHYhPkI15pvEt0CQQDuLZvZ1i7JZB/KfUhM3pgsnApFxRFcGCwOG7bVXAM5
++fkLnAENP/yWzawD/HOctDxzQ7qdcSWlx0Ux2Ww9n4nDAkEA6LMkhxcnVAM7y6aQ
+u6eKcHSJxDmFbHJoxVyyVlVynL9qDgKTckZvvzLopgBo7VawsqyC0YV7XZTxgsvV
+wzK72wJAJjBR6N+aqNfQ8RqdWRXnuF9clks+uVF23tw6uIMEUWtvLxlYYdN8oIFh
+r1HvB5UujByz80KNEsOcqJ1/6XGHGQJBANzLXhVwOrjUeKA7Y4kq54jcivvNOHQ1
++oOJ+Q1B9oYUeaThfNYpT060F1urd+P7JZ3jYh078lpRQPdCQYn9UZECQENnF2pp
+Gl92V3wIHINZYD6o97L+/6Cw3H7TvkikX3bQf1vKy4P7+rE89jEAgA0jrMWPu6WG
+Vtdh93Euj6RHtUE=
+-----END PRIVATE KEY-----
+''';
+
+void main() {
+  late AppDatabase db;
+  late Directory tempDir;
+  late File privateKeyFile;
+  late Map<String, String> testEnv;
+
+  setUp(() async {
+    db = AppDatabase(NativeDatabase.memory());
+    await db
+        .into(db.teams)
+        .insert(
+          DriftTeam(
+            id: 'team-123',
+            name: 'Test Team',
+            installationIds: const [98765],
+            aiEnabled: false,
+            runNumber: 1,
+            createdAt: DateTime.now().toUtc(),
+            updatedAt: DateTime.now().toUtc(),
+          ),
+        );
+
+    tempDir = Directory.systemTemp.createTempSync('repositories_test_');
+    privateKeyFile = File(p.join(tempDir.path, 'private_key.pem'));
+    privateKeyFile.writeAsStringSync(testRsaPrivateKey);
+
+    testEnv = {
+      'GITHUB_APP_ID': '123456',
+      'GITHUB_PRIVATE_KEY_PATH': privateKeyFile.path,
+      'GITHUB_API_BASE_URL': 'https://api.github.com',
+    };
+  });
+
+  tearDown(() async {
+    await db.close();
+    if (tempDir.existsSync()) {
+      tempDir.deleteSync(recursive: true);
+    }
+  });
+
+  group('Repositories Endpoint', () {
+    test('responds with 401 Unauthorized when uid is null', () async {
+      final context = TestRequestContext(
+        path: '/teams/team-123/github/repositories',
+        method: HttpMethod.get,
+      );
+      context.provide<AppDatabase>(db);
+      context.provide<String?>(null);
+      context.provide<Map<String, String>>(testEnv);
+
+      final response = await repositories_route.onRequest(
+        context.context,
+        'team-123',
+      );
+      expect(response.statusCode, equals(HttpStatus.unauthorized));
+    });
+
+    test('responds with 403 Forbidden when user is not team member', () async {
+      final context = TestRequestContext(
+        path: '/teams/team-123/github/repositories',
+        method: HttpMethod.get,
+      );
+      context.provide<AppDatabase>(db);
+      context.provide<String?>('non-member-user');
+      context.provide<Map<String, String>>(testEnv);
+
+      final response = await repositories_route.onRequest(
+        context.context,
+        'team-123',
+      );
+      expect(response.statusCode, equals(HttpStatus.forbidden));
+    });
+
+    test(
+      'responds with 400 Bad Request when GitHub App installationIds is empty',
+      () async {
+        await db
+            .into(db.teamMembers)
+            .insert(
+              TeamMembersCompanion.insert(
+                teamId: 'team-456',
+                userId: 'user-1',
+              ),
+            );
+        await db
+            .into(db.teams)
+            .insert(
+              DriftTeam(
+                id: 'team-456',
+                name: 'Test Team 2',
+                installationIds: const [],
+                aiEnabled: false,
+                runNumber: 1,
+                createdAt: DateTime.now().toUtc(),
+                updatedAt: DateTime.now().toUtc(),
+              ),
+            );
+
+        final context = TestRequestContext(
+          path: '/teams/team-456/github/repositories',
+          method: HttpMethod.get,
+        );
+        context.provide<AppDatabase>(db);
+        context.provide<String?>('user-1');
+        context.provide<Map<String, String>>(testEnv);
+
+        final response = await repositories_route.onRequest(
+          context.context,
+          'team-456',
+        );
+        expect(response.statusCode, equals(HttpStatus.badRequest));
+        final body = await response.json() as Map<String, dynamic>;
+        expect(
+          body['error'],
+          equals('GitHub App is not installed for this team'),
+        );
+      },
+    );
+
+    test('responds with 200 OK and lists repositories from GitHub', () async {
+      await db
+          .into(db.teamMembers)
+          .insert(
+            TeamMembersCompanion.insert(
+              teamId: 'team-123',
+              userId: 'user-1',
+            ),
+          );
+
+      final mockHttpClient = MockClient((request) async {
+        if (request.method == 'POST' &&
+            request.url.path.endsWith('/access_tokens')) {
+          return http.Response(
+            jsonEncode({'token': 'ghs_mockedtoken123456'}),
+            200,
+          );
+        }
+
+        if (request.method == 'GET' &&
+            request.url.path.endsWith('/installation/repositories')) {
+          return http.Response(
+            jsonEncode({
+              'repositories': [
+                {
+                  'id': 1296269,
+                  'name': 'Hello-World',
+                  'full_name': 'octocat/Hello-World',
+                  'private': true,
+                  'owner': {
+                    'login': 'octocat',
+                  },
+                  'default_branch': 'master',
+                },
+                {
+                  'id': 99999,
+                  'name': 'Spoon-Knife',
+                  'full_name': 'octocat/Spoon-Knife',
+                  'private': false,
+                  'owner': {
+                    'login': 'octocat',
+                  },
+                  'default_branch': 'main',
+                },
+              ],
+            }),
+            200,
+          );
+        }
+
+        return http.Response('Not Found', 404);
+      });
+
+      final context = TestRequestContext(
+        path: '/teams/team-123/github/repositories',
+        method: HttpMethod.get,
+      );
+      context.provide<AppDatabase>(db);
+      context.provide<String?>('user-1');
+      context.provide<Map<String, String>>(testEnv);
+      context.provide<http.Client>(mockHttpClient);
+
+      final response = await repositories_route.onRequest(
+        context.context,
+        'team-123',
+      );
+      expect(response.statusCode, equals(HttpStatus.ok));
+
+      final body = await response.json() as Map<String, dynamic>;
+      expect(body['success'], isTrue);
+      final repositories = body['repositories'] as List<dynamic>;
+      expect(repositories, hasLength(2));
+      expect(repositories[0]['fullName'], equals('octocat/Hello-World'));
+      expect(repositories[0]['name'], equals('Hello-World'));
+      expect(repositories[0]['owner'], equals('octocat'));
+      expect(repositories[0]['private'], isTrue);
+      expect(repositories[0]['defaultBranch'], equals('master'));
+
+      expect(repositories[1]['fullName'], equals('octocat/Spoon-Knife'));
+      expect(repositories[1]['name'], equals('Spoon-Knife'));
+      expect(repositories[1]['owner'], equals('octocat'));
+      expect(repositories[1]['private'], isFalse);
+      expect(repositories[1]['defaultBranch'], equals('main'));
+    });
+  });
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * チームのGitHubリポジトリ一覧を取得するAPIを追加（複数インストールを統合）。
  * ダッシュボード側でREST経由でリポジトリ取得を行うよう更新。
* **バグ修正**
  * 未認証、チーム外、未設定、チーム未存在などで適切なステータスとエラーを返すよう改善。リポジトリ情報の表示内容も安定化。
* **テスト**
  * エンドポイントの主要な正常系・異常系を検証するテストを追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->