### PR TITLE
feat: implement LumeSshService to automate SSH key installation and cleanup for VM job execution

### DIFF
--- a/apps/openci_build_job_processor/.vscode/settings.json
+++ b/apps/openci_build_job_processor/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "cSpell.words": ["askpass", "keygen", "Lume", "openci"]
+}

--- a/apps/openci_build_job_processor/lib/src/job_executor.dart
+++ b/apps/openci_build_job_processor/lib/src/job_executor.dart
@@ -1,7 +1,9 @@
 import 'dart:async';
 import 'dart:math';
 
+import 'package:lume_dart/lume_dart.dart';
 import 'package:openci_build_job_processor/openci_build_job_processor.dart';
+import 'package:openci_build_job_processor/src/lume/lume_ssh_service.dart';
 import 'package:openci_shared/openci_shared.dart';
 import 'package:sentry/sentry.dart';
 
@@ -10,13 +12,16 @@ class JobExecutor {
     required OpenCiApiService apiService,
     required LumeService lumeService,
     required String baseVmName,
+    LumeSshService? sshService,
   }) : _apiService = apiService,
        _lumeService = lumeService,
-       _baseVmName = baseVmName;
+       _baseVmName = baseVmName,
+       _sshService = sshService ?? LumeSshService();
 
   final OpenCiApiService _apiService;
   final LumeService _lumeService;
   final String _baseVmName;
+  final LumeSshService _sshService;
   final _random = Random();
 
   Future<void> execute(BuildJob job, String lumeUrl) async {
@@ -24,6 +29,7 @@ class JobExecutor {
     final vmName = 'openci-vm-${job.id}';
     bool isSuccess = false;
     bool vmCreated = false;
+    LumeVM? vm;
 
     try {
       await _createRun(job.id, runId);
@@ -35,13 +41,18 @@ class JobExecutor {
         onVmCreated: () => vmCreated = true,
       );
 
+      vm = await _lumeService.waitForVmToBeReady(lumeUrl, vmName);
+      await _sshService.setupDirectSsh(vm, runId);
+
       isSuccess = true;
+      // start processing build job
     } catch (e, s) {
       await Sentry.captureException(e, stackTrace: s);
     } finally {
       if (vmCreated) {
         await _cleanupVm(lumeUrl, vmName);
       }
+      _sshService.cleanupTempSshKeys(runId);
     }
 
     await _completeJob(job.id, runId, isSuccess);
@@ -93,7 +104,6 @@ class JobExecutor {
     onVmCreated();
 
     await _lumeService.runVm(lumeUrl, vmName);
-    await _lumeService.waitForVmToBeReady(lumeUrl, vmName);
   }
 
   Future<void> _createRun(String jobId, String runId) async {

--- a/apps/openci_build_job_processor/lib/src/lume/lume_ssh_service.dart
+++ b/apps/openci_build_job_processor/lib/src/lume/lume_ssh_service.dart
@@ -25,6 +25,7 @@ class LumeSshService {
 
   // Visible for testing to speed up test execution
   Duration retryDelay = const Duration(seconds: 5);
+  Duration sshTimeout = const Duration(seconds: 45);
 
   String getSshKeyPath(String runId) => '/tmp/openci-ssh-key-$runId';
   String getAskPassPath(String runId) => '/tmp/openci-askpass-$runId.sh';
@@ -161,10 +162,18 @@ class LumeSshService {
         'DISPLAY': ':0',
       },
     );
-    await process.stdin.close();
-    await process.stdout.drain<void>();
-    await process.stderr.drain<void>();
-    return process.exitCode;
+
+    try {
+      return await () async {
+        await process.stdin.close();
+        await process.stdout.drain<void>();
+        await process.stderr.drain<void>();
+        return await process.exitCode;
+      }().timeout(sshTimeout);
+    } on TimeoutException {
+      process.kill();
+      return -1;
+    }
   }
 
   void cleanupTempSshKeys(String runId) {

--- a/apps/openci_build_job_processor/lib/src/lume/lume_ssh_service.dart
+++ b/apps/openci_build_job_processor/lib/src/lume/lume_ssh_service.dart
@@ -23,6 +23,9 @@ class LumeSshService {
     'ServerAliveCountMax=5',
   ];
 
+  // Visible for testing to speed up test execution
+  Duration retryDelay = const Duration(seconds: 5);
+
   String getSshKeyPath(String runId) => '/tmp/openci-ssh-key-$runId';
   String getAskPassPath(String runId) => '/tmp/openci-askpass-$runId.sh';
 
@@ -58,16 +61,59 @@ class LumeSshService {
 
     await generateSshKey(sshKeyPath);
 
-    final pubKey = File('$sshKeyPath.pub').readAsStringSync().trim();
     final ip = vm.ipAddress;
     if (ip == null) {
       throw StateError('VM IP is null; cannot install SSH key.');
     }
 
-    final askpass = File(askPassPath);
-    askpass.writeAsStringSync("#!/bin/sh\nprintf '%s' '$_sshPassword'\n");
-    await Process.run('chmod', ['+x', askPassPath]);
+    final pubKey = File('$sshKeyPath.pub').readAsStringSync().trim();
+    await installPublicKeyToVm(
+      ip: ip,
+      pubKey: pubKey,
+      askPassPath: askPassPath,
+    );
+  }
 
+  Future<void> installPublicKeyToVm({
+    required String ip,
+    required String pubKey,
+    required String askPassPath,
+  }) async {
+    await prepareAskPassFile(askPassPath);
+
+    try {
+      await installKeyViaPasswordSsh(
+        ip: ip,
+        pubKey: pubKey,
+        askPassPath: askPassPath,
+      );
+    } finally {
+      deleteAskPassFile(askPassPath);
+    }
+  }
+
+  Future<void> prepareAskPassFile(String path) async {
+    final askpass = File(path);
+    askpass.writeAsStringSync("#!/bin/sh\nprintf '%s' '$_sshPassword'\n");
+    await Process.run('chmod', ['+x', path]);
+  }
+
+  void deleteAskPassFile(String path) {
+    try {
+      final askpass = File(path);
+      if (askpass.existsSync()) {
+        askpass.deleteSync();
+      }
+    } catch (e, s) {
+      unawaited(Sentry.captureException(e, stackTrace: s));
+    }
+  }
+
+  Future<void> installKeyViaPasswordSsh({
+    required String ip,
+    required String pubKey,
+    required String askPassPath,
+  }) async {
     const installCmd =
         'mkdir -p ~/.ssh && touch ~/.ssh/authorized_keys && chmod 700 ~/.ssh && chmod 600 ~/.ssh/authorized_keys';
 
@@ -77,19 +123,13 @@ class LumeSshService {
 
     var exitCode = -1;
     for (var attempt = 1; attempt <= 5; attempt++) {
-      exitCode = await _runPasswordSsh(
+      exitCode = await runPasswordSsh(
         ip: ip,
         command: '$installCmd && $appendCmd',
         askPassPath: askPassPath,
       );
       if (exitCode == 0) break;
-      await Future<void>.delayed(const Duration(seconds: 5));
-    }
-
-    try {
-      askpass.deleteSync();
-    } catch (e, s) {
-      unawaited(Sentry.captureException(e, stackTrace: s));
+      await Future<void>.delayed(retryDelay);
     }
 
     if (exitCode != 0) {
@@ -97,7 +137,7 @@ class LumeSshService {
     }
   }
 
-  Future<int> _runPasswordSsh({
+  Future<int> runPasswordSsh({
     required String ip,
     required String command,
     required String askPassPath,

--- a/apps/openci_build_job_processor/lib/src/lume/lume_ssh_service.dart
+++ b/apps/openci_build_job_processor/lib/src/lume/lume_ssh_service.dart
@@ -1,0 +1,130 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:lume_dart/lume_dart.dart';
+import 'package:sentry/sentry.dart';
+
+class LumeSshService {
+  static const _sshUser = 'admin';
+  static const _sshPassword = 'admin';
+  static const List<String> _sshBaseOpts = [
+    '-o',
+    'StrictHostKeyChecking=no',
+    '-o',
+    'UserKnownHostsFile=/dev/null',
+    '-o',
+    'LogLevel=ERROR',
+    '-o',
+    'ConnectTimeout=30',
+    '-o',
+    'ServerAliveInterval=30',
+    '-o',
+    'ServerAliveCountMax=5',
+  ];
+
+  String getSshKeyPath(String runId) => '/tmp/openci-ssh-key-$runId';
+  String getAskPassPath(String runId) => '/tmp/openci-askpass-$runId.sh';
+
+  Future<void> setupDirectSsh(LumeVM vm, String runId) async {
+    final sshKeyPath = getSshKeyPath(runId);
+    final askPassPath = getAskPassPath(runId);
+    final keyFile = File(sshKeyPath);
+    if (!keyFile.existsSync()) {
+      await Process.run('ssh-keygen', [
+        '-t',
+        'ed25519',
+        '-f',
+        sshKeyPath,
+        '-N',
+        '',
+        '-q',
+      ]);
+    }
+    final pubKey = File('$sshKeyPath.pub').readAsStringSync().trim();
+    final ip = vm.ipAddress;
+    if (ip == null) {
+      throw StateError('VM IP is null; cannot install SSH key.');
+    }
+
+    final askpass = File(askPassPath);
+    askpass.writeAsStringSync("#!/bin/sh\nprintf '%s' '$_sshPassword'\n");
+    await Process.run('chmod', ['+x', askPassPath]);
+
+    const installCmd =
+        'mkdir -p ~/.ssh && touch ~/.ssh/authorized_keys && chmod 700 ~/.ssh && chmod 600 ~/.ssh/authorized_keys';
+
+    Future<int> runPasswordSsh(String command) async {
+      final process = await Process.start(
+        '/usr/bin/ssh',
+        [
+          ..._sshBaseOpts,
+          '-o',
+          'PubkeyAuthentication=no',
+          '-o',
+          'PreferredAuthentications=password,keyboard-interactive',
+          '-o',
+          'NumberOfPasswordPrompts=1',
+          '$_sshUser@$ip',
+          command,
+        ],
+        environment: {
+          'SSH_ASKPASS': askPassPath,
+          'SSH_ASKPASS_REQUIRE': 'force',
+          'DISPLAY': ':0',
+        },
+      );
+      await process.stdin.close();
+      await process.stdout.drain<void>();
+      await process.stderr.drain<void>();
+      return process.exitCode;
+    }
+
+    final pubKeyB64 = base64Encode(utf8.encode('$pubKey\n'));
+    final appendCmd =
+        'printf %s \'$pubKeyB64\' | base64 -D >> ~/.ssh/authorized_keys';
+
+    var exitCode = -1;
+    for (var attempt = 1; attempt <= 5; attempt++) {
+      exitCode = await runPasswordSsh('$installCmd && $appendCmd');
+      if (exitCode == 0) break;
+      await Future<void>.delayed(const Duration(seconds: 5));
+    }
+
+    try {
+      askpass.deleteSync();
+    } catch (e, s) {
+      unawaited(Sentry.captureException(e, stackTrace: s));
+    }
+
+    if (exitCode != 0) {
+      throw Exception('Failed to install SSH key on VM. Exit code: $exitCode');
+    }
+  }
+
+  void cleanupTempSshKeys(String runId) {
+    try {
+      final sshKeyPath = getSshKeyPath(runId);
+      final keyFile = File(sshKeyPath);
+      if (keyFile.existsSync()) {
+        keyFile.deleteSync();
+      }
+      final pubKeyFile = File('$sshKeyPath.pub');
+      if (pubKeyFile.existsSync()) {
+        pubKeyFile.deleteSync();
+      }
+    } catch (e, s) {
+      unawaited(Sentry.captureException(e, stackTrace: s));
+    }
+
+    try {
+      final askPassPath = getAskPassPath(runId);
+      final askPassFile = File(askPassPath);
+      if (askPassFile.existsSync()) {
+        askPassFile.deleteSync();
+      }
+    } catch (e, s) {
+      unawaited(Sentry.captureException(e, stackTrace: s));
+    }
+  }
+}

--- a/apps/openci_build_job_processor/lib/src/lume/lume_ssh_service.dart
+++ b/apps/openci_build_job_processor/lib/src/lume/lume_ssh_service.dart
@@ -26,21 +26,38 @@ class LumeSshService {
   String getSshKeyPath(String runId) => '/tmp/openci-ssh-key-$runId';
   String getAskPassPath(String runId) => '/tmp/openci-askpass-$runId.sh';
 
+  Future<void> generateSshKey(String sshKeyPath) async {
+    final keyFile = File(sshKeyPath);
+    final pubKeyFile = File('$sshKeyPath.pub');
+
+    try {
+      if (keyFile.existsSync()) {
+        keyFile.deleteSync();
+      }
+      if (pubKeyFile.existsSync()) {
+        pubKeyFile.deleteSync();
+      }
+    } catch (e, s) {
+      unawaited(Sentry.captureException(e, stackTrace: s));
+    }
+
+    await Process.run('ssh-keygen', [
+      '-t',
+      'ed25519',
+      '-f',
+      sshKeyPath,
+      '-N',
+      '',
+      '-q',
+    ]);
+  }
+
   Future<void> setupDirectSsh(LumeVM vm, String runId) async {
     final sshKeyPath = getSshKeyPath(runId);
     final askPassPath = getAskPassPath(runId);
-    final keyFile = File(sshKeyPath);
-    if (!keyFile.existsSync()) {
-      await Process.run('ssh-keygen', [
-        '-t',
-        'ed25519',
-        '-f',
-        sshKeyPath,
-        '-N',
-        '',
-        '-q',
-      ]);
-    }
+
+    await generateSshKey(sshKeyPath);
+
     final pubKey = File('$sshKeyPath.pub').readAsStringSync().trim();
     final ip = vm.ipAddress;
     if (ip == null) {
@@ -54,39 +71,17 @@ class LumeSshService {
     const installCmd =
         'mkdir -p ~/.ssh && touch ~/.ssh/authorized_keys && chmod 700 ~/.ssh && chmod 600 ~/.ssh/authorized_keys';
 
-    Future<int> runPasswordSsh(String command) async {
-      final process = await Process.start(
-        '/usr/bin/ssh',
-        [
-          ..._sshBaseOpts,
-          '-o',
-          'PubkeyAuthentication=no',
-          '-o',
-          'PreferredAuthentications=password,keyboard-interactive',
-          '-o',
-          'NumberOfPasswordPrompts=1',
-          '$_sshUser@$ip',
-          command,
-        ],
-        environment: {
-          'SSH_ASKPASS': askPassPath,
-          'SSH_ASKPASS_REQUIRE': 'force',
-          'DISPLAY': ':0',
-        },
-      );
-      await process.stdin.close();
-      await process.stdout.drain<void>();
-      await process.stderr.drain<void>();
-      return process.exitCode;
-    }
-
     final pubKeyB64 = base64Encode(utf8.encode('$pubKey\n'));
     final appendCmd =
         'printf %s \'$pubKeyB64\' | base64 -D >> ~/.ssh/authorized_keys';
 
     var exitCode = -1;
     for (var attempt = 1; attempt <= 5; attempt++) {
-      exitCode = await runPasswordSsh('$installCmd && $appendCmd');
+      exitCode = await _runPasswordSsh(
+        ip: ip,
+        command: '$installCmd && $appendCmd',
+        askPassPath: askPassPath,
+      );
       if (exitCode == 0) break;
       await Future<void>.delayed(const Duration(seconds: 5));
     }
@@ -100,6 +95,36 @@ class LumeSshService {
     if (exitCode != 0) {
       throw Exception('Failed to install SSH key on VM. Exit code: $exitCode');
     }
+  }
+
+  Future<int> _runPasswordSsh({
+    required String ip,
+    required String command,
+    required String askPassPath,
+  }) async {
+    final process = await Process.start(
+      '/usr/bin/ssh',
+      [
+        ..._sshBaseOpts,
+        '-o',
+        'PubkeyAuthentication=no',
+        '-o',
+        'PreferredAuthentications=password,keyboard-interactive',
+        '-o',
+        'NumberOfPasswordPrompts=1',
+        '$_sshUser@$ip',
+        command,
+      ],
+      environment: {
+        'SSH_ASKPASS': askPassPath,
+        'SSH_ASKPASS_REQUIRE': 'force',
+        'DISPLAY': ':0',
+      },
+    );
+    await process.stdin.close();
+    await process.stdout.drain<void>();
+    await process.stderr.drain<void>();
+    return process.exitCode;
   }
 
   void cleanupTempSshKeys(String runId) {

--- a/apps/openci_build_job_processor/test/lume/lume_ssh_service_test.dart
+++ b/apps/openci_build_job_processor/test/lume/lume_ssh_service_test.dart
@@ -3,6 +3,23 @@ import 'dart:io';
 import 'package:openci_build_job_processor/src/lume/lume_ssh_service.dart';
 import 'package:test/test.dart';
 
+class MockLumeSshService extends LumeSshService {
+  int mockExitCode = 0;
+  int runCount = 0;
+  List<String> executedCommands = [];
+
+  @override
+  Future<int> runPasswordSsh({
+    required String ip,
+    required String command,
+    required String askPassPath,
+  }) async {
+    runCount++;
+    executedCommands.add(command);
+    return mockExitCode;
+  }
+}
+
 void main() {
   group('LumeSshService', () {
     late LumeSshService sshService;
@@ -43,6 +60,13 @@ void main() {
       expect(File(pubKeyPath).existsSync(), isFalse);
       expect(File(askPassPath).existsSync(), isFalse);
     });
+
+    test(
+      'cleanupTempSshKeys completes without exception when files do not exist',
+      () {
+        expect(() => sshService.cleanupTempSshKeys(testRunId), returnsNormally);
+      },
+    );
 
     test('generateSshKey generates valid SSH key pair files', () async {
       final keyPath = sshService.getSshKeyPath(testRunId);
@@ -107,6 +131,106 @@ void main() {
         } finally {
           sshService.cleanupTempSshKeys(testRunId);
         }
+      },
+    );
+
+    test(
+      'prepareAskPassFile creates askpass file with executable permissions and correct password',
+      () async {
+        final askPassPath = sshService.getAskPassPath(testRunId);
+
+        if (File(askPassPath).existsSync()) File(askPassPath).deleteSync();
+
+        try {
+          await sshService.prepareAskPassFile(askPassPath);
+
+          final file = File(askPassPath);
+          expect(file.existsSync(), isTrue);
+
+          // Verify content contains password
+          final content = file.readAsStringSync();
+          expect(content, contains('admin'));
+          expect(content, startsWith('#!/bin/sh'));
+
+          // Verify executable permission (non-Windows check)
+          if (!Platform.isWindows) {
+            final result = await Process.run('test', ['-x', askPassPath]);
+            expect(
+              result.exitCode,
+              equals(0),
+              reason: 'File should be executable',
+            );
+          }
+        } finally {
+          sshService.cleanupTempSshKeys(testRunId);
+        }
+      },
+    );
+
+    test('deleteAskPassFile deletes the file successfully', () {
+      final askPassPath = sshService.getAskPassPath(testRunId);
+      final file = File(askPassPath);
+
+      file.writeAsStringSync('dummy-askpass-content');
+      expect(file.existsSync(), isTrue);
+
+      sshService.deleteAskPassFile(askPassPath);
+      expect(file.existsSync(), isFalse);
+    });
+
+    test(
+      'deleteAskPassFile completes without exception when file does not exist',
+      () {
+        final askPassPath = sshService.getAskPassPath(testRunId);
+        final file = File(askPassPath);
+        if (file.existsSync()) file.deleteSync();
+
+        expect(
+          () => sshService.deleteAskPassFile(askPassPath),
+          returnsNormally,
+        );
+      },
+    );
+
+    test(
+      'installKeyViaPasswordSsh completes successfully on first attempt when exitCode is 0',
+      () async {
+        final mockService = MockLumeSshService();
+        mockService.mockExitCode = 0;
+        mockService.retryDelay = Duration.zero;
+
+        await mockService.installKeyViaPasswordSsh(
+          ip: '127.0.0.1',
+          pubKey: 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAA...',
+          askPassPath: '/tmp/dummy-askpass',
+        );
+
+        expect(mockService.runCount, equals(1));
+        expect(mockService.executedCommands.first, contains('authorized_keys'));
+      },
+    );
+
+    test(
+      'installKeyViaPasswordSsh retries and throws exception when all attempts fail',
+      () async {
+        final mockService = MockLumeSshService();
+        mockService.mockExitCode = 1; // Always fail
+        mockService.retryDelay = Duration.zero; // Speed up test
+
+        var threw = false;
+        try {
+          await mockService.installKeyViaPasswordSsh(
+            ip: '127.0.0.1',
+            pubKey: 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAA...',
+            askPassPath: '/tmp/dummy-askpass',
+          );
+        } catch (e) {
+          threw = true;
+          expect(e, isA<Exception>());
+        }
+
+        expect(threw, isTrue);
+        expect(mockService.runCount, equals(5));
       },
     );
   });

--- a/apps/openci_build_job_processor/test/lume/lume_ssh_service_test.dart
+++ b/apps/openci_build_job_processor/test/lume/lume_ssh_service_test.dart
@@ -233,5 +233,17 @@ void main() {
         expect(mockService.runCount, equals(5));
       },
     );
+
+    test('runPasswordSsh returns -1 and kills process on timeout', () async {
+      sshService.sshTimeout = const Duration(milliseconds: 1);
+
+      final exitCode = await sshService.runPasswordSsh(
+        ip: '127.0.0.1',
+        command: 'sleep 10',
+        askPassPath: '/tmp/non-existent-askpass-path',
+      );
+
+      expect(exitCode, equals(-1));
+    });
   });
 }

--- a/apps/openci_build_job_processor/test/lume/lume_ssh_service_test.dart
+++ b/apps/openci_build_job_processor/test/lume/lume_ssh_service_test.dart
@@ -20,7 +20,21 @@ class MockLumeSshService extends LumeSshService {
   }
 }
 
-void main() {
+Future<bool> _hasCommand(String command) async {
+  try {
+    final result = Platform.isWindows
+        ? await Process.run('where', [command])
+        : await Process.run('which', [command]);
+    return result.exitCode == 0;
+  } catch (_) {
+    return false;
+  }
+}
+
+void main() async {
+  final hasSshKeygen = await _hasCommand('ssh-keygen');
+  final hasSsh = File('/usr/bin/ssh').existsSync() || await _hasCommand('ssh');
+
   group('LumeSshService', () {
     late LumeSshService sshService;
     const testRunId = 'test-run-123';
@@ -68,32 +82,36 @@ void main() {
       },
     );
 
-    test('generateSshKey generates valid SSH key pair files', () async {
-      final keyPath = sshService.getSshKeyPath(testRunId);
-      final pubKeyPath = '$keyPath.pub';
+    test(
+      'generateSshKey generates valid SSH key pair files',
+      () async {
+        final keyPath = sshService.getSshKeyPath(testRunId);
+        final pubKeyPath = '$keyPath.pub';
 
-      // Ensure files do not exist beforehand
-      if (File(keyPath).existsSync()) File(keyPath).deleteSync();
-      if (File(pubKeyPath).existsSync()) File(pubKeyPath).deleteSync();
+        // Ensure files do not exist beforehand
+        if (File(keyPath).existsSync()) File(keyPath).deleteSync();
+        if (File(pubKeyPath).existsSync()) File(pubKeyPath).deleteSync();
 
-      try {
-        await sshService.generateSshKey(keyPath);
+        try {
+          await sshService.generateSshKey(keyPath);
 
-        expect(File(keyPath).existsSync(), isTrue);
-        expect(File(pubKeyPath).existsSync(), isTrue);
+          expect(File(keyPath).existsSync(), isTrue);
+          expect(File(pubKeyPath).existsSync(), isTrue);
 
-        // Verify the private key content starts with the standard header
-        final privateKeyContent = File(keyPath).readAsStringSync();
-        expect(privateKeyContent, contains('BEGIN OPENSSH PRIVATE KEY'));
+          // Verify the private key content starts with the standard header
+          final privateKeyContent = File(keyPath).readAsStringSync();
+          expect(privateKeyContent, contains('BEGIN OPENSSH PRIVATE KEY'));
 
-        // Verify public key starts with key type
-        final publicKeyContent = File(pubKeyPath).readAsStringSync();
-        expect(publicKeyContent, startsWith('ssh-ed25519'));
-      } finally {
-        // Cleanup after test
-        sshService.cleanupTempSshKeys(testRunId);
-      }
-    });
+          // Verify public key starts with key type
+          final publicKeyContent = File(pubKeyPath).readAsStringSync();
+          expect(publicKeyContent, startsWith('ssh-ed25519'));
+        } finally {
+          // Cleanup after test
+          sshService.cleanupTempSshKeys(testRunId);
+        }
+      },
+      skip: hasSshKeygen ? null : 'ssh-keygen command not available',
+    );
 
     test(
       'generateSshKey deletes existing keys and generates a new pair',
@@ -132,6 +150,7 @@ void main() {
           sshService.cleanupTempSshKeys(testRunId);
         }
       },
+      skip: hasSshKeygen ? null : 'ssh-keygen command not available',
     );
 
     test(
@@ -234,16 +253,20 @@ void main() {
       },
     );
 
-    test('runPasswordSsh returns -1 and kills process on timeout', () async {
-      sshService.sshTimeout = const Duration(milliseconds: 1);
+    test(
+      'runPasswordSsh returns -1 and kills process on timeout',
+      () async {
+        sshService.sshTimeout = const Duration(milliseconds: 1);
 
-      final exitCode = await sshService.runPasswordSsh(
-        ip: '127.0.0.1',
-        command: 'sleep 10',
-        askPassPath: '/tmp/non-existent-askpass-path',
-      );
+        final exitCode = await sshService.runPasswordSsh(
+          ip: '127.0.0.1',
+          command: 'sleep 10',
+          askPassPath: '/tmp/non-existent-askpass-path',
+        );
 
-      expect(exitCode, equals(-1));
-    });
+        expect(exitCode, equals(-1));
+      },
+      skip: hasSsh ? null : 'ssh command not available',
+    );
   });
 }

--- a/apps/openci_build_job_processor/test/lume/lume_ssh_service_test.dart
+++ b/apps/openci_build_job_processor/test/lume/lume_ssh_service_test.dart
@@ -1,0 +1,113 @@
+import 'dart:io';
+
+import 'package:openci_build_job_processor/src/lume/lume_ssh_service.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('LumeSshService', () {
+    late LumeSshService sshService;
+    const testRunId = 'test-run-123';
+
+    setUp(() {
+      sshService = LumeSshService();
+    });
+
+    test('getSshKeyPath returns correct path', () {
+      final path = sshService.getSshKeyPath(testRunId);
+      expect(path, equals('/tmp/openci-ssh-key-test-run-123'));
+    });
+
+    test('getAskPassPath returns correct path', () {
+      final path = sshService.getAskPassPath(testRunId);
+      expect(path, equals('/tmp/openci-askpass-test-run-123.sh'));
+    });
+
+    test('cleanupTempSshKeys deletes files if they exist', () {
+      final keyPath = sshService.getSshKeyPath(testRunId);
+      final pubKeyPath = '$keyPath.pub';
+      final askPassPath = sshService.getAskPassPath(testRunId);
+
+      // Create dummy files
+      File(keyPath).writeAsStringSync('dummy-key');
+      File(pubKeyPath).writeAsStringSync('dummy-pub');
+      File(askPassPath).writeAsStringSync('dummy-askpass');
+
+      expect(File(keyPath).existsSync(), isTrue);
+      expect(File(pubKeyPath).existsSync(), isTrue);
+      expect(File(askPassPath).existsSync(), isTrue);
+
+      // Cleanup
+      sshService.cleanupTempSshKeys(testRunId);
+
+      expect(File(keyPath).existsSync(), isFalse);
+      expect(File(pubKeyPath).existsSync(), isFalse);
+      expect(File(askPassPath).existsSync(), isFalse);
+    });
+
+    test('generateSshKey generates valid SSH key pair files', () async {
+      final keyPath = sshService.getSshKeyPath(testRunId);
+      final pubKeyPath = '$keyPath.pub';
+
+      // Ensure files do not exist beforehand
+      if (File(keyPath).existsSync()) File(keyPath).deleteSync();
+      if (File(pubKeyPath).existsSync()) File(pubKeyPath).deleteSync();
+
+      try {
+        await sshService.generateSshKey(keyPath);
+
+        expect(File(keyPath).existsSync(), isTrue);
+        expect(File(pubKeyPath).existsSync(), isTrue);
+
+        // Verify the private key content starts with the standard header
+        final privateKeyContent = File(keyPath).readAsStringSync();
+        expect(privateKeyContent, contains('BEGIN OPENSSH PRIVATE KEY'));
+
+        // Verify public key starts with key type
+        final publicKeyContent = File(pubKeyPath).readAsStringSync();
+        expect(publicKeyContent, startsWith('ssh-ed25519'));
+      } finally {
+        // Cleanup after test
+        sshService.cleanupTempSshKeys(testRunId);
+      }
+    });
+
+    test(
+      'generateSshKey deletes existing keys and generates a new pair',
+      () async {
+        final keyPath = sshService.getSshKeyPath(testRunId);
+        final pubKeyPath = '$keyPath.pub';
+
+        // Create dummy files beforehand
+        File(keyPath).writeAsStringSync('old-dummy-private-key');
+        File(pubKeyPath).writeAsStringSync('old-dummy-public-key');
+
+        expect(
+          File(keyPath).readAsStringSync(),
+          equals('old-dummy-private-key'),
+        );
+        expect(
+          File(pubKeyPath).readAsStringSync(),
+          equals('old-dummy-public-key'),
+        );
+
+        try {
+          await sshService.generateSshKey(keyPath);
+
+          expect(File(keyPath).existsSync(), isTrue);
+          expect(File(pubKeyPath).existsSync(), isTrue);
+
+          // Check that old files are overwritten and contain new ed25519 keys
+          final privateKeyContent = File(keyPath).readAsStringSync();
+          expect(privateKeyContent, isNot(equals('old-dummy-private-key')));
+          expect(privateKeyContent, contains('BEGIN OPENSSH PRIVATE KEY'));
+
+          final publicKeyContent = File(pubKeyPath).readAsStringSync();
+          expect(publicKeyContent, isNot(equals('old-dummy-public-key')));
+          expect(publicKeyContent, startsWith('ssh-ed25519'));
+        } finally {
+          sshService.cleanupTempSshKeys(testRunId);
+        }
+      },
+    );
+  });
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * ビルド用VMに一時SSH鍵とaskpassを用意し、VM準備完了後に直接SSH接続を自動設定します。
  * 公開鍵の反映は失敗時に最大5回まで自動再試行します。
* **バグ修正**
  * ジョブ終了後に一時鍵・askpass関連ファイルを確実に削除し、VM準備前に後続処理へ進む可能性を解消しました。
* **テスト**
  * SSH鍵生成、再試行、タイムアウトなどのケースを追加検証しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->