### PR TITLE
feat: add support for dynamic domain configuration in Caddy via environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,7 @@ S3_SECRET_KEY=your-secret-key-here
 
 # App configuration
 APP_ENV=development
-OPENCI_DOMAIN=localhost
+OPENCI_DOMAIN=http://localhost
 
 # GitHub Configurations
 GITHUB_WEBHOOK_SECRET=your-github-webhook-secret-here

--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,7 @@ S3_SECRET_KEY=your-secret-key-here
 
 # App configuration
 APP_ENV=development
+OPENCI_DOMAIN=localhost
 
 # GitHub Configurations
 GITHUB_WEBHOOK_SECRET=your-github-webhook-secret-here

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,3 +1,3 @@
-api.openci.org, http://localhost {
+{$OPENCI_DOMAIN} {
     reverse_proxy server:8080
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,7 +49,7 @@ services:
     container_name: openci-caddy
     restart: unless-stopped
     environment:
-      - OPENCI_DOMAIN=${OPENCI_DOMAIN:-localhost}
+      - OPENCI_DOMAIN=${OPENCI_DOMAIN:?OPENCI_DOMAIN environment variable is required}
     ports:
       - "80:80"
       - "443:443"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,6 +48,8 @@ services:
     image: caddy:2-alpine
     container_name: openci-caddy
     restart: unless-stopped
+    environment:
+      - OPENCI_DOMAIN=${OPENCI_DOMAIN:-localhost}
     ports:
       - "80:80"
       - "443:443"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * ドメイン設定に環境変数 `OPENCI_DOMAIN` を使えるようになり、ローカル環境でも簡単に切り替えられるようになりました。
  * サンプル値として `http://localhost` を用意し、初期設定がしやすくなりました。
* **設定**
  * Caddy とコンテナ起動時の設定で `OPENCI_DOMAIN` を反映するように変更しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->