### PR TITLE
refactor: remove forced token refresh in auth provider to improve performance

### DIFF
--- a/apps/dashboard/lib/auth/auth_provider.dart
+++ b/apps/dashboard/lib/auth/auth_provider.dart
@@ -16,7 +16,7 @@ Future<String> authedFirebaseIdToken(Ref ref) async {
   if (user == null) {
     throw StateError('User is not authenticated');
   }
-  final token = await user.getIdToken(true);
+  final token = await user.getIdToken();
   if (token == null) {
     throw StateError('Could not get Firebase ID token');
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 認証済みユーザーの Firebase ID トークン取得方法を調整し、既存トークンを優先して利用するようになりました。
  * これにより、不要な再取得を減らし、認証処理がより安定することがあります。


<!-- end of auto-generated comment: release notes by coderabbit.ai -->