### PR TITLE
feat: add delete command for Lume virtual machines

### DIFF
--- a/packages/lume_dart/lib/lume_dart.dart
+++ b/packages/lume_dart/lib/lume_dart.dart
@@ -1,2 +1,3 @@
 export 'src/virtual_machine/clone.dart';
+export 'src/virtual_machine/delete.dart';
 export 'src/virtual_machine/stop.dart';

--- a/packages/lume_dart/lib/src/virtual_machine/delete.dart
+++ b/packages/lume_dart/lib/src/virtual_machine/delete.dart
@@ -1,0 +1,21 @@
+import 'dart:io';
+
+import 'process.dart';
+
+Future<void> delete({
+  required String name,
+  bool showLogs = true,
+  ProcessRunner runProcess = Process.run,
+}) async {
+  if (showLogs) {
+    print('Deleting macOS VM "$name" via Lume...');
+  }
+
+  final result = await runProcess('lume', ['delete', name, '--force']);
+  if (result.exitCode != 0) {
+    throw StateError('Failed to delete VM via Lume: ${result.stderr}');
+  }
+  if (showLogs) {
+    print('VM deleted successfully: "$name"');
+  }
+}

--- a/packages/lume_dart/test/virtual_machine/delete_test.dart
+++ b/packages/lume_dart/test/virtual_machine/delete_test.dart
@@ -1,0 +1,70 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:lume_dart/src/virtual_machine/delete.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('lume delete unit tests', () {
+    test('delete passes correct arguments to lume', () async {
+      final capturedArgs = <String>[];
+      await delete(
+        name: 'test-vm',
+        showLogs: false,
+        runProcess: (executable, args) async {
+          capturedArgs.addAll(args);
+          return ProcessResult(0, 0, '', '');
+        },
+      );
+      expect(capturedArgs, equals(['delete', 'test-vm', '--force']));
+    });
+
+    test('delete throws StateError when process fails', () async {
+      expect(
+        () => delete(
+          name: 'test-vm',
+          showLogs: false,
+          runProcess: (executable, args) async {
+            return ProcessResult(0, 1, '', 'lume: command not found');
+          },
+        ),
+        throwsA(isA<StateError>()),
+      );
+    });
+
+    test('delete prints logs when showLogs is true', () async {
+      final logs = <String>[];
+      await runZoned(
+        () => delete(
+          name: 'test-vm',
+          showLogs: true,
+          runProcess: (executable, args) async => ProcessResult(0, 0, '', ''),
+        ),
+        zoneSpecification: ZoneSpecification(
+          print: (self, parent, zone, line) {
+            logs.add(line);
+          },
+        ),
+      );
+      expect(logs, contains('Deleting macOS VM "test-vm" via Lume...'));
+      expect(logs, contains('VM deleted successfully: "test-vm"'));
+    });
+
+    test('delete does not print logs when showLogs is false', () async {
+      final logs = <String>[];
+      await runZoned(
+        () => delete(
+          name: 'test-vm',
+          showLogs: false,
+          runProcess: (executable, args) async => ProcessResult(0, 0, '', ''),
+        ),
+        zoneSpecification: ZoneSpecification(
+          print: (self, parent, zone, line) {
+            logs.add(line);
+          },
+        ),
+      );
+      expect(logs, isEmpty);
+    });
+  });
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * macOS VM の削除機能を追加し、ライブラリ経由で削除操作を利用できるようになりました。
  * 削除処理の進行状況や完了メッセージを表示でき、必要に応じてログ出力を無効化できます。

* **Tests**
  * 削除コマンドの引数、失敗時のエラー、ログ出力の有無を確認するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->