### PR TITLE
feat: migrate team creation to server-side and add support for custom team IDs

### DIFF
--- a/apps/dashboard/lib/auth/auth_page.dart
+++ b/apps/dashboard/lib/auth/auth_page.dart
@@ -2,13 +2,12 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:cloud_functions/cloud_functions.dart';
 import 'package:dashboard/app_strings.dart';
 import 'package:dashboard/firebase/firebase_config_provider.dart';
-import 'package:dashboard/firebase/firestore.dart';
 import 'package:dashboard/firebase/functions.dart';
 import 'package:dashboard/firebase/plist_parser.dart';
+import 'package:dashboard/openci_server_url_provider.dart';
 import 'package:dashboard/team/selected_team_provider.dart';
 import 'package:dashboard/theme/app_colors.dart';
 import 'package:dashboard/utilities/function_error_message.dart';
@@ -21,6 +20,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:http/http.dart' as http;
 import 'package:url_launcher/url_launcher.dart';
 
 void _processInvitations() {
@@ -332,26 +332,41 @@ class AuthPage extends HookConsumerWidget {
                                                 final userId =
                                                     credential.user!.uid;
                                                 final teamId = userId;
-                                                final timestamp =
-                                                    FieldValue.serverTimestamp();
-                                                final batch = firestore.batch();
-                                                batch.set(
-                                                  firestore
-                                                      .collection(
-                                                        teamsCollection,
-                                                      )
-                                                      .doc(teamId),
-                                                  {
-                                                    'id': teamId,
-                                                    'name': teamId,
-                                                    'members': [userId],
-                                                    'installationIds': <int>[],
-                                                    'aiEnabled': true,
-                                                    'createdAt': timestamp,
-                                                    'updatedAt': timestamp,
-                                                  },
+                                                final idToken = await credential
+                                                    .user!
+                                                    .getIdToken();
+                                                final serverUrl = ref.read(
+                                                  openciServerUrlProvider,
                                                 );
-                                                await batch.commit();
+
+                                                final response = await http
+                                                    .post(
+                                                      Uri.parse(
+                                                        '$serverUrl/teams',
+                                                      ),
+                                                      headers: {
+                                                        'Authorization':
+                                                            'Bearer $idToken',
+                                                        'Content-Type':
+                                                            'application/json',
+                                                      },
+                                                      body: jsonEncode({
+                                                        'id': teamId,
+                                                        'name': teamId,
+                                                      }),
+                                                    )
+                                                    .timeout(
+                                                      const Duration(
+                                                        seconds: 10,
+                                                      ),
+                                                    );
+
+                                                if (response.statusCode !=
+                                                    200) {
+                                                  throw StateError(
+                                                    'Failed to initialize team on the server: ${response.body}',
+                                                  );
+                                                }
                                                 await ref
                                                     .read(
                                                       selectedTeamIdProvider

--- a/apps/openci_server/routes/teams/index.dart
+++ b/apps/openci_server/routes/teams/index.dart
@@ -88,7 +88,39 @@ Future<Response> _post(RequestContext context) async {
       );
     }
 
-    final teamId = const Uuid().v4();
+    if (payload.containsKey('id') && payload['id'] is! String) {
+      return Response.json(
+        statusCode: HttpStatus.badRequest,
+        body: {
+          'success': false,
+          'error': 'id must be a string',
+        },
+      );
+    }
+
+    final payloadId = payload['id'] as String?;
+    final trimmedPayloadId = payloadId?.trim();
+    if (trimmedPayloadId != null && trimmedPayloadId.isEmpty) {
+      return Response.json(
+        statusCode: HttpStatus.badRequest,
+        body: {'success': false, 'error': 'id cannot be empty'},
+      );
+    }
+
+    if (trimmedPayloadId != null) {
+      final existingTeam = await db.teamDao.getTeam(trimmedPayloadId);
+      if (existingTeam != null) {
+        return Response.json(
+          statusCode: HttpStatus.conflict,
+          body: {
+            'success': false,
+            'error': 'Team with ID $trimmedPayloadId already exists',
+          },
+        );
+      }
+    }
+
+    final teamId = trimmedPayloadId ?? const Uuid().v4();
     final now = DateTime.now().toUtc();
 
     final driftTeam = DriftTeam(

--- a/apps/openci_server/test/routes/teams/index_test.dart
+++ b/apps/openci_server/test/routes/teams/index_test.dart
@@ -309,6 +309,70 @@ void main() {
     );
 
     test(
+      'responds with 200 OK and custom team ID when id is provided',
+      () async {
+        final context = TestRequestContext(
+          path: '/teams',
+          method: HttpMethod.post,
+          body: jsonEncode({'id': 'custom-team-id', 'name': 'Custom Team'}),
+        );
+
+        context.provide<AppDatabase>(db);
+        context.provide<String?>('user-1');
+
+        final response = await route.onRequest(context.context);
+
+        expect(response.statusCode, equals(HttpStatus.ok));
+
+        final body = await response.json() as Map<String, dynamic>;
+        expect(body['success'], isTrue);
+        expect(body['id'], equals('custom-team-id'));
+
+        final team = await (db.select(
+          db.teams,
+        )..where((t) => t.id.equals('custom-team-id'))).getSingleOrNull();
+        expect(team, isNotNull);
+        expect(team!.name, equals('Custom Team'));
+      },
+    );
+
+    test(
+      'responds with 409 Conflict when team with same ID already exists',
+      () async {
+        await db
+            .into(db.teams)
+            .insert(
+              DriftTeam(
+                id: 'existing-id',
+                name: 'Old Team',
+                installationIds: const [],
+                runNumber: 1,
+                aiEnabled: true,
+                createdAt: DateTime.now().toUtc(),
+                updatedAt: DateTime.now().toUtc(),
+              ),
+            );
+
+        final context = TestRequestContext(
+          path: '/teams',
+          method: HttpMethod.post,
+          body: jsonEncode({'id': 'existing-id', 'name': 'Duplicate Team'}),
+        );
+
+        context.provide<AppDatabase>(db);
+        context.provide<String?>('user-1');
+
+        final response = await route.onRequest(context.context);
+
+        expect(response.statusCode, equals(HttpStatus.conflict));
+
+        final body = await response.json() as Map<String, dynamic>;
+        expect(body['success'], isFalse);
+        expect(body['error'], contains('already exists'));
+      },
+    );
+
+    test(
       'responds with 500 Internal Server Error when database fails',
       () async {
         final mockDb = MockAppDatabase();


### PR DESCRIPTION
…

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * アカウント作成時のチーム初期化が、外部サーバーへの送信に対応しました。
  * チーム作成時に、任意のチームIDを指定できるようになりました。
* **不具合修正**
  * 既存のチームIDで重複作成した場合に、適切にエラーを返すようになりました。
  * チーム作成処理で、応答が正常でない場合に失敗として扱うようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->