### PR TITLE
feat: add pagination support to build logs endpoint with limit and offset query parameters

### DIFF
--- a/apps/openci_server/routes/builds/[id]/runs/[runId]/logs.dart
+++ b/apps/openci_server/routes/builds/[id]/runs/[runId]/logs.dart
@@ -33,13 +33,36 @@ Future<Response> _get(
       );
     }
 
+    final queryParams = context.request.uri.queryParameters;
+    final limit = int.tryParse(queryParams['limit'] ?? '') ?? 1000;
+    final offset = int.tryParse(queryParams['offset'] ?? '') ?? 0;
+
     final logs = await db.buildJobDao.getBuildJobLogs(runId);
-    final logText = logs.map((l) => l.logContent).join('');
+    final rawText = logs.map((l) => l.logContent).join('');
+    final allLines = rawText
+        .split('\n')
+        .where((line) => line.isNotEmpty)
+        .toList();
+
+    final start = offset;
+    final end = start + limit;
+
+    final slicedLines = allLines.sublist(
+      start.clamp(0, allLines.length),
+      end.clamp(0, allLines.length),
+    );
+
+    var logText = slicedLines.join('\n');
+    if (slicedLines.isNotEmpty) {
+      logText += '\n';
+    }
 
     return Response(
       body: logText,
       headers: {
         'content-type': 'text/plain; charset=utf-8',
+        'x-total-lines': allLines.length.toString(),
+        'x-has-more': (end < allLines.length).toString(),
       },
     );
   } catch (e, s) {

--- a/apps/openci_server/test/routes/builds/[id]/runs/[runId]/logs_test.dart
+++ b/apps/openci_server/test/routes/builds/[id]/runs/[runId]/logs_test.dart
@@ -93,9 +93,97 @@ void main() {
         expect(response.statusCode, equals(HttpStatus.ok));
         expect(response.headers['content-type'], contains('text/plain'));
         expect(response.headers['content-type'], contains('charset=utf-8'));
+        expect(response.headers['x-total-lines'], equals('2'));
+        expect(response.headers['x-has-more'], equals('false'));
 
         final bodyText = await response.body();
         expect(bodyText, equals('line 1\nline 2\n'));
+      },
+    );
+
+    test(
+      'responds with 200 OK and returns paginated logs with headers when limit and offset are provided',
+      () async {
+        final now = _getNormalizedNow();
+        final team = DriftTeam(
+          id: 'team-xyz',
+          name: 'Team XYZ',
+          githubBaseUrl: null,
+          installationIds: const [],
+          runNumber: 1,
+          aiEnabled: true,
+          createdAt: now,
+          updatedAt: now,
+        );
+
+        await db.teamDao.createTeamAndMember(team, 'user-123');
+
+        final job = DriftBuildJob(
+          id: 'job-xyz',
+          status: BuildJobStatus.QUEUED,
+          owner: 'owner',
+          repo: 'repo',
+          workflowName: 'workflow',
+          teamId: 'team-xyz',
+          createdAt: now,
+          updatedAt: now,
+        );
+
+        await db.buildJobDao.insertBuildJob(job);
+
+        final run = DriftBuildRun(
+          id: 'run-456',
+          buildJobId: 'job-xyz',
+          status: 'success',
+          createdAt: now,
+          updatedAt: now,
+        );
+        await db.buildRunDao.insertBuildRun(run);
+
+        await db.buildJobDao.insertBuildJobLog(
+          'run-456',
+          'line 1\nline 2\nline 3\n',
+        );
+
+        // Test with limit=2, offset=0
+        final context1 = TestRequestContext(
+          path: '/builds/job-xyz/runs/run-456/logs?limit=2&offset=0',
+          method: HttpMethod.get,
+        );
+        context1.provide<AppDatabase>(db);
+        context1.provide<String?>('user-123');
+        context1.provide<DriftBuildJob>(job);
+
+        final response1 = await route.onRequest(
+          context1.context,
+          'job-xyz',
+          'run-456',
+        );
+
+        expect(response1.statusCode, equals(HttpStatus.ok));
+        expect(response1.headers['x-total-lines'], equals('3'));
+        expect(response1.headers['x-has-more'], equals('true'));
+        expect(await response1.body(), equals('line 1\nline 2\n'));
+
+        // Test with limit=2, offset=2
+        final context2 = TestRequestContext(
+          path: '/builds/job-xyz/runs/run-456/logs?limit=2&offset=2',
+          method: HttpMethod.get,
+        );
+        context2.provide<AppDatabase>(db);
+        context2.provide<String?>('user-123');
+        context2.provide<DriftBuildJob>(job);
+
+        final response2 = await route.onRequest(
+          context2.context,
+          'job-xyz',
+          'run-456',
+        );
+
+        expect(response2.statusCode, equals(HttpStatus.ok));
+        expect(response2.headers['x-total-lines'], equals('3'));
+        expect(response2.headers['x-has-more'], equals('false'));
+        expect(await response2.body(), equals('line 3\n'));
       },
     );
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * ビルド実行ログを、`limit` と `offset` によって必要な行だけ取得できるようになりました。
  * レスポンスに全体行数と、続きがあるかどうかを示す情報が追加されました。
* **テスト**
  * ログ取得の既存テストを更新し、新しいレスポンス形式を検証するようにしました。
  * さらに、ページング指定時の取得結果を確認するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->