### PR TITLE
feat: initialize openci_build_job_processor app and integrate into docker-compose environment

### DIFF
--- a/.openci/openci-build-job-processor.yaml
+++ b/.openci/openci-build-job-processor.yaml
@@ -1,0 +1,25 @@
+name: GoodCI Build Job Processor CI
+
+on:
+  push:
+    branches:
+      - develop
+
+  pull_request:
+    branches:
+      - develop
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/openci_build_job_processor
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run Flutter Analyze
+        run: flutter analyze
+
+      - name: Run Flutter Test
+        run: flutter test

--- a/apps/openci_build_job_processor/Dockerfile
+++ b/apps/openci_build_job_processor/Dockerfile
@@ -1,0 +1,28 @@
+FROM dart:3.11.5 AS build
+
+WORKDIR /app
+
+COPY packages/openci_shared/ ./packages/openci_shared/
+COPY apps/openci_build_job_processor/ ./apps/openci_build_job_processor/
+
+WORKDIR /app/apps/openci_build_job_processor
+
+# Remove workspace resolution so that dart pub get works successfully
+RUN sed -i '/resolution: workspace/d' pubspec.yaml && \
+    sed -i 's/openci_shared: \^1.0.1/openci_shared:\n    path: ..\/..\/packages\/openci_shared/g' pubspec.yaml
+
+RUN dart pub get
+RUN dart compile exe bin/main.dart -o processor
+
+FROM debian:bookworm-slim
+
+RUN groupadd -g 10001 appgroup && \
+    useradd -u 10001 -g appgroup -m -s /bin/bash appuser
+
+WORKDIR /app
+
+COPY --from=build --chown=appuser:appgroup /app/apps/openci_build_job_processor/processor /app/processor
+
+USER appuser
+
+CMD ["/app/processor"]

--- a/apps/openci_build_job_processor/analysis_options.yaml
+++ b/apps/openci_build_job_processor/analysis_options.yaml
@@ -1,0 +1,7 @@
+include: package:lints/recommended.yaml
+
+linter:
+  rules:
+    avoid_print: false
+    prefer_const_constructors: true
+    prefer_const_declarations: true

--- a/apps/openci_build_job_processor/bin/main.dart
+++ b/apps/openci_build_job_processor/bin/main.dart
@@ -2,19 +2,16 @@
 
 import 'dart:io';
 
+import 'package:openci_build_job_processor/openci_build_job_processor.dart';
+
 Future<void> main() async {
   final serverUrl = Platform.environment['OPENCI_SERVER_URL'];
   final runsOnPattern = Platform.environment['OPENCI_RUNS_ON_PATTERN'];
   final baseVmName = Platform.environment['LUME_BASE_VM_NAME'];
-  final lumeServerUrlsStr = Platform.environment['LUME_SERVER_URLS'];
+  final lumeServerUrls = Platform.environment['LUME_SERVER_URLS'];
+  final lumeServerUrlList = parseLumeServerUrls(lumeServerUrls);
 
-  final lumeServerUrls = lumeServerUrlsStr!
-      .split(',')
-      .map((url) => url.trim())
-      .where((url) => url.isNotEmpty)
-      .toList();
-
-  if (lumeServerUrls.isEmpty) {
+  if (lumeServerUrlList.isEmpty) {
     throw StateError('LUME_SERVER_URLS must contain at least one URL.');
   }
 }

--- a/apps/openci_build_job_processor/bin/main.dart
+++ b/apps/openci_build_job_processor/bin/main.dart
@@ -1,0 +1,35 @@
+import 'dart:io';
+
+Future<void> main() async {
+  final serverUrl = Platform.environment['OPENCI_SERVER_URL'];
+  if (serverUrl == null || serverUrl.isEmpty) {
+    throw StateError('OPENCI_SERVER_URL environment variable is required.');
+  }
+
+  final runsOnPattern = Platform.environment['OPENCI_RUNS_ON_PATTERN'];
+  if (runsOnPattern == null || runsOnPattern.isEmpty) {
+    throw StateError(
+      'OPENCI_RUNS_ON_PATTERN environment variable is required.',
+    );
+  }
+
+  final baseVmName = Platform.environment['LUME_BASE_VM_NAME'];
+  if (baseVmName == null || baseVmName.isEmpty) {
+    throw StateError('LUME_BASE_VM_NAME environment variable is required.');
+  }
+
+  final lumeServerUrlsStr = Platform.environment['LUME_SERVER_URLS'];
+  if (lumeServerUrlsStr == null || lumeServerUrlsStr.isEmpty) {
+    throw StateError('LUME_SERVER_URLS environment variable is required.');
+  }
+
+  final lumeServerUrls = lumeServerUrlsStr
+      .split(',')
+      .map((url) => url.trim())
+      .where((url) => url.isNotEmpty)
+      .toList();
+
+  if (lumeServerUrls.isEmpty) {
+    throw StateError('LUME_SERVER_URLS must contain at least one URL.');
+  }
+}

--- a/apps/openci_build_job_processor/bin/main.dart
+++ b/apps/openci_build_job_processor/bin/main.dart
@@ -1,29 +1,14 @@
+// ignore_for_file: unused_local_variable
+
 import 'dart:io';
 
 Future<void> main() async {
   final serverUrl = Platform.environment['OPENCI_SERVER_URL'];
-  if (serverUrl == null || serverUrl.isEmpty) {
-    throw StateError('OPENCI_SERVER_URL environment variable is required.');
-  }
-
   final runsOnPattern = Platform.environment['OPENCI_RUNS_ON_PATTERN'];
-  if (runsOnPattern == null || runsOnPattern.isEmpty) {
-    throw StateError(
-      'OPENCI_RUNS_ON_PATTERN environment variable is required.',
-    );
-  }
-
   final baseVmName = Platform.environment['LUME_BASE_VM_NAME'];
-  if (baseVmName == null || baseVmName.isEmpty) {
-    throw StateError('LUME_BASE_VM_NAME environment variable is required.');
-  }
-
   final lumeServerUrlsStr = Platform.environment['LUME_SERVER_URLS'];
-  if (lumeServerUrlsStr == null || lumeServerUrlsStr.isEmpty) {
-    throw StateError('LUME_SERVER_URLS environment variable is required.');
-  }
 
-  final lumeServerUrls = lumeServerUrlsStr
+  final lumeServerUrls = lumeServerUrlsStr!
       .split(',')
       .map((url) => url.trim())
       .where((url) => url.isNotEmpty)

--- a/apps/openci_build_job_processor/lib/openci_build_job_processor.dart
+++ b/apps/openci_build_job_processor/lib/openci_build_job_processor.dart
@@ -1,0 +1,3 @@
+library;
+
+export 'src/lume_server_url_parser.dart';

--- a/apps/openci_build_job_processor/lib/src/lume_server_url_parser.dart
+++ b/apps/openci_build_job_processor/lib/src/lume_server_url_parser.dart
@@ -1,0 +1,10 @@
+List<String> parseLumeServerUrls(String? urlsStr) {
+  if (urlsStr == null) {
+    return [];
+  }
+  return urlsStr
+      .split(',')
+      .map((url) => url.trim())
+      .where((url) => url.isNotEmpty)
+      .toList();
+}

--- a/apps/openci_build_job_processor/pubspec.yaml
+++ b/apps/openci_build_job_processor/pubspec.yaml
@@ -1,0 +1,15 @@
+name: openci_build_job_processor
+description: OpenCIのビルドジョブを処理するDartプログラムです。
+version: 1.0.0
+publish_to: none
+
+environment:
+  sdk: ^3.11.5
+
+resolution: workspace
+
+dependencies:
+
+dev_dependencies:
+  lints: ^6.0.0
+  test: ^1.24.0

--- a/apps/openci_build_job_processor/test/lume_server_url_parser_test.dart
+++ b/apps/openci_build_job_processor/test/lume_server_url_parser_test.dart
@@ -3,7 +3,7 @@ import 'package:test/test.dart';
 
 void main() {
   group('parseLumeServerUrls', () {
-    test('正常系: カンマ区切りのURLが正しくパースされ、トリムされること', () {
+    test('should parse comma-separated URLs and trim them', () {
       const input =
           'http://localhost:8080, http://localhost:8081 ,http://localhost:8082';
       final result = parseLumeServerUrls(input);
@@ -14,25 +14,28 @@ void main() {
       ]);
     });
 
-    test('正常系: 空の要素が除外されること', () {
+    test('should exclude empty elements', () {
       const input = 'http://localhost:8080,, http://localhost:8081, ';
       final result = parseLumeServerUrls(input);
       expect(result, ['http://localhost:8080', 'http://localhost:8081']);
     });
 
-    test('準正常系: null の場合は空のリストを返すこと', () {
+    test('should return an empty list when input is null', () {
       final result = parseLumeServerUrls(null);
       expect(result, isEmpty);
     });
 
-    test('準正常系: 空文字列の場合は空のリストを返すこと', () {
+    test('should return an empty list when input is an empty string', () {
       final result = parseLumeServerUrls('');
       expect(result, isEmpty);
     });
 
-    test('準正常系: カンマのみの場合は空のリストを返すこと', () {
-      final result = parseLumeServerUrls('  ,  ');
-      expect(result, isEmpty);
-    });
+    test(
+      'should return an empty list when input contains only commas and spaces',
+      () {
+        final result = parseLumeServerUrls('  ,  ');
+        expect(result, isEmpty);
+      },
+    );
   });
 }

--- a/apps/openci_build_job_processor/test/lume_server_url_parser_test.dart
+++ b/apps/openci_build_job_processor/test/lume_server_url_parser_test.dart
@@ -1,0 +1,38 @@
+import 'package:openci_build_job_processor/openci_build_job_processor.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('parseLumeServerUrls', () {
+    test('正常系: カンマ区切りのURLが正しくパースされ、トリムされること', () {
+      const input =
+          'http://localhost:8080, http://localhost:8081 ,http://localhost:8082';
+      final result = parseLumeServerUrls(input);
+      expect(result, [
+        'http://localhost:8080',
+        'http://localhost:8081',
+        'http://localhost:8082',
+      ]);
+    });
+
+    test('正常系: 空の要素が除外されること', () {
+      const input = 'http://localhost:8080,, http://localhost:8081, ';
+      final result = parseLumeServerUrls(input);
+      expect(result, ['http://localhost:8080', 'http://localhost:8081']);
+    });
+
+    test('準正常系: null の場合は空のリストを返すこと', () {
+      final result = parseLumeServerUrls(null);
+      expect(result, isEmpty);
+    });
+
+    test('準正常系: 空文字列の場合は空のリストを返すこと', () {
+      final result = parseLumeServerUrls('');
+      expect(result, isEmpty);
+    });
+
+    test('準正常系: カンマのみの場合は空のリストを返すこと', () {
+      final result = parseLumeServerUrls('  ,  ');
+      expect(result, isEmpty);
+    });
+  });
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,9 +52,9 @@ services:
     restart: unless-stopped
     environment:
       - OPENCI_SERVER_URL=http://server:8080
-      - OPENCI_RUNS_ON_PATTERN=${OPENCI_RUNS_ON_PATTERN}
-      - LUME_BASE_VM_NAME=${LUME_BASE_VM_NAME}
-      - LUME_SERVER_URLS=${LUME_SERVER_URLS}
+      - OPENCI_RUNS_ON_PATTERN=${OPENCI_RUNS_ON_PATTERN:?OPENCI_RUNS_ON_PATTERN environment variable is required}
+      - LUME_BASE_VM_NAME=${LUME_BASE_VM_NAME:?LUME_BASE_VM_NAME environment variable is required}
+      - LUME_SERVER_URLS=${LUME_SERVER_URLS:?LUME_SERVER_URLS environment variable is required}
     depends_on:
       - server
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,20 @@ services:
       - db
       - seaweedfs
 
+  job-processor:
+    build:
+      context: .
+      dockerfile: apps/openci_build_job_processor/Dockerfile
+    container_name: openci-job-processor
+    restart: unless-stopped
+    environment:
+      - OPENCI_SERVER_URL=http://server:8080
+      - OPENCI_RUNS_ON_PATTERN=${OPENCI_RUNS_ON_PATTERN}
+      - LUME_BASE_VM_NAME=${LUME_BASE_VM_NAME}
+      - LUME_SERVER_URLS=${LUME_SERVER_URLS}
+    depends_on:
+      - server
+
   caddy:
     image: caddy:2-alpine
     container_name: openci-caddy

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,6 +6,7 @@ environment:
 
 workspace:
   - apps/dashboard
+  - apps/openci_build_job_processor
   - apps/openci_server
   - apps/openci_worker_cli
   - packages/app_minimizer_plus


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * ビルドジョブを処理する新しいジョブプロセッササービスを追加しました（Docker Compose 対応）。
* **改善**
  * Docker のマルチステージビルドに対応し、非 root（専用ユーザー）で実行します。
  * 起動時に `OPENCI_SERVER_URL` / `OPENCI_RUNS_ON_PATTERN` / `LUME_BASE_VM_NAME` / `LUME_SERVER_URLS` を読み取り、`LUME_SERVER_URLS` をカンマ区切りで解析します。
* **テスト**
  * `LUME_SERVER_URLS` の区切り・除外ルールを検証するテストを追加しました。
* **Chores**
  * Dart のLint/CI設定を更新しました。関連の既存CI設定も整理しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->