### PR TITLE
feat: implement VM lifecycle management (clone, run, stop, delete) in job processor using Lume service

### DIFF
--- a/apps/openci_build_job_processor/lib/src/job_processor.dart
+++ b/apps/openci_build_job_processor/lib/src/job_processor.dart
@@ -1,6 +1,7 @@
 // ignore_for_file: avoid_print
 
 import 'dart:async';
+import 'dart:io';
 import 'dart:math';
 
 import 'package:openci_build_job_processor/openci_build_job_processor.dart';
@@ -93,12 +94,41 @@ class JobProcessor {
     }
 
     bool isSuccess = false;
+    final vmName = 'openci-vm-${job.id}';
+    final baseVmName =
+        Platform.environment['LUME_BASE_VM_NAME'] ?? 'tahoe-base_v1.2.3';
+
     try {
-      print('Executing job steps on $lumeUrl...');
+      print('Cloning VM from $baseVmName to $vmName on Lume host $lumeUrl...');
+      await _lumeService.cloneVm(lumeUrl, baseVmName, vmName);
+
+      print('Starting VM $vmName on Lume host $lumeUrl...');
+      await _lumeService.runVm(lumeUrl, vmName);
+
+      print('Waiting for VM $vmName to be ready...');
+      final vm = await _lumeService.waitForVmToBeReady(lumeUrl, vmName);
+      print(
+        'VM $vmName is ready on IP ${vm.ipAddress}. Executing job steps...',
+      );
+
       await Future<void>.delayed(const Duration(seconds: 5));
       isSuccess = true;
     } catch (e) {
-      print('Exception during job execution: $e');
+      print('Exception during VM operation or job execution: $e');
+    } finally {
+      try {
+        print('Stopping VM $vmName on Lume host $lumeUrl...');
+        await _lumeService.stopVm(lumeUrl, vmName);
+      } catch (e) {
+        print('Failed to stop VM $vmName: $e');
+      }
+
+      try {
+        print('Deleting VM $vmName on Lume host $lumeUrl...');
+        await _lumeService.deleteVm(lumeUrl, vmName);
+      } catch (e) {
+        print('Failed to delete VM $vmName: $e');
+      }
     }
 
     try {

--- a/apps/openci_build_job_processor/lib/src/lume/lume_api_service.chopper.dart
+++ b/apps/openci_build_job_processor/lib/src/lume/lume_api_service.chopper.dart
@@ -24,4 +24,35 @@ final class _$LumeApiService extends LumeApiService {
     final Request $request = Request('GET', $url, client.baseUrl);
     return client.send<List<LumeVM>, LumeVM>($request);
   }
+
+  @override
+  Future<Response<dynamic>> cloneVm(String fullUrl, Map<String, dynamic> body) {
+    final Uri $url = Uri.parse('${fullUrl}');
+    final $body = body;
+    final Request $request = Request('POST', $url, client.baseUrl, body: $body);
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> runVm(String fullUrl, Map<String, dynamic> body) {
+    final Uri $url = Uri.parse('${fullUrl}');
+    final $body = body;
+    final Request $request = Request('POST', $url, client.baseUrl, body: $body);
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> stopVm(String fullUrl, Map<String, dynamic> body) {
+    final Uri $url = Uri.parse('${fullUrl}');
+    final $body = body;
+    final Request $request = Request('POST', $url, client.baseUrl, body: $body);
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> deleteVm(String fullUrl) {
+    final Uri $url = Uri.parse('${fullUrl}');
+    final Request $request = Request('DELETE', $url, client.baseUrl);
+    return client.send<dynamic, dynamic>($request);
+  }
 }

--- a/apps/openci_build_job_processor/lib/src/lume/lume_api_service.dart
+++ b/apps/openci_build_job_processor/lib/src/lume/lume_api_service.dart
@@ -10,4 +10,25 @@ abstract class LumeApiService extends ChopperService {
 
   @GET(path: '{fullUrl}')
   Future<Response<List<LumeVM>>> getVms(@Path('fullUrl') String fullUrl);
+
+  @POST(path: '{fullUrl}')
+  Future<Response<dynamic>> cloneVm(
+    @Path('fullUrl') String fullUrl,
+    @Body() Map<String, dynamic> body,
+  );
+
+  @POST(path: '{fullUrl}')
+  Future<Response<dynamic>> runVm(
+    @Path('fullUrl') String fullUrl,
+    @Body() Map<String, dynamic> body,
+  );
+
+  @POST(path: '{fullUrl}')
+  Future<Response<dynamic>> stopVm(
+    @Path('fullUrl') String fullUrl,
+    @Body() Map<String, dynamic> body,
+  );
+
+  @DELETE(path: '{fullUrl}')
+  Future<Response<dynamic>> deleteVm(@Path('fullUrl') String fullUrl);
 }

--- a/apps/openci_build_job_processor/lib/src/lume/lume_service.dart
+++ b/apps/openci_build_job_processor/lib/src/lume/lume_service.dart
@@ -35,9 +35,11 @@ class LumeService {
     return null;
   }
 
+  static const _defaultTimeout = Duration(seconds: 30);
+
   Future<int> _getRunningVmCount(String lumeUrl) async {
     final url = '$lumeUrl/lume/vms';
-    final response = await _api.getVms(url);
+    final response = await _api.getVms(url).timeout(_defaultTimeout);
 
     if (!response.isSuccessful) {
       throw StateError(
@@ -59,10 +61,9 @@ class LumeService {
     String targetName,
   ) async {
     final url = '$lumeUrl/lume/vms/clone';
-    final response = await _api.cloneVm(url, {
-      'name': sourceName,
-      'newName': targetName,
-    });
+    final response = await _api
+        .cloneVm(url, {'name': sourceName, 'newName': targetName})
+        .timeout(_defaultTimeout);
 
     if (!response.isSuccessful) {
       throw StateError(
@@ -73,7 +74,9 @@ class LumeService {
 
   Future<void> runVm(String lumeUrl, String vmName) async {
     final url = '$lumeUrl/lume/vms/$vmName/run';
-    final response = await _api.runVm(url, {'noDisplay': true});
+    final response = await _api
+        .runVm(url, {'noDisplay': true})
+        .timeout(_defaultTimeout);
 
     if (!response.isSuccessful) {
       throw StateError(
@@ -84,7 +87,7 @@ class LumeService {
 
   Future<void> stopVm(String lumeUrl, String vmName) async {
     final url = '$lumeUrl/lume/vms/$vmName/stop';
-    final response = await _api.stopVm(url, {});
+    final response = await _api.stopVm(url, {}).timeout(_defaultTimeout);
 
     if (!response.isSuccessful) {
       throw StateError(
@@ -95,7 +98,7 @@ class LumeService {
 
   Future<void> deleteVm(String lumeUrl, String vmName) async {
     final url = '$lumeUrl/lume/vms/$vmName';
-    final response = await _api.deleteVm(url);
+    final response = await _api.deleteVm(url).timeout(_defaultTimeout);
 
     if (!response.isSuccessful) {
       throw StateError(
@@ -114,7 +117,7 @@ class LumeService {
 
     while (DateTime.now().isBefore(stopTime)) {
       try {
-        final response = await _api.getVms(url);
+        final response = await _api.getVms(url).timeout(_defaultTimeout);
         if (response.isSuccessful && response.body != null) {
           final vms = response.body!;
           final index = vms.indexWhere((v) => v.name == vmName);

--- a/apps/openci_build_job_processor/lib/src/lume/lume_service.dart
+++ b/apps/openci_build_job_processor/lib/src/lume/lume_service.dart
@@ -3,6 +3,7 @@
 import 'dart:async';
 
 import 'package:chopper/chopper.dart';
+import 'package:lume_dart/lume_dart.dart';
 import 'package:openci_build_job_processor/src/lume/lume_api_service.dart';
 import 'package:openci_build_job_processor/src/lume/lume_json_converter.dart';
 
@@ -50,5 +51,91 @@ class LumeService {
     }
 
     return vms.where((vm) => vm.status.toLowerCase() == 'running').length;
+  }
+
+  Future<void> cloneVm(
+    String lumeUrl,
+    String sourceName,
+    String targetName,
+  ) async {
+    final url = '$lumeUrl/lume/vms/clone';
+    final response = await _api.cloneVm(url, {
+      'name': sourceName,
+      'newName': targetName,
+    });
+
+    if (!response.isSuccessful) {
+      throw StateError(
+        'Failed to clone VM on $lumeUrl: ${response.statusCode} - ${response.error}',
+      );
+    }
+  }
+
+  Future<void> runVm(String lumeUrl, String vmName) async {
+    final url = '$lumeUrl/lume/vms/$vmName/run';
+    final response = await _api.runVm(url, {'noDisplay': true});
+
+    if (!response.isSuccessful) {
+      throw StateError(
+        'Failed to run VM on $lumeUrl: ${response.statusCode} - ${response.error}',
+      );
+    }
+  }
+
+  Future<void> stopVm(String lumeUrl, String vmName) async {
+    final url = '$lumeUrl/lume/vms/$vmName/stop';
+    final response = await _api.stopVm(url, {});
+
+    if (!response.isSuccessful) {
+      throw StateError(
+        'Failed to stop VM on $lumeUrl: ${response.statusCode} - ${response.error}',
+      );
+    }
+  }
+
+  Future<void> deleteVm(String lumeUrl, String vmName) async {
+    final url = '$lumeUrl/lume/vms/$vmName';
+    final response = await _api.deleteVm(url);
+
+    if (!response.isSuccessful) {
+      throw StateError(
+        'Failed to delete VM on $lumeUrl: ${response.statusCode} - ${response.error}',
+      );
+    }
+  }
+
+  Future<LumeVM> waitForVmToBeReady(
+    String lumeUrl,
+    String vmName, {
+    Duration timeout = const Duration(minutes: 5),
+  }) async {
+    final url = '$lumeUrl/lume/vms';
+    final stopTime = DateTime.now().add(timeout);
+
+    while (DateTime.now().isBefore(stopTime)) {
+      try {
+        final response = await _api.getVms(url);
+        if (response.isSuccessful && response.body != null) {
+          final vms = response.body!;
+          final index = vms.indexWhere((v) => v.name == vmName);
+          if (index != -1) {
+            final vm = vms[index];
+            if (vm.status.toLowerCase() == 'running' &&
+                vm.ipAddress != null &&
+                vm.sshAvailable == true) {
+              return vm;
+            }
+          }
+        }
+      } catch (e) {
+        // Ignore transient API or connection errors while booting
+        print('Warning while waiting for VM: $e');
+      }
+      await Future<void>.delayed(const Duration(seconds: 2));
+    }
+
+    throw TimeoutException(
+      'Timeout waiting for Lume VM "$vmName" to boot and become SSH available on $lumeUrl.',
+    );
   }
 }

--- a/apps/openci_build_job_processor/test/lume/lume_service_test.dart
+++ b/apps/openci_build_job_processor/test/lume/lume_service_test.dart
@@ -6,15 +6,71 @@ import 'package:openci_build_job_processor/src/lume/lume_api_service.dart';
 import 'package:test/test.dart';
 
 class FakeLumeApiService extends LumeApiService {
-  FakeLumeApiService(this.getVmsMock);
+  FakeLumeApiService(
+    this.getVmsMock, {
+    this.cloneVmMock,
+    this.runVmMock,
+    this.stopVmMock,
+    this.deleteVmMock,
+  });
 
   final Future<Response<List<LumeVM>>> Function(String url) getVmsMock;
+  final Future<Response<dynamic>> Function(
+    String url,
+    Map<String, dynamic> body,
+  )?
+  cloneVmMock;
+  final Future<Response<dynamic>> Function(
+    String url,
+    Map<String, dynamic> body,
+  )?
+  runVmMock;
+  final Future<Response<dynamic>> Function(
+    String url,
+    Map<String, dynamic> body,
+  )?
+  stopVmMock;
+  final Future<Response<dynamic>> Function(String url)? deleteVmMock;
 
   @override
   Type get definitionType => LumeApiService;
 
   @override
   Future<Response<List<LumeVM>>> getVms(String url) => getVmsMock(url);
+
+  @override
+  Future<Response<dynamic>> cloneVm(
+    String url,
+    Map<String, dynamic> body,
+  ) async {
+    return cloneVmMock != null
+        ? await cloneVmMock!(url, body)
+        : Response(http.Response('{}', 200), null);
+  }
+
+  @override
+  Future<Response<dynamic>> runVm(String url, Map<String, dynamic> body) async {
+    return runVmMock != null
+        ? await runVmMock!(url, body)
+        : Response(http.Response('{}', 202), null);
+  }
+
+  @override
+  Future<Response<dynamic>> stopVm(
+    String url,
+    Map<String, dynamic> body,
+  ) async {
+    return stopVmMock != null
+        ? await stopVmMock!(url, body)
+        : Response(http.Response('{}', 200), null);
+  }
+
+  @override
+  Future<Response<dynamic>> deleteVm(String url) async {
+    return deleteVmMock != null
+        ? await deleteVmMock!(url)
+        : Response(http.Response('{}', 200), null);
+  }
 }
 
 void main() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * ビルドジョブで、Lume上の仮想マシンを複製・起動して処理できるようになりました。
  * 仮想マシンが準備完了した場合のみジョブを成功扱いにします。
  * ジョブ完了時やエラー時に、仮想マシンを停止・削除します。
  * 使用するベース仮想マシンを環境変数で指定できます。

* **改善**
  * 仮想マシンの準備待ちにタイムアウトを設定し、操作中のエラーを記録します。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->