### PR TITLE
Dl macos latest 2

### DIFF
--- a/apps/openci_server/lib/build_job/build_job_dao.dart
+++ b/apps/openci_server/lib/build_job/build_job_dao.dart
@@ -63,6 +63,22 @@ class BuildJobDao extends DatabaseAccessor<AppDatabase>
         .getSingleOrNull();
   }
 
+  Future<List<DriftBuildJob>> getRecentSuccessfulMacosJobs({
+    required String owner,
+    required String repo,
+    int limit = 10,
+  }) async {
+    return (select(buildJobs)
+          ..where((t) => t.owner.equals(owner))
+          ..where((t) => t.repo.equals(repo))
+          ..where((t) => t.status.equals(BuildJobStatus.SUCCESS.name))
+          ..where((t) => t.runsOn.like('%macos%'))
+          ..where((t) => t.branch.equals('develop'))
+          ..orderBy([(t) => OrderingTerm.desc(t.completedAt)])
+          ..limit(limit))
+        .get();
+  }
+
   Future<DriftBuildJob?> getBuildJob(String id) =>
       (select(buildJobs)..where((t) => t.id.equals(id))).getSingleOrNull();
 

--- a/apps/openci_server/routes/updates/[owner]/[repo]/macos/latest.dart
+++ b/apps/openci_server/routes/updates/[owner]/[repo]/macos/latest.dart
@@ -18,12 +18,13 @@ Future<Response> onRequest(
     final db = context.read<AppDatabase>();
     final storage = context.read<StorageManager>();
 
-    final job = await db.buildJobDao.getLatestSuccessfulMacosJob(
+    final jobs = await db.buildJobDao.getRecentSuccessfulMacosJobs(
       owner: owner,
       repo: repo,
+      limit: 10,
     );
 
-    if (job == null) {
+    if (jobs.isEmpty) {
       return Response.json(
         statusCode: HttpStatus.notFound,
         body: {
@@ -34,29 +35,38 @@ Future<Response> onRequest(
     }
 
     const filename = 'OpenCI-dashboard-macos.zip';
-    final objectName = 'artifacts/buildJobs/${job.id}/$filename';
 
-    try {
-      final stream = await storage.downloadObject(objectName);
-      return Response.stream(
-        body: stream,
-        headers: {
-          HttpHeaders.contentTypeHeader: 'application/zip',
-          'content-disposition': 'attachment; filename="$filename"',
-        },
-      );
-    } catch (e) {
-      if (e.toString().contains('NoSuchKey') || e.toString().contains('404')) {
-        return Response.json(
-          statusCode: HttpStatus.notFound,
-          body: {
-            'success': false,
-            'error': 'Artifact not found for build ${job.id}',
+    for (final job in jobs) {
+      final objectName = 'artifacts/buildJobs/${job.id}/$filename';
+      try {
+        final stream = await storage.downloadObject(objectName);
+        return Response.stream(
+          body: stream,
+          headers: {
+            HttpHeaders.contentTypeHeader: 'application/zip',
+            'content-disposition': 'attachment; filename="$filename"',
           },
         );
+      } catch (e) {
+        if (e.toString().contains('NoSuchKey') ||
+            e.toString().contains('404') ||
+            e.toString().contains('does not exist') ||
+            e.toString().contains('MinioError')) {
+          // Fallback to the next successful job if this artifact is missing
+          continue;
+        }
+        rethrow;
       }
-      rethrow;
     }
+
+    return Response.json(
+      statusCode: HttpStatus.notFound,
+      body: {
+        'success': false,
+        'error':
+            'No macOS build artifact found for recent successful jobs in $owner/$repo',
+      },
+    );
   } catch (e, s) {
     return handleRouteException(
       e,

--- a/apps/openci_server/routes/updates/[owner]/[repo]/macos/latest.dart
+++ b/apps/openci_server/routes/updates/[owner]/[repo]/macos/latest.dart
@@ -1,0 +1,67 @@
+import 'dart:io';
+
+import 'package:dart_frog/dart_frog.dart';
+import 'package:openci_server/database.dart';
+import 'package:openci_server/request/error_handler.dart';
+import 'package:openci_server/storage.dart';
+
+Future<Response> onRequest(
+  RequestContext context,
+  String owner,
+  String repo,
+) async {
+  if (context.request.method != HttpMethod.get) {
+    return Response(statusCode: HttpStatus.methodNotAllowed);
+  }
+
+  try {
+    final db = context.read<AppDatabase>();
+    final storage = context.read<StorageManager>();
+
+    final job = await db.buildJobDao.getLatestSuccessfulMacosJob(
+      owner: owner,
+      repo: repo,
+    );
+
+    if (job == null) {
+      return Response.json(
+        statusCode: HttpStatus.notFound,
+        body: {
+          'success': false,
+          'error': 'No successful macOS build found for $owner/$repo',
+        },
+      );
+    }
+
+    const filename = 'OpenCI-dashboard-macos.zip';
+    final objectName = 'artifacts/buildJobs/${job.id}/$filename';
+
+    try {
+      final stream = await storage.downloadObject(objectName);
+      return Response.stream(
+        body: stream,
+        headers: {
+          HttpHeaders.contentTypeHeader: 'application/zip',
+          'content-disposition': 'attachment; filename="$filename"',
+        },
+      );
+    } catch (e) {
+      if (e.toString().contains('NoSuchKey') || e.toString().contains('404')) {
+        return Response.json(
+          statusCode: HttpStatus.notFound,
+          body: {
+            'success': false,
+            'error': 'Artifact not found for build ${job.id}',
+          },
+        );
+      }
+      rethrow;
+    }
+  } catch (e, s) {
+    return handleRouteException(
+      e,
+      s,
+      logMessage: 'Failed to serve latest macOS build for $owner/$repo',
+    );
+  }
+}

--- a/apps/openci_server/test/routes/updates/latest_test.dart
+++ b/apps/openci_server/test/routes/updates/latest_test.dart
@@ -86,7 +86,7 @@ void main() {
         expect(response.statusCode, equals(HttpStatus.notFound));
         final body = await response.json() as Map<String, dynamic>;
         expect(body['success'], isFalse);
-        expect(body['error'], contains('Artifact not found for build'));
+        expect(body['error'], contains('No macOS build artifact found'));
       },
     );
 

--- a/apps/openci_server/test/routes/updates/latest_test.dart
+++ b/apps/openci_server/test/routes/updates/latest_test.dart
@@ -1,0 +1,145 @@
+import 'dart:io';
+
+import 'package:dart_frog/dart_frog.dart';
+import 'package:dart_frog_test/dart_frog_test.dart';
+import 'package:drift/native.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openci_server/database.dart';
+import 'package:openci_server/storage.dart';
+import 'package:openci_shared/openci_shared.dart';
+import 'package:test/test.dart';
+
+import '../../../routes/updates/[owner]/[repo]/macos/latest.dart' as route;
+
+class MockStorageManager extends Mock implements StorageManager {}
+
+void main() {
+  late AppDatabase db;
+  late MockStorageManager storage;
+
+  setUp(() {
+    db = AppDatabase(NativeDatabase.memory());
+    storage = MockStorageManager();
+  });
+
+  tearDown(() async {
+    await db.close();
+  });
+
+  group('GET /updates/<owner>/<repo>/macos/latest', () {
+    test('responds with 404 when no successful macOS build is found', () async {
+      final context = TestRequestContext(
+        path: '/updates/openci-org/openci/macos/latest',
+        method: HttpMethod.get,
+      );
+      context.provide<AppDatabase>(db);
+      context.provide<StorageManager>(storage);
+
+      final response = await route.onRequest(
+        context.context,
+        'openci-org',
+        'openci',
+      );
+
+      expect(response.statusCode, equals(HttpStatus.notFound));
+      final body = await response.json() as Map<String, dynamic>;
+      expect(body['success'], isFalse);
+      expect(body['error'], contains('No successful macOS build found'));
+    });
+
+    test(
+      'responds with 404 when successful macOS build exists but zip is missing in storage',
+      () async {
+        final job = DriftBuildJob(
+          id: 'job-123',
+          status: BuildJobStatus.SUCCESS,
+          owner: 'openci-org',
+          repo: 'openci',
+          workflowName: 'CI',
+          runsOn: 'macos-latest',
+          branch: 'develop',
+          createdAt: DateTime.now().toUtc(),
+          updatedAt: DateTime.now().toUtc(),
+          completedAt: DateTime.now().toUtc(),
+        );
+        await db.buildJobDao.insertBuildJob(job);
+
+        when(
+          () => storage.downloadObject(
+            'artifacts/buildJobs/job-123/OpenCI-dashboard-macos.zip',
+          ),
+        ).thenThrow(Exception('NoSuchKey'));
+
+        final context = TestRequestContext(
+          path: '/updates/openci-org/openci/macos/latest',
+          method: HttpMethod.get,
+        );
+        context.provide<AppDatabase>(db);
+        context.provide<StorageManager>(storage);
+
+        final response = await route.onRequest(
+          context.context,
+          'openci-org',
+          'openci',
+        );
+
+        expect(response.statusCode, equals(HttpStatus.notFound));
+        final body = await response.json() as Map<String, dynamic>;
+        expect(body['success'], isFalse);
+        expect(body['error'], contains('Artifact not found for build'));
+      },
+    );
+
+    test(
+      'responds with 200 and zip stream when zip exists in storage',
+      () async {
+        final job = DriftBuildJob(
+          id: 'job-123',
+          status: BuildJobStatus.SUCCESS,
+          owner: 'openci-org',
+          repo: 'openci',
+          workflowName: 'CI',
+          runsOn: 'macos-latest',
+          branch: 'develop',
+          createdAt: DateTime.now().toUtc(),
+          updatedAt: DateTime.now().toUtc(),
+          completedAt: DateTime.now().toUtc(),
+        );
+        await db.buildJobDao.insertBuildJob(job);
+
+        final dummyZipContent = 'dummy zip bytes'.codeUnits;
+        when(
+          () => storage.downloadObject(
+            'artifacts/buildJobs/job-123/OpenCI-dashboard-macos.zip',
+          ),
+        ).thenAnswer((_) async => Stream<List<int>>.value(dummyZipContent));
+
+        final context = TestRequestContext(
+          path: '/updates/openci-org/openci/macos/latest',
+          method: HttpMethod.get,
+        );
+        context.provide<AppDatabase>(db);
+        context.provide<StorageManager>(storage);
+
+        final response = await route.onRequest(
+          context.context,
+          'openci-org',
+          'openci',
+        );
+
+        expect(response.statusCode, equals(HttpStatus.ok));
+        expect(
+          response.headers[HttpHeaders.contentTypeHeader],
+          equals('application/zip'),
+        );
+        expect(
+          response.headers['content-disposition'],
+          equals('attachment; filename="OpenCI-dashboard-macos.zip"'),
+        );
+
+        final responseBody = await response.body();
+        expect(responseBody, equals('dummy zip bytes'));
+      },
+    );
+  });
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * macOS 向けの更新取得で、最新1件ではなく直近の成功ビルドを最大10件まで確認するようになりました。
  * 対象アーティファクトが見つからない場合、次の候補ビルドへ自動で切り替えて探します。

* **バグ修正**
  * 成功ビルドはあるのにファイルがない場合のエラーメッセージを、より分かりやすい内容に更新しました。
  * 該当するビルドがない場合は、適切な404レスポンスを返すようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->