### PR TITLE
refactor: make selected team ID nullable and update session clearing logic

### DIFF
--- a/apps/dashboard/lib/firebase/firebase_config_provider.dart
+++ b/apps/dashboard/lib/firebase/firebase_config_provider.dart
@@ -137,6 +137,8 @@ Future<void> clearSelfHostedConfig() async {
   final prefs = await SharedPreferences.getInstance();
   await prefs.remove(_prefKey);
   await prefs.remove(_activeProjectIdPrefKey);
+  await prefs.remove('custom_openci_server_url');
+  await prefs.remove('selected_team_id');
 }
 
 /// Riverpod provider to expose the self-hosted config to UI widgets.

--- a/apps/dashboard/lib/settings/settings_page.dart
+++ b/apps/dashboard/lib/settings/settings_page.dart
@@ -4,8 +4,10 @@ import 'package:dashboard/app_strings.dart';
 import 'package:dashboard/build_info.dart';
 import 'package:dashboard/firebase/firebase_config_provider.dart';
 import 'package:dashboard/macos_updater_initializer.dart';
+import 'package:dashboard/openci_server_url_provider.dart';
 import 'package:dashboard/revenue_cat/revenue_cat.dart';
 import 'package:dashboard/revenue_cat/subscription_page.dart';
+import 'package:dashboard/team/selected_team_provider.dart';
 import 'package:dashboard/team/team_provider.dart';
 import 'package:dashboard/theme/app_colors.dart';
 import 'package:dashboard/utilities/snack_bar_extension.dart';
@@ -498,11 +500,11 @@ String? _formatBuildUpdatedText() {
   return '最終更新: $formattedDate$shaSuffix';
 }
 
-class _SelfHostedIndicator extends StatelessWidget {
+class _SelfHostedIndicator extends ConsumerWidget {
   const _SelfHostedIndicator();
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final settingsT = t.settings;
 
     return FutureBuilder<SelfHostedConfig?>(
@@ -587,6 +589,9 @@ class _SelfHostedIndicator extends StatelessWidget {
                     ),
                     onPressed: () async {
                       await clearSelfHostedConfig();
+                      ref.invalidate(selfHostedConfigProvider);
+                      ref.invalidate(openciServerUrlProvider);
+                      ref.invalidate(selectedTeamIdProvider);
                       if (!context.mounted) return;
                       context.showSnackBarMessage(
                         settingsT.resetToCloudSuccess,

--- a/apps/dashboard/lib/team/selected_team_provider.dart
+++ b/apps/dashboard/lib/team/selected_team_provider.dart
@@ -9,10 +9,10 @@ class SelectedTeamId extends _$SelectedTeamId {
   static const _key = 'selected_team_id';
 
   @override
-  Future<String> build() async {
+  Future<String?> build() async {
     final teams = await ref.watch(teamListProvider.future);
     if (teams.isEmpty) {
-      throw StateError("No teams available");
+      return null;
     }
 
     final selectedId = fetchSelectedId();

--- a/apps/dashboard/lib/team/selected_team_provider.g.dart
+++ b/apps/dashboard/lib/team/selected_team_provider.g.dart
@@ -13,7 +13,7 @@ part of 'selected_team_provider.dart';
 final selectedTeamIdProvider = SelectedTeamIdProvider._();
 
 final class SelectedTeamIdProvider
-    extends $AsyncNotifierProvider<SelectedTeamId, String> {
+    extends $AsyncNotifierProvider<SelectedTeamId, String?> {
   SelectedTeamIdProvider._()
     : super(
         from: null,
@@ -33,19 +33,19 @@ final class SelectedTeamIdProvider
   SelectedTeamId create() => SelectedTeamId();
 }
 
-String _$selectedTeamIdHash() => r'4c0ec8e558139478f5ba4f87715764587c331d0d';
+String _$selectedTeamIdHash() => r'68ef31ba55d8216a2af573a1f80b62b8147a4b91';
 
-abstract class _$SelectedTeamId extends $AsyncNotifier<String> {
-  FutureOr<String> build();
+abstract class _$SelectedTeamId extends $AsyncNotifier<String?> {
+  FutureOr<String?> build();
   @$mustCallSuper
   @override
   void runBuild() {
-    final ref = this.ref as $Ref<AsyncValue<String>, String>;
+    final ref = this.ref as $Ref<AsyncValue<String?>, String?>;
     final element =
         ref.element
             as $ClassProviderElement<
-              AnyNotifier<AsyncValue<String>, String>,
-              AsyncValue<String>,
+              AnyNotifier<AsyncValue<String?>, String?>,
+              AsyncValue<String?>,
               Object?,
               Object?
             >;

--- a/apps/dashboard/lib/workspace/workspace_page.dart
+++ b/apps/dashboard/lib/workspace/workspace_page.dart
@@ -1,7 +1,9 @@
 import 'package:dashboard/team/selected_team_provider.dart';
 import 'package:dashboard/team/switch_team_bottom_sheet.dart';
 import 'package:dashboard/team/team_provider.dart';
+import 'package:dashboard/utilities/async_error_widget.dart';
 import 'package:dashboard/workspace/dashboard_shell.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
@@ -10,21 +12,27 @@ class WorkspacePage extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final selectedTeamId = ref.watch(selectedTeamIdProvider).value;
+    final selectedTeamIdAsync = ref.watch(selectedTeamIdProvider);
     final teamAsync = ref.watch(teamStateProvider);
 
-    if (selectedTeamId == null) {
-      return const Scaffold(
+    return selectedTeamIdAsync.when(
+      data: (selectedTeamId) {
+        if (selectedTeamId == null) {
+          FirebaseAuth.instance.signOut();
+          throw Exception("No team selected");
+        }
+        final teamName = teamAsync.asData?.value.name;
+        return DashboardShell(
+          key: ValueKey(selectedTeamId),
+          workspaceId: selectedTeamId,
+          workspaceName: teamName ?? 'OpenCI team',
+          onSwitchTeam: () => showTeamFlowModal(context),
+        );
+      },
+      loading: () => const Scaffold(
         body: Center(child: CircularProgressIndicator.adaptive()),
-      );
-    }
-
-    final teamName = teamAsync.asData?.value.name;
-    return DashboardShell(
-      key: ValueKey(selectedTeamId),
-      workspaceId: selectedTeamId,
-      workspaceName: teamName ?? 'OpenCI team',
-      onSwitchTeam: () => showTeamFlowModal(context),
+      ),
+      error: asyncErrorWidget,
     );
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 自己ホスト設定をクラウドへ戻す際に、関連する保存情報もまとめて削除されるようになりました。
  * チーム未選択時の挙動を改善し、初期化エラーではなく未選択状態として扱うようになりました。
  * ワークスペース表示で、チーム情報の取得状態に応じて適切に読み込み・エラー表示が切り替わるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->