### PR TITLE
feat: implement GitHub repository branches endpoint and service method

### DIFF
--- a/apps/dashboard/lib/workflow/list/github_repository_provider.dart
+++ b/apps/dashboard/lib/workflow/list/github_repository_provider.dart
@@ -1,8 +1,6 @@
 import 'dart:convert';
 
 import 'package:dashboard/auth/auth_provider.dart';
-import 'package:dashboard/firebase/firestore.dart';
-import 'package:dashboard/firebase/functions.dart';
 import 'package:dashboard/openci_server_url_provider.dart';
 import 'package:dashboard/team/team_provider.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
@@ -61,36 +59,51 @@ Future<List<GitHubRepo>> gitHubRepositories(Ref ref) async {
 }
 
 @riverpod
-Stream<List<String>> gitHubBranches(Ref ref, String repoFullName) {
+Stream<List<String>> gitHubBranches(Ref ref, String repoFullName) async* {
   final team = ref.watch(teamStateProvider).value;
-  if (team == null) return Stream.value(const []);
+  if (team == null) {
+    yield const [];
+    return;
+  }
 
-  final repositoryId = repoFullName.replaceAll('/', ':');
-  final docRef = firestore
-      .collection(teamsCollection)
-      .doc(team.id)
-      .collection('repositories_v0')
-      .doc(repositoryId);
+  final serverUrl = ref.watch(openciServerUrlProvider);
+  final token = await ref.watch(authedFirebaseIdTokenProvider.future);
 
-  return docRef.snapshots().asyncMap((snapshot) async {
-    if (!snapshot.exists) {
-      final functions = firebaseFunctions;
-      try {
-        await functions.httpsCallable('listBranches').call({
-          'teamId': team.id,
-          'repository': repoFullName,
-        });
-      } catch (_) {
-        // Ignore initialization error since it will be retried or shown as error
-      }
+  Future<List<String>> fetch(String tkn) async {
+    try {
+      final parts = repoFullName.split('/');
+      if (parts.length != 2) return const [];
+      final owner = parts[0];
+      final repo = parts[1];
+
+      final url = Uri.parse(
+        '$serverUrl/teams/${team.id}/github/repositories/$owner/$repo/branches',
+      );
+      final response = await http
+          .get(
+            url,
+            headers: {
+              'Authorization': 'Bearer $tkn',
+            },
+          )
+          .timeout(const Duration(seconds: 10));
+
+      if (response.statusCode != 200) return const [];
+
+      final data = jsonDecode(response.body) as Map<String, dynamic>;
+      final branches = (data['branches'] as List<dynamic>?)
+          ?.map((e) => e.toString())
+          .toList();
+      return branches ?? const [];
+    } catch (e) {
       return const [];
     }
+  }
 
-    final data = snapshot.data();
-    if (data == null) return const [];
-    final branches = (data['branches'] as List<dynamic>?)
-        ?.map((e) => e.toString())
-        .toList();
-    return branches ?? const [];
+  yield await fetch(token);
+
+  yield* Stream.periodic(const Duration(seconds: 15)).asyncMap((_) async {
+    final tkn = await ref.read(authedFirebaseIdTokenProvider.future);
+    return fetch(tkn);
   });
 }

--- a/apps/dashboard/lib/workflow/list/github_repository_provider.g.dart
+++ b/apps/dashboard/lib/workflow/list/github_repository_provider.g.dart
@@ -125,7 +125,7 @@ final class GitHubBranchesProvider
   }
 }
 
-String _$gitHubBranchesHash() => r'791cc84409e0f7abfc230f9702ed230626fa3940';
+String _$gitHubBranchesHash() => r'39f0c2f140be1ceab2f658e8dae4dddf3f473c14';
 
 final class GitHubBranchesFamily extends $Family
     with $FunctionalFamilyOverride<Stream<List<String>>, String> {

--- a/apps/openci_server/lib/github/github_service.dart
+++ b/apps/openci_server/lib/github/github_service.dart
@@ -189,4 +189,53 @@ class GitHubService {
       };
     }).toList();
   }
+
+  static Future<List<String>> listBranches({
+    required String owner,
+    required String repo,
+    required String installationIdStr,
+    Map<String, String>? environment,
+    http.Client? client,
+  }) async {
+    final token = await getInstallationToken(
+      installationIdStr: installationIdStr,
+      environment: environment,
+      client: client,
+    );
+
+    final env = environment ?? Platform.environment;
+    final githubApiBaseUrlStr = env['GITHUB_API_BASE_URL'];
+    if (githubApiBaseUrlStr == null || githubApiBaseUrlStr.isEmpty) {
+      throw StateError(
+        'GITHUB_API_BASE_URL environment variable is not configured',
+      );
+    }
+
+    final url = '$githubApiBaseUrlStr/repos/$owner/$repo/branches';
+    final headers = {
+      'Authorization': 'Bearer $token',
+      'Accept': 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+      'User-Agent': 'OpenCI-Server',
+    };
+
+    final response = client != null
+        ? await client.get(Uri.parse(url), headers: headers)
+        : await http.get(Uri.parse(url), headers: headers);
+
+    if (response.statusCode >= 300) {
+      throw HttpException(
+        'Failed to list branches from GitHub: ${response.statusCode} ${response.body}',
+      );
+    }
+
+    final data = jsonDecode(response.body) as List<dynamic>;
+    return data
+        .map((item) {
+          final map = item as Map<String, dynamic>;
+          return map['name'] as String? ?? '';
+        })
+        .where((name) => name.isNotEmpty)
+        .toList();
+  }
 }

--- a/apps/openci_server/routes/teams/[id]/github/repositories/[owner]/[repo]/branches.dart
+++ b/apps/openci_server/routes/teams/[id]/github/repositories/[owner]/[repo]/branches.dart
@@ -1,0 +1,114 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:dart_frog/dart_frog.dart';
+import 'package:http/http.dart' as http;
+import 'package:openci_server/database.dart';
+import 'package:openci_server/github/github_service.dart';
+import 'package:openci_server/request/error_handler.dart';
+
+FutureOr<Response> onRequest(
+  RequestContext context,
+  String id,
+  String owner,
+  String repo,
+) {
+  return switch (context.request.method) {
+    HttpMethod.get => _get(context, id, owner, repo),
+    _ => Response(statusCode: HttpStatus.methodNotAllowed),
+  };
+}
+
+Future<Response> _get(
+  RequestContext context,
+  String teamId,
+  String owner,
+  String repo,
+) async {
+  try {
+    final db = context.read<AppDatabase>();
+    final uid = context.read<String?>();
+    if (uid == null) {
+      return Response.json(
+        statusCode: HttpStatus.unauthorized,
+        body: {'success': false, 'error': 'Authentication required'},
+      );
+    }
+
+    final isMember = await db.teamDao.isTeamMember(uid, teamId);
+    if (!isMember) {
+      return Response.json(
+        statusCode: HttpStatus.forbidden,
+        body: {'success': false, 'error': 'Forbidden'},
+      );
+    }
+
+    final driftTeam = await db.teamDao.getTeam(teamId);
+    if (driftTeam == null) {
+      return Response.json(
+        statusCode: HttpStatus.notFound,
+        body: {'success': false, 'error': 'Team not found'},
+      );
+    }
+
+    final installationIds = driftTeam.installationIds;
+    if (installationIds.isEmpty) {
+      return Response.json(
+        statusCode: HttpStatus.badRequest,
+        body: {
+          'success': false,
+          'error': 'GitHub App is not installed for this team',
+        },
+      );
+    }
+
+    Map<String, String> env;
+    try {
+      env = context.read<Map<String, String>>();
+    } catch (_) {
+      env = Platform.environment;
+    }
+
+    http.Client client;
+    try {
+      client = context.read<http.Client>();
+    } catch (_) {
+      client = http.Client();
+    }
+
+    final allBranches = <String>{};
+    Object? lastError;
+
+    for (final installationId in installationIds) {
+      try {
+        final branches = await GitHubService.listBranches(
+          owner: owner,
+          repo: repo,
+          installationIdStr: installationId.toString(),
+          environment: env,
+          client: client,
+        );
+        allBranches.addAll(branches);
+      } catch (e) {
+        lastError = e;
+      }
+    }
+
+    if (allBranches.isEmpty && lastError != null) {
+      throw lastError;
+    }
+
+    return Response.json(
+      body: {
+        'success': true,
+        'branches': allBranches.toList(),
+      },
+    );
+  } catch (e, s) {
+    return handleRouteException(
+      e,
+      s,
+      logMessage: 'Failed to list branches for $owner/$repo in team $teamId',
+    );
+  }
+}

--- a/apps/openci_server/test/routes/teams/branches_test.dart
+++ b/apps/openci_server/test/routes/teams/branches_test.dart
@@ -1,0 +1,170 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:dart_frog/dart_frog.dart';
+import 'package:dart_frog_test/dart_frog_test.dart';
+import 'package:drift/native.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:openci_server/database.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+import '../../../routes/teams/[id]/github/repositories/[owner]/[repo]/branches.dart'
+    as branches_route;
+
+const testRsaPrivateKey = '''
+-----BEGIN PRIVATE KEY-----
+MIICdwIBADANBgkqhkiG9w0BAQEFAASCAmEwggJdAgEAAoGBANiAAR187atVXowj
+f+vCsYaoXkXkaxt1TPYiEa6r8NY1no2sQUa1X281FhNdYFlsCjAot4OBgGKe6GHx
+R/qL2ifaSReCAf8DpqDi6SMMOjg+Owrya44E0Ld/SEVHyDy8PnLTmI2ijydhptjK
+slf33COCWnIE88OQutWM3/OyMkrRAgMBAAECgYEAg/2OMH8gmusiCEgATijVeGYf
+i3bVwdjCwfBFXXtgCgiIkJDq/wPGmhMAUXAFNJ9EmtXIA/mo3vdIb6XdHyeyKKi9
+LRly8gHlowdJ5HTbjrBCJlpPTG/Hxo1+3Q+W50240LyuZLByOy7AABr86bIq8Xxo
+F4U13aHYhPkI15pvEt0CQQDuLZvZ1i7JZB/KfUhM3pgsnApFxRFcGCwOG7bVXAM5
++fkLnAENP/yWzawD/HOctDxzQ7qdcSWlx0Ux2Ww9n4nDAkEA6LMkhxcnVAM7y6aQ
+u6eKcHSJxDmFbHJoxVyyVlVynL9qDgKTckZvvzLopgBo7VawsqyC0YV7XZTxgsvV
+wzK72wJAJjBR6N+aqNfQ8RqdWRXnuF9clks+uVF23tw6uIMEUWtvLxlYYdN8oIFh
+r1HvB5UujByz80KNEsOcqJ1/6XGHGQJBANzLXhVwOrjUeKA7Y4kq54jcivvNOHQ1
++oOJ+Q1B9oYUeaThfNYpT060F1urd+P7JZ3jYh078lpRQPdCQYn9UZECQENnF2pp
+Gl92V3wIHINZYD6o97L+/6Cw3H7TvkikX3bQf1vKy4P7+rE89jEAgA0jrMWPu6WG
+Vtdh93Euj6RHtUE=
+-----END PRIVATE KEY-----
+''';
+
+void main() {
+  late AppDatabase db;
+  late Directory tempDir;
+  late File privateKeyFile;
+  late Map<String, String> testEnv;
+
+  setUp(() async {
+    db = AppDatabase(NativeDatabase.memory());
+    await db
+        .into(db.teams)
+        .insert(
+          DriftTeam(
+            id: 'team-123',
+            name: 'Test Team',
+            installationIds: const [98765],
+            aiEnabled: false,
+            runNumber: 1,
+            createdAt: DateTime.now().toUtc(),
+            updatedAt: DateTime.now().toUtc(),
+          ),
+        );
+
+    tempDir = Directory.systemTemp.createTempSync('branches_test_');
+    privateKeyFile = File(p.join(tempDir.path, 'private_key.pem'));
+    privateKeyFile.writeAsStringSync(testRsaPrivateKey);
+
+    testEnv = {
+      'GITHUB_APP_ID': '123456',
+      'GITHUB_PRIVATE_KEY_PATH': privateKeyFile.path,
+      'GITHUB_API_BASE_URL': 'https://api.github.com',
+    };
+  });
+
+  tearDown(() async {
+    await db.close();
+    if (tempDir.existsSync()) {
+      tempDir.deleteSync(recursive: true);
+    }
+  });
+
+  group('Branches Endpoint', () {
+    test('responds with 401 Unauthorized when uid is null', () async {
+      final context = TestRequestContext(
+        path: '/teams/team-123/github/repositories/owner/repo/branches',
+        method: HttpMethod.get,
+      );
+      context.provide<AppDatabase>(db);
+      context.provide<String?>(null);
+      context.provide<Map<String, String>>(testEnv);
+
+      final response = await branches_route.onRequest(
+        context.context,
+        'team-123',
+        'owner',
+        'repo',
+      );
+      expect(response.statusCode, equals(HttpStatus.unauthorized));
+    });
+
+    test('responds with 403 Forbidden when user is not team member', () async {
+      final context = TestRequestContext(
+        path: '/teams/team-123/github/repositories/owner/repo/branches',
+        method: HttpMethod.get,
+      );
+      context.provide<AppDatabase>(db);
+      context.provide<String?>('non-member-user');
+      context.provide<Map<String, String>>(testEnv);
+
+      final response = await branches_route.onRequest(
+        context.context,
+        'team-123',
+        'owner',
+        'repo',
+      );
+      expect(response.statusCode, equals(HttpStatus.forbidden));
+    });
+
+    test('responds with 200 OK and lists branches from GitHub', () async {
+      await db
+          .into(db.teamMembers)
+          .insert(
+            TeamMembersCompanion.insert(
+              teamId: 'team-123',
+              userId: 'user-1',
+            ),
+          );
+
+      final mockHttpClient = MockClient((request) async {
+        if (request.method == 'POST' &&
+            request.url.path.endsWith('/access_tokens')) {
+          return http.Response(
+            jsonEncode({'token': 'ghs_mockedtoken123456'}),
+            200,
+          );
+        }
+
+        if (request.method == 'GET' &&
+            request.url.path.endsWith('/repos/owner/repo/branches')) {
+          return http.Response(
+            jsonEncode([
+              {'name': 'main'},
+              {'name': 'develop'},
+              {'name': 'feature/test'},
+            ]),
+            200,
+          );
+        }
+
+        return http.Response('Not Found', 404);
+      });
+
+      final context = TestRequestContext(
+        path: '/teams/team-123/github/repositories/owner/repo/branches',
+        method: HttpMethod.get,
+      );
+      context.provide<AppDatabase>(db);
+      context.provide<String?>('user-1');
+      context.provide<Map<String, String>>(testEnv);
+      context.provide<http.Client>(mockHttpClient);
+
+      final response = await branches_route.onRequest(
+        context.context,
+        'team-123',
+        'owner',
+        'repo',
+      );
+      expect(response.statusCode, equals(HttpStatus.ok));
+
+      final body = await response.json() as Map<String, dynamic>;
+      expect(body['success'], isTrue);
+      final branches = body['branches'] as List<dynamic>;
+      expect(branches, hasLength(3));
+      expect(branches, containsAll(['main', 'develop', 'feature/test']));
+    });
+  });
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * チームのGitHubリポジトリに対して、ブランチ一覧を取得できるようになりました。
  * ブランチ情報は最新状態を定期的に再取得し、画面に反映されます。

* **改善**
  * ブランチ取得の失敗時は、安全に空の一覧として扱うようになりました。
  * 認証や権限がない場合は、適切なエラーを返すようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->