### PR TITLE
feat: implement 1-hour execution timeout for VM and Docker build jobs

### DIFF
--- a/apps/openci_worker_cli/lib/constants.dart
+++ b/apps/openci_worker_cli/lib/constants.dart
@@ -16,3 +16,5 @@ const exitCodeUpdateRequested = 42;
 const firebaseSignInUrl =
     'https://identitytoolkit.googleapis.com/v1/accounts:signInWithPassword';
 const firebaseTokenRefreshUrl = 'https://securetoken.googleapis.com/v1/token';
+
+const maxJobTimeout = Duration(hours: 1);

--- a/apps/openci_worker_cli/lib/docker_job_executor.dart
+++ b/apps/openci_worker_cli/lib/docker_job_executor.dart
@@ -282,6 +282,32 @@ Future<bool> processDockerJob(
         conclusion: 'success',
       );
       await apiClient.handleBuildJobStatusChange(completedJob, 'SUCCESS');
+    } on TimeoutException catch (timeoutError) {
+      await logError(
+        buildJobId,
+        runId,
+        'Job execution timed out: $timeoutError',
+      );
+      await apiClient.updateRunStatus(
+        buildJobId: buildJobId,
+        runId: runId,
+        status: 'completed',
+        conclusion: 'timed_out',
+      );
+      await apiClient.completeJob(buildJobId, 'TIMED_OUT');
+
+      final timedOutJob = buildJob.copyWith(
+        status: BuildJobStatus.TIMED_OUT,
+        latestRunId: runId,
+        completedAt: DateTime.now(),
+      );
+      await apiClient.updateCheckRun(
+        timedOutJob,
+        'completed',
+        conclusion: 'timed_out',
+      );
+      await apiClient.handleBuildJobStatusChange(timedOutJob, 'TIMED_OUT');
+      return true;
     } catch (actError) {
       await logWarning(buildJobId, runId, 'Act build failed: $actError');
       await apiClient.updateRunStatus(
@@ -305,6 +331,33 @@ Future<bool> processDockerJob(
       await apiClient.handleBuildJobStatusChange(failedJob, 'FAILURE');
       return true;
     }
+  } on TimeoutException catch (e, s) {
+    await logError(
+      buildJobId,
+      runId,
+      'Job timed out: $e',
+      stackTrace: s.toString(),
+    );
+    await apiClient.updateRunStatus(
+      buildJobId: buildJobId,
+      runId: runId,
+      status: 'completed',
+      conclusion: 'timed_out',
+    );
+    await apiClient.completeJob(buildJobId, 'TIMED_OUT');
+
+    final timedOutJob = buildJob.copyWith(
+      status: BuildJobStatus.TIMED_OUT,
+      latestRunId: runId,
+      completedAt: DateTime.now(),
+    );
+    await apiClient.updateCheckRun(
+      timedOutJob,
+      'completed',
+      conclusion: 'timed_out',
+    );
+    await apiClient.handleBuildJobStatusChange(timedOutJob, 'TIMED_OUT');
+    return true;
   } catch (e, s) {
     await logError(
       buildJobId,

--- a/apps/openci_worker_cli/lib/docker_job_executor.dart
+++ b/apps/openci_worker_cli/lib/docker_job_executor.dart
@@ -263,72 +263,36 @@ Future<bool> processDockerJob(
       await Future.delayed(const Duration(seconds: 5));
 
       await logInfo(buildJobId, runId, 'Build completed successfully');
-      await apiClient.updateRunStatus(
-        buildJobId: buildJobId,
+      await updateJobFinalStatus(
+        apiClient: apiClient,
+        buildJob: buildJob,
         runId: runId,
-        status: 'completed',
-        conclusion: 'success',
-      );
-      await apiClient.completeJob(buildJobId, 'SUCCESS');
-
-      final completedJob = buildJob.copyWith(
         status: BuildJobStatus.SUCCESS,
-        latestRunId: runId,
-        completedAt: DateTime.now(),
-      );
-      await apiClient.updateCheckRun(
-        completedJob,
-        'completed',
         conclusion: 'success',
       );
-      await apiClient.handleBuildJobStatusChange(completedJob, 'SUCCESS');
     } on TimeoutException catch (timeoutError) {
       await logError(
         buildJobId,
         runId,
         'Job execution timed out: $timeoutError',
       );
-      await apiClient.updateRunStatus(
-        buildJobId: buildJobId,
+      await updateJobFinalStatus(
+        apiClient: apiClient,
+        buildJob: buildJob,
         runId: runId,
-        status: 'completed',
-        conclusion: 'timed_out',
-      );
-      await apiClient.completeJob(buildJobId, 'TIMED_OUT');
-
-      final timedOutJob = buildJob.copyWith(
         status: BuildJobStatus.TIMED_OUT,
-        latestRunId: runId,
-        completedAt: DateTime.now(),
-      );
-      await apiClient.updateCheckRun(
-        timedOutJob,
-        'completed',
         conclusion: 'timed_out',
       );
-      await apiClient.handleBuildJobStatusChange(timedOutJob, 'TIMED_OUT');
       return true;
     } catch (actError) {
       await logWarning(buildJobId, runId, 'Act build failed: $actError');
-      await apiClient.updateRunStatus(
-        buildJobId: buildJobId,
+      await updateJobFinalStatus(
+        apiClient: apiClient,
+        buildJob: buildJob,
         runId: runId,
-        status: 'completed',
-        conclusion: 'failure',
-      );
-      await apiClient.completeJob(buildJobId, 'FAILURE');
-
-      final failedJob = buildJob.copyWith(
         status: BuildJobStatus.FAILURE,
-        latestRunId: runId,
-        completedAt: DateTime.now(),
-      );
-      await apiClient.updateCheckRun(
-        failedJob,
-        'completed',
         conclusion: 'failure',
       );
-      await apiClient.handleBuildJobStatusChange(failedJob, 'FAILURE');
       return true;
     }
   } on TimeoutException catch (e, s) {
@@ -338,25 +302,13 @@ Future<bool> processDockerJob(
       'Job timed out: $e',
       stackTrace: s.toString(),
     );
-    await apiClient.updateRunStatus(
-      buildJobId: buildJobId,
+    await updateJobFinalStatus(
+      apiClient: apiClient,
+      buildJob: buildJob,
       runId: runId,
-      status: 'completed',
-      conclusion: 'timed_out',
-    );
-    await apiClient.completeJob(buildJobId, 'TIMED_OUT');
-
-    final timedOutJob = buildJob.copyWith(
       status: BuildJobStatus.TIMED_OUT,
-      latestRunId: runId,
-      completedAt: DateTime.now(),
-    );
-    await apiClient.updateCheckRun(
-      timedOutJob,
-      'completed',
       conclusion: 'timed_out',
     );
-    await apiClient.handleBuildJobStatusChange(timedOutJob, 'TIMED_OUT');
     return true;
   } catch (e, s) {
     await logError(
@@ -365,25 +317,13 @@ Future<bool> processDockerJob(
       'Job failed: $e',
       stackTrace: s.toString(),
     );
-    await apiClient.updateRunStatus(
-      buildJobId: buildJobId,
+    await updateJobFinalStatus(
+      apiClient: apiClient,
+      buildJob: buildJob,
       runId: runId,
-      status: 'completed',
-      conclusion: 'failure',
-    );
-    await apiClient.completeJob(buildJobId, 'FAILURE');
-
-    final failedJob = buildJob.copyWith(
       status: BuildJobStatus.FAILURE,
-      latestRunId: runId,
-      completedAt: DateTime.now(),
-    );
-    await apiClient.updateCheckRun(
-      failedJob,
-      'completed',
       conclusion: 'failure',
     );
-    await apiClient.handleBuildJobStatusChange(failedJob, 'FAILURE');
     rethrow;
   } finally {
     await flushRemainingLogs(runId: runId);

--- a/apps/openci_worker_cli/lib/docker_runner.dart
+++ b/apps/openci_worker_cli/lib/docker_runner.dart
@@ -3,8 +3,8 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:logging/logging.dart';
-import 'package:openci_worker_cli/constants.dart';
 import 'package:openci_worker_cli/build_job_logger.dart';
+import 'package:openci_worker_cli/constants.dart';
 import 'package:sentry/sentry.dart';
 import 'package:uuid/uuid.dart';
 
@@ -131,6 +131,7 @@ Future<void> execStreamingInContainer(
   String runId,
   String token, {
   required Future<bool> Function() isCancelled,
+  Duration timeout = maxJobTimeout,
 }) async {
   final process = await Process.start('docker', ['exec', name, ...command]);
 
@@ -175,7 +176,15 @@ Future<void> execStreamingInContainer(
     }
   }, onDone: () => stderrCompleter.complete());
 
+  final startTime = DateTime.now();
+  var isTimedOut = false;
+
   final cancelTimer = Timer.periodic(const Duration(seconds: 5), (_) async {
+    if (DateTime.now().difference(startTime) > timeout) {
+      isTimedOut = true;
+      process.kill(ProcessSignal.sigterm);
+      return;
+    }
     if (await isCancelled()) {
       process.kill(ProcessSignal.sigterm);
     }
@@ -185,6 +194,12 @@ Future<void> execStreamingInContainer(
   cancelTimer.cancel();
   await stdoutCompleter.future;
   await stderrCompleter.future;
+
+  if (isTimedOut) {
+    throw TimeoutException(
+      'Job execution exceeded timeout of ${timeout.inMinutes} minutes.',
+    );
+  }
 
   if (exitCode != 0) {
     throw Exception('act exited with code $exitCode');

--- a/apps/openci_worker_cli/lib/job_executor.dart
+++ b/apps/openci_worker_cli/lib/job_executor.dart
@@ -390,72 +390,36 @@ Future<bool> processJob(
       await Future.delayed(const Duration(seconds: 5));
 
       await logInfo(buildJobId, runId, 'Build completed successfully');
-      await apiClient.updateRunStatus(
-        buildJobId: buildJobId,
+      await updateJobFinalStatus(
+        apiClient: apiClient,
+        buildJob: buildJob,
         runId: runId,
-        status: 'completed',
-        conclusion: 'success',
-      );
-      await apiClient.completeJob(buildJobId, 'SUCCESS');
-
-      final completedJob = buildJob.copyWith(
         status: BuildJobStatus.SUCCESS,
-        latestRunId: runId,
-        completedAt: DateTime.now(),
-      );
-      await apiClient.updateCheckRun(
-        completedJob,
-        'completed',
         conclusion: 'success',
       );
-      await apiClient.handleBuildJobStatusChange(completedJob, 'SUCCESS');
     } on TimeoutException catch (timeoutError) {
       await logError(
         buildJobId,
         runId,
         'Job execution timed out: $timeoutError',
       );
-      await apiClient.updateRunStatus(
-        buildJobId: buildJobId,
+      await updateJobFinalStatus(
+        apiClient: apiClient,
+        buildJob: buildJob,
         runId: runId,
-        status: 'completed',
-        conclusion: 'timed_out',
-      );
-      await apiClient.completeJob(buildJobId, 'TIMED_OUT');
-
-      final timedOutJob = buildJob.copyWith(
         status: BuildJobStatus.TIMED_OUT,
-        latestRunId: runId,
-        completedAt: DateTime.now(),
-      );
-      await apiClient.updateCheckRun(
-        timedOutJob,
-        'completed',
         conclusion: 'timed_out',
       );
-      await apiClient.handleBuildJobStatusChange(timedOutJob, 'TIMED_OUT');
       return true;
     } catch (actError) {
       await logWarning(buildJobId, runId, 'Act build failed: $actError');
-      await apiClient.updateRunStatus(
-        buildJobId: buildJobId,
+      await updateJobFinalStatus(
+        apiClient: apiClient,
+        buildJob: buildJob,
         runId: runId,
-        status: 'completed',
-        conclusion: 'failure',
-      );
-      await apiClient.completeJob(buildJobId, 'FAILURE');
-
-      final failedJob = buildJob.copyWith(
         status: BuildJobStatus.FAILURE,
-        latestRunId: runId,
-        completedAt: DateTime.now(),
-      );
-      await apiClient.updateCheckRun(
-        failedJob,
-        'completed',
         conclusion: 'failure',
       );
-      await apiClient.handleBuildJobStatusChange(failedJob, 'FAILURE');
       return true;
     }
   } on TimeoutException catch (e, s) {
@@ -465,25 +429,13 @@ Future<bool> processJob(
       'Job timed out: $e',
       stackTrace: s.toString(),
     );
-    await apiClient.updateRunStatus(
-      buildJobId: buildJobId,
+    await updateJobFinalStatus(
+      apiClient: apiClient,
+      buildJob: buildJob,
       runId: runId,
-      status: 'completed',
-      conclusion: 'timed_out',
-    );
-    await apiClient.completeJob(buildJobId, 'TIMED_OUT');
-
-    final timedOutJob = buildJob.copyWith(
       status: BuildJobStatus.TIMED_OUT,
-      latestRunId: runId,
-      completedAt: DateTime.now(),
-    );
-    await apiClient.updateCheckRun(
-      timedOutJob,
-      'completed',
       conclusion: 'timed_out',
     );
-    await apiClient.handleBuildJobStatusChange(timedOutJob, 'TIMED_OUT');
     return true;
   } catch (e, s) {
     await logError(
@@ -492,25 +444,13 @@ Future<bool> processJob(
       'Job failed: $e',
       stackTrace: s.toString(),
     );
-    await apiClient.updateRunStatus(
-      buildJobId: buildJobId,
+    await updateJobFinalStatus(
+      apiClient: apiClient,
+      buildJob: buildJob,
       runId: runId,
-      status: 'completed',
-      conclusion: 'failure',
-    );
-    await apiClient.completeJob(buildJobId, 'FAILURE');
-
-    final failedJob = buildJob.copyWith(
       status: BuildJobStatus.FAILURE,
-      latestRunId: runId,
-      completedAt: DateTime.now(),
-    );
-    await apiClient.updateCheckRun(
-      failedJob,
-      'completed',
       conclusion: 'failure',
     );
-    await apiClient.handleBuildJobStatusChange(failedJob, 'FAILURE');
     rethrow;
   } finally {
     await flushRemainingLogs(runId: runId);
@@ -700,4 +640,33 @@ String buildEventPayload(BuildJob buildJob) {
     'pusher': {'name': owner},
     'sender': {'login': owner},
   });
+}
+
+Future<void> updateJobFinalStatus({
+  required ApiClient apiClient,
+  required BuildJob buildJob,
+  required String runId,
+  required BuildJobStatus status,
+  required String conclusion,
+}) async {
+  final buildJobId = buildJob.id;
+  await apiClient.updateRunStatus(
+    buildJobId: buildJobId,
+    runId: runId,
+    status: 'completed',
+    conclusion: conclusion,
+  );
+  await apiClient.completeJob(buildJobId, status.name);
+
+  final updatedJob = buildJob.copyWith(
+    status: status,
+    latestRunId: runId,
+    completedAt: DateTime.now(),
+  );
+  await apiClient.updateCheckRun(
+    updatedJob,
+    'completed',
+    conclusion: conclusion,
+  );
+  await apiClient.handleBuildJobStatusChange(updatedJob, status.name);
 }

--- a/apps/openci_worker_cli/lib/job_executor.dart
+++ b/apps/openci_worker_cli/lib/job_executor.dart
@@ -409,6 +409,32 @@ Future<bool> processJob(
         conclusion: 'success',
       );
       await apiClient.handleBuildJobStatusChange(completedJob, 'SUCCESS');
+    } on TimeoutException catch (timeoutError) {
+      await logError(
+        buildJobId,
+        runId,
+        'Job execution timed out: $timeoutError',
+      );
+      await apiClient.updateRunStatus(
+        buildJobId: buildJobId,
+        runId: runId,
+        status: 'completed',
+        conclusion: 'timed_out',
+      );
+      await apiClient.completeJob(buildJobId, 'TIMED_OUT');
+
+      final timedOutJob = buildJob.copyWith(
+        status: BuildJobStatus.TIMED_OUT,
+        latestRunId: runId,
+        completedAt: DateTime.now(),
+      );
+      await apiClient.updateCheckRun(
+        timedOutJob,
+        'completed',
+        conclusion: 'timed_out',
+      );
+      await apiClient.handleBuildJobStatusChange(timedOutJob, 'TIMED_OUT');
+      return true;
     } catch (actError) {
       await logWarning(buildJobId, runId, 'Act build failed: $actError');
       await apiClient.updateRunStatus(
@@ -432,6 +458,33 @@ Future<bool> processJob(
       await apiClient.handleBuildJobStatusChange(failedJob, 'FAILURE');
       return true;
     }
+  } on TimeoutException catch (e, s) {
+    await logError(
+      buildJobId,
+      runId,
+      'Job timed out: $e',
+      stackTrace: s.toString(),
+    );
+    await apiClient.updateRunStatus(
+      buildJobId: buildJobId,
+      runId: runId,
+      status: 'completed',
+      conclusion: 'timed_out',
+    );
+    await apiClient.completeJob(buildJobId, 'TIMED_OUT');
+
+    final timedOutJob = buildJob.copyWith(
+      status: BuildJobStatus.TIMED_OUT,
+      latestRunId: runId,
+      completedAt: DateTime.now(),
+    );
+    await apiClient.updateCheckRun(
+      timedOutJob,
+      'completed',
+      conclusion: 'timed_out',
+    );
+    await apiClient.handleBuildJobStatusChange(timedOutJob, 'TIMED_OUT');
+    return true;
   } catch (e, s) {
     await logError(
       buildJobId,

--- a/apps/openci_worker_cli/lib/vm.dart
+++ b/apps/openci_worker_cli/lib/vm.dart
@@ -436,6 +436,7 @@ Future<void> execCommandStreaming(
   String runId,
   String token, {
   required Future<bool> Function() isCancelled,
+  Duration timeout = maxJobTimeout,
 }) async {
   if (vmIp == null) {
     throw StateError('Cannot stream SSH command: VM IP is null.');
@@ -503,7 +504,15 @@ Future<void> execCommandStreaming(
     }
   }, onDone: () => stderrCompleter.complete());
 
+  final startTime = DateTime.now();
+  var isTimedOut = false;
+
   final cancelTimer = Timer.periodic(const Duration(seconds: 5), (_) async {
+    if (DateTime.now().difference(startTime) > timeout) {
+      isTimedOut = true;
+      process.kill(ProcessSignal.sigterm);
+      return;
+    }
     if (await isCancelled()) {
       process.kill(ProcessSignal.sigterm);
     }
@@ -513,6 +522,12 @@ Future<void> execCommandStreaming(
   cancelTimer.cancel();
   await stdoutCompleter.future;
   await stderrCompleter.future;
+
+  if (isTimedOut) {
+    throw TimeoutException(
+      'Job execution exceeded timeout of ${timeout.inMinutes} minutes.',
+    );
+  }
 
   if (exitCode != 0) {
     throw Exception('act exited with code $exitCode');


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * ジョブ実行に最大 1 時間のタイムアウトが追加されました。
  * 実行が制限時間を超えた場合、自動的に停止して `timed_out` として完了扱いになります。

* **Bug Fixes**
  * タイムアウト時の状態更新が明確になり、成功・失敗とは別に正しく記録されるようになりました。
  * タイムアウト発生時のログ出力が強化されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->