### PR TITLE
feat: add stop VM functionality and refactor process execution to be injectable

### DIFF
--- a/packages/lume_dart/lib/lume_dart.dart
+++ b/packages/lume_dart/lib/lume_dart.dart
@@ -1,1 +1,2 @@
 export 'src/virtual_machine/clone.dart';
+export 'src/virtual_machine/stop.dart';

--- a/packages/lume_dart/lib/src/virtual_machine/clone.dart
+++ b/packages/lume_dart/lib/src/virtual_machine/clone.dart
@@ -1,11 +1,12 @@
 import 'dart:io';
 
-Future<ProcessResult> Function(String, List<String>) runProcess = Process.run;
+import 'process.dart';
 
 Future<void> clone({
   required String sourceName,
   required String targetName,
   bool showLogs = true,
+  ProcessRunner runProcess = Process.run,
 }) async {
   if (showLogs) {
     print('Cloning macOS VM "$sourceName" to "$targetName" via Lume...');

--- a/packages/lume_dart/lib/src/virtual_machine/process.dart
+++ b/packages/lume_dart/lib/src/virtual_machine/process.dart
@@ -1,0 +1,6 @@
+import 'dart:io';
+
+typedef ProcessRunner = Future<ProcessResult> Function(
+  String executable,
+  List<String> arguments,
+);

--- a/packages/lume_dart/lib/src/virtual_machine/stop.dart
+++ b/packages/lume_dart/lib/src/virtual_machine/stop.dart
@@ -1,0 +1,21 @@
+import 'dart:io';
+
+import 'process.dart';
+
+Future<void> stop({
+  required String name,
+  bool showLogs = true,
+  ProcessRunner runProcess = Process.run,
+}) async {
+  if (showLogs) {
+    print('Stopping macOS VM "$name" via Lume...');
+  }
+
+  final result = await runProcess('lume', ['stop', name]);
+  if (result.exitCode != 0) {
+    throw StateError('Failed to stop VM via Lume: ${result.stderr}');
+  }
+  if (showLogs) {
+    print('VM stopped successfully: "$name"');
+  }
+}

--- a/packages/lume_dart/test/virtual_machine/stop_test.dart
+++ b/packages/lume_dart/test/virtual_machine/stop_test.dart
@@ -1,30 +1,28 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:lume_dart/src/virtual_machine/clone.dart';
+import 'package:lume_dart/src/virtual_machine/stop.dart';
 import 'package:test/test.dart';
 
 void main() {
-  group('lume clone unit tests', () {
-    test('clone passes correct arguments to lume', () async {
+  group('lume stop unit tests', () {
+    test('stop passes correct arguments to lume', () async {
       final capturedArgs = <String>[];
-      await clone(
-        sourceName: 'src-vm',
-        targetName: 'dest-vm',
+      await stop(
+        name: 'test-vm',
         showLogs: false,
         runProcess: (executable, args) async {
           capturedArgs.addAll(args);
           return ProcessResult(0, 0, '', '');
         },
       );
-      expect(capturedArgs, equals(['clone', 'src-vm', 'dest-vm']));
+      expect(capturedArgs, equals(['stop', 'test-vm']));
     });
 
-    test('clone throws StateError when process fails', () async {
+    test('stop throws StateError when process fails', () async {
       expect(
-        () => clone(
-          sourceName: 'src-vm',
-          targetName: 'dest-vm',
+        () => stop(
+          name: 'test-vm',
           showLogs: false,
           runProcess: (executable, args) async {
             return ProcessResult(0, 1, '', 'lume: command not found');
@@ -34,12 +32,11 @@ void main() {
       );
     });
 
-    test('clone prints logs when showLogs is true', () async {
+    test('stop prints logs when showLogs is true', () async {
       final logs = <String>[];
       await runZoned(
-        () => clone(
-          sourceName: 'src-vm',
-          targetName: 'dest-vm',
+        () => stop(
+          name: 'test-vm',
           showLogs: true,
           runProcess: (executable, args) async => ProcessResult(0, 0, '', ''),
         ),
@@ -49,17 +46,15 @@ void main() {
           },
         ),
       );
-      expect(
-          logs, contains('Cloning macOS VM "src-vm" to "dest-vm" via Lume...'));
-      expect(logs, contains('VM cloned successfully: "src-vm" -> "dest-vm"'));
+      expect(logs, contains('Stopping macOS VM "test-vm" via Lume...'));
+      expect(logs, contains('VM stopped successfully: "test-vm"'));
     });
 
-    test('clone does not print logs when showLogs is false', () async {
+    test('stop does not print logs when showLogs is false', () async {
       final logs = <String>[];
       await runZoned(
-        () => clone(
-          sourceName: 'src-vm',
-          targetName: 'dest-vm',
+        () => stop(
+          name: 'test-vm',
           showLogs: false,
           runProcess: (executable, args) async => ProcessResult(0, 0, '', ''),
         ),


### PR DESCRIPTION
\

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * macOS VM を停止する機能を追加し、ライブラリ経由で利用できるようになりました。
  * VM の複製処理がより扱いやすくなり、実行時の処理を差し替えやすくなりました。

* **Bug Fixes**
  * 停止や複製に失敗した場合、エラー内容がより明確に返るようになりました。
  * ログ表示の有無を切り替えたときの挙動を安定化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->