### PR TITLE
chore: increase default container resources and limit worker startup to three credentials

### DIFF
--- a/.agents/rules/tools.md
+++ b/.agents/rules/tools.md
@@ -7,3 +7,5 @@ trigger: always_on
 - コードのコメントアウトは不要
 
 - コード生成は、dart run build_runner build でok。-dやflutter pub runを使う必要なし。
+
+- openci_worker_cliなど、pub.devに公開しているパッケージのコードを更新した際は、pubspec.yamlのversionをあげて、差分をCHANGELOGにかいて。

--- a/apps/openci_worker_cli/CHANGELOG.md
+++ b/apps/openci_worker_cli/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.3.12
+
+- Fix: Upgrade default Docker container resource limits to 4 CPUs (up from 2) and 8GB RAM (up from 4g) to prevent resource starvation during Flutter analysis.
+
 ## 2.3.11
 
 - Fix: Prevent supervisor process crash on ProcessException during auto-update, and report the exception to Sentry.

--- a/apps/openci_worker_cli/lib/docker_runner.dart
+++ b/apps/openci_worker_cli/lib/docker_runner.dart
@@ -20,8 +20,8 @@ String containerName({required String workerId, required String buildJobId}) {
 Future<void> createContainer(String name) async {
   _log.info('Creating container $name from $dockerImage...');
 
-  final dockerCpus = Platform.environment['OPENCI_DOCKER_CPUS'] ?? '2';
-  final dockerMemory = Platform.environment['OPENCI_DOCKER_MEMORY'] ?? '4g';
+  final dockerCpus = Platform.environment['OPENCI_DOCKER_CPUS'] ?? '4';
+  final dockerMemory = Platform.environment['OPENCI_DOCKER_MEMORY'] ?? '8g';
 
   final args = ['create', '--name', name];
 

--- a/apps/openci_worker_cli/pubspec.yaml
+++ b/apps/openci_worker_cli/pubspec.yaml
@@ -1,6 +1,6 @@
 name: openci_worker_cli
 description: OpenCI Worker CLI - A CI/CD worker for OpenCI
-version: 2.3.11
+version: 2.3.12
 repository: https://github.com/openci-org/openci
 false_secrets:
   - lib/firebase.dart

--- a/start-workers.sh
+++ b/start-workers.sh
@@ -58,7 +58,7 @@ if (!projectId || !apiKey || !serverUrl) {
   process.exit(1);
 }
 
-platformCreds.forEach((cred, index) => {
+platformCreds.slice(0, 3).forEach((cred, index) => {
   const email = cred.email;
   const password = cred.password;
   


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * Dockerワーカーの標準リソース上限を、CPU 2コア/メモリ4GBからCPU 4コア/メモリ8GBに引き上げました。
  * ワーカー起動時に処理する認証情報の対象を最大3件に制限しました。
* **ドキュメント**
  * 公開パッケージ更新時の手順（バージョン更新・CHANGELOG追記）をルールに追記しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->