### PR TITLE
feat: implement iOS private key generation service and endpoint for teams

### DIFF
--- a/apps/openci_server/lib/ios_signing/ios_signing_service.dart
+++ b/apps/openci_server/lib/ios_signing/ios_signing_service.dart
@@ -1,0 +1,21 @@
+import 'dart:io';
+
+class IosSigningService {
+  static Future<String> generatePrivateKey() async {
+    final result = await Process.run('openssl', ['genrsa', '2048']);
+    if (result.exitCode != 0) {
+      throw ProcessException(
+        'openssl',
+        ['genrsa', '2048'],
+        'openssl genrsa failed: ${result.stderr}',
+      );
+    }
+
+    final privateKeyPem = result.stdout.toString().trim();
+    if (privateKeyPem.isEmpty) {
+      throw const FormatException('Generated private key is empty');
+    }
+
+    return privateKeyPem;
+  }
+}

--- a/apps/openci_server/routes/teams/[id]/ios-signing/generate-key.dart
+++ b/apps/openci_server/routes/teams/[id]/ios-signing/generate-key.dart
@@ -1,0 +1,96 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:dart_frog/dart_frog.dart';
+import 'package:openci_server/database.dart';
+import 'package:openci_server/ios_signing/ios_signing_service.dart';
+import 'package:openci_server/request/error_handler.dart';
+import 'package:openci_server/secret/secret_crypter.dart';
+import 'package:openci_server/secret/secret_table.dart';
+
+FutureOr<Response> onRequest(RequestContext context, String id) {
+  return switch (context.request.method) {
+    HttpMethod.post => _post(context, id),
+    _ => Response(statusCode: HttpStatus.methodNotAllowed),
+  };
+}
+
+Future<Response> _post(RequestContext context, String teamId) async {
+  try {
+    final db = context.read<AppDatabase>();
+    final uid = context.read<String?>();
+    if (uid == null) {
+      return Response.json(
+        statusCode: HttpStatus.unauthorized,
+        body: {'success': false, 'error': 'Authentication required'},
+      );
+    }
+
+    final isMember = await db.teamDao.isTeamMember(uid, teamId);
+    if (!isMember) {
+      return Response.json(
+        statusCode: HttpStatus.forbidden,
+        body: {'success': false, 'error': 'Forbidden'},
+      );
+    }
+
+    Map<String, String> env;
+    try {
+      env = context.read<Map<String, String>>();
+    } catch (_) {
+      env = Platform.environment;
+    }
+
+    final encryptionKey = env['SECRET_ENCRYPTION_KEY'];
+    if (encryptionKey == null || encryptionKey.trim().isEmpty) {
+      stderr.writeln('SECRET_ENCRYPTION_KEY environment variable is not set');
+      return Response.json(
+        statusCode: HttpStatus.internalServerError,
+        body: {
+          'success': false,
+          'error': 'Encryption key is not configured on the server',
+        },
+      );
+    }
+
+    final SecretCrypter crypter;
+    try {
+      crypter = SecretCrypter(encryptionKey);
+    } catch (e) {
+      stderr.writeln('Failed to initialize SecretCrypter: $e');
+      return Response.json(
+        statusCode: HttpStatus.internalServerError,
+        body: {
+          'success': false,
+          'error': 'Invalid encryption key configuration',
+        },
+      );
+    }
+
+    final privateKeyPem = await IosSigningService.generatePrivateKey();
+
+    final encryptedValue = await crypter.encrypt(privateKeyPem);
+    final now = DateTime.now().toUtc();
+
+    final driftSecret = DriftSecret(
+      name: 'OPENCI_IOS_CERTIFICATE_PRIVATE_KEY',
+      teamId: teamId,
+      encryptedValue: encryptedValue,
+      createdAt: now,
+      updatedAt: now,
+    );
+
+    await db.secretDao.insertOrUpdateSecret(driftSecret);
+
+    return Response.json(
+      body: {'success': true},
+    );
+  } catch (e, s) {
+    return handleRouteException(
+      e,
+      s,
+      logMessage:
+          'Failed to generate iOS certificate private key for team $teamId',
+    );
+  }
+}

--- a/apps/openci_server/test/ios_signing/ios_signing_service_test.dart
+++ b/apps/openci_server/test/ios_signing/ios_signing_service_test.dart
@@ -1,0 +1,13 @@
+import 'package:openci_server/ios_signing/ios_signing_service.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('IosSigningService', () {
+    test('generatePrivateKey generates a valid RSA private key PEM', () async {
+      final key = await IosSigningService.generatePrivateKey();
+      expect(key, isNotEmpty);
+      expect(key, contains('-----BEGIN PRIVATE KEY-----'));
+      expect(key, contains('-----END PRIVATE KEY-----'));
+    });
+  });
+}

--- a/apps/openci_server/test/routes/teams/ios_signing_generate_key_test.dart
+++ b/apps/openci_server/test/routes/teams/ios_signing_generate_key_test.dart
@@ -1,0 +1,119 @@
+import 'dart:io';
+
+import 'package:dart_frog/dart_frog.dart';
+import 'package:dart_frog_test/dart_frog_test.dart';
+import 'package:drift/native.dart';
+import 'package:openci_server/database.dart';
+import 'package:openci_server/secret/secret_crypter.dart';
+import 'package:test/test.dart';
+
+import '../../../routes/teams/[id]/ios-signing/generate-key.dart'
+    as generate_key_route;
+
+void main() {
+  late AppDatabase db;
+  late Map<String, String> testEnv;
+  const encryptionKey = 'cTN0Nnc5eiRDJkYpSkBOY1FmVGZXblpyNHU3eCFBJUQ=';
+  setUp(() async {
+    db = AppDatabase(NativeDatabase.memory());
+    await db
+        .into(db.teams)
+        .insert(
+          DriftTeam(
+            id: 'team-123',
+            name: 'Test Team',
+            installationIds: const [98765],
+            aiEnabled: false,
+            runNumber: 1,
+            createdAt: DateTime.now().toUtc(),
+            updatedAt: DateTime.now().toUtc(),
+          ),
+        );
+
+    testEnv = {
+      'SECRET_ENCRYPTION_KEY': encryptionKey,
+    };
+  });
+
+  tearDown(() async {
+    await db.close();
+  });
+
+  group('Generate Key Endpoint', () {
+    test('responds with 401 Unauthorized when uid is null', () async {
+      final context = TestRequestContext(
+        path: '/teams/team-123/ios-signing/generate-key',
+        method: HttpMethod.post,
+      );
+      context.provide<AppDatabase>(db);
+      context.provide<String?>(null);
+      context.provide<Map<String, String>>(testEnv);
+
+      final response = await generate_key_route.onRequest(
+        context.context,
+        'team-123',
+      );
+      expect(response.statusCode, equals(HttpStatus.unauthorized));
+    });
+
+    test('responds with 403 Forbidden when user is not team member', () async {
+      final context = TestRequestContext(
+        path: '/teams/team-123/ios-signing/generate-key',
+        method: HttpMethod.post,
+      );
+      context.provide<AppDatabase>(db);
+      context.provide<String?>('non-member-user');
+      context.provide<Map<String, String>>(testEnv);
+
+      final response = await generate_key_route.onRequest(
+        context.context,
+        'team-123',
+      );
+      expect(response.statusCode, equals(HttpStatus.forbidden));
+    });
+
+    test(
+      'responds with 200 OK, generates RSA private key and saves it encrypted',
+      () async {
+        await db
+            .into(db.teamMembers)
+            .insert(
+              TeamMembersCompanion.insert(
+                teamId: 'team-123',
+                userId: 'user-1',
+              ),
+            );
+
+        final context = TestRequestContext(
+          path: '/teams/team-123/ios-signing/generate-key',
+          method: HttpMethod.post,
+        );
+        context.provide<AppDatabase>(db);
+        context.provide<String?>('user-1');
+        context.provide<Map<String, String>>(testEnv);
+
+        final response = await generate_key_route.onRequest(
+          context.context,
+          'team-123',
+        );
+        expect(response.statusCode, equals(HttpStatus.ok));
+
+        final body = await response.json() as Map<String, dynamic>;
+        expect(body['success'], isTrue);
+
+        final secret = await db.secretDao.getSecret(
+          'team-123',
+          'OPENCI_IOS_CERTIFICATE_PRIVATE_KEY',
+        );
+        expect(secret, isNotNull);
+        expect(secret!.name, equals('OPENCI_IOS_CERTIFICATE_PRIVATE_KEY'));
+        expect(secret.teamId, equals('team-123'));
+
+        final crypter = SecretCrypter(encryptionKey);
+        final decrypted = await crypter.decrypt(secret.encryptedValue);
+        expect(decrypted, contains('-----BEGIN PRIVATE KEY-----'));
+        expect(decrypted, contains('-----END PRIVATE KEY-----'));
+      },
+    );
+  });
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * iOS署名用の秘密鍵を生成して保存するエンドポイントを追加しました。
  * チーム単位で iOS 用の秘密鍵を作成できるようになりました。
* **テスト**
  * 秘密鍵生成が有効なPEM形式で返ることを確認するテストを追加しました。
  * 認証、権限、保存結果まで含めたエンドポイントのテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->