### PR TITLE
feat: initialize openci_build_job_processor_linux microservice and add to docker-compose

### DIFF
--- a/apps/openci_build_job_processor_linux/Dockerfile
+++ b/apps/openci_build_job_processor_linux/Dockerfile
@@ -1,0 +1,32 @@
+FROM dart:3.11.5 AS build
+
+WORKDIR /app
+
+COPY packages/openci_shared/ ./packages/openci_shared/
+COPY apps/openci_build_job_processor_linux/ ./apps/openci_build_job_processor_linux/
+
+WORKDIR /app/apps/openci_build_job_processor_linux
+
+# Remove workspace resolution so that dart pub get works successfully
+RUN sed -i '/resolution: workspace/d' pubspec.yaml && \
+    sed -i 's/openci_shared: \^1.0.1/openci_shared:\n    path: ..\/..\/packages\/openci_shared/g' pubspec.yaml
+
+RUN dart pub get
+RUN dart compile exe bin/main.dart -o processor
+
+FROM debian:bookworm-slim
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN groupadd -g 10001 appgroup && \
+    useradd -u 10001 -g appgroup -m -s /bin/bash appuser
+
+WORKDIR /app
+
+COPY --from=build --chown=appuser:appgroup /app/apps/openci_build_job_processor_linux/processor /app/processor
+
+USER appuser
+
+CMD ["/app/processor"]

--- a/apps/openci_build_job_processor_linux/analysis_options.yaml
+++ b/apps/openci_build_job_processor_linux/analysis_options.yaml
@@ -1,0 +1,7 @@
+include: package:lints/recommended.yaml
+
+linter:
+  rules:
+    avoid_print: true
+    prefer_const_constructors: true
+    prefer_const_declarations: true

--- a/apps/openci_build_job_processor_linux/bin/main.dart
+++ b/apps/openci_build_job_processor_linux/bin/main.dart
@@ -1,0 +1,9 @@
+import 'dart:async';
+import 'dart:io';
+
+Future<void> main() async {
+  stderr.writeln('openci_build_job_processor_linux started (mock entrypoint)');
+  while (true) {
+    await Future.delayed(const Duration(seconds: 60));
+  }
+}

--- a/apps/openci_build_job_processor_linux/lib/src/processor_config.dart
+++ b/apps/openci_build_job_processor_linux/lib/src/processor_config.dart
@@ -1,0 +1,45 @@
+import 'dart:io';
+
+class ProcessorConfig {
+  ProcessorConfig({
+    required this.serverUrl,
+    required this.runsOnPattern,
+    required this.baseInstanceName,
+    required this.incusApiUrl,
+    required this.internalApiKey,
+    this.sentryDsn,
+    this.maxConcurrentJobs = 3,
+  });
+
+  final String serverUrl;
+  final String runsOnPattern;
+  final String baseInstanceName;
+  final String incusApiUrl;
+  final String internalApiKey;
+  final String? sentryDsn;
+  final int maxConcurrentJobs;
+
+  factory ProcessorConfig.fromEnvironment() {
+    String getRequired(String key) {
+      final value = Platform.environment[key];
+      if (value == null || value.isEmpty) {
+        throw StateError('必要な環境変数 $key が設定されていません。');
+      }
+      return value;
+    }
+
+    final maxConcurrentJobsStr =
+        Platform.environment['OPENCI_MAX_CONCURRENT_JOBS'] ?? '3';
+    final maxConcurrentJobs = int.tryParse(maxConcurrentJobsStr) ?? 3;
+
+    return ProcessorConfig(
+      serverUrl: getRequired('OPENCI_SERVER_URL'),
+      runsOnPattern: getRequired('OPENCI_RUNS_ON_PATTERN'),
+      baseInstanceName: getRequired('INCUS_BASE_INSTANCE'),
+      incusApiUrl: getRequired('INCUS_API_URL'),
+      internalApiKey: getRequired('INTERNAL_API_KEY'),
+      sentryDsn: Platform.environment['SENTRY_DSN'],
+      maxConcurrentJobs: maxConcurrentJobs,
+    );
+  }
+}

--- a/apps/openci_build_job_processor_linux/pubspec.yaml
+++ b/apps/openci_build_job_processor_linux/pubspec.yaml
@@ -1,0 +1,28 @@
+name: openci_build_job_processor_linux
+description: OpenCIのLinuxビルドジョブをIncusで処理するDartプログラムです。
+version: 1.0.0
+publish_to: none
+
+environment:
+  sdk: ^3.11.5
+
+resolution: workspace
+
+dependencies:
+  chopper: ^8.6.0
+  freezed_annotation: ^3.1.0
+  http: ^1.2.0
+  json_annotation: ^4.11.0
+  logging: ^1.2.0
+  openci_shared: ^1.0.1
+  retry: ^3.1.2
+  sentry: ^9.22.0
+  uuid: ^4.3.3
+
+dev_dependencies:
+  build_runner: ^2.15.0
+  chopper_generator: ^8.6.2
+  freezed: ^3.2.5
+  json_serializable: ^6.13.0
+  lints: ^6.0.0
+  test: ^1.24.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,6 +89,26 @@ services:
       - tailscale
       - server
 
+  job-processor-linux:
+    build:
+      context: .
+      dockerfile: apps/openci_build_job_processor_linux/Dockerfile
+    container_name: openci-job-processor-linux
+    network_mode: "service:tailscale"
+    user: "root"
+    restart: unless-stopped
+    environment:
+      - OPENCI_SERVER_URL=http://server:8080
+      - OPENCI_RUNS_ON_PATTERN=${OPENCI_RUNS_ON_PATTERN_LINUX:?OPENCI_RUNS_ON_PATTERN_LINUX environment variable is required}
+      - INCUS_BASE_INSTANCE=${INCUS_BASE_INSTANCE:?INCUS_BASE_INSTANCE environment variable is required}
+      - INCUS_API_URL=${INCUS_API_URL:?INCUS_API_URL environment variable is required}
+      - INTERNAL_API_KEY=${INTERNAL_API_KEY:?INTERNAL_API_KEY environment variable is required}
+      - SENTRY_DSN=${SENTRY_DSN_JOB_PROCESSOR_LINUX:-}
+      - OPENCI_MAX_CONCURRENT_JOBS=${OPENCI_MAX_CONCURRENT_JOBS_LINUX:-3}
+    depends_on:
+      - tailscale
+      - server
+
   caddy:
     image: caddy:2-alpine
     container_name: openci-caddy

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,6 +7,7 @@ environment:
 workspace:
   - apps/dashboard
   - apps/openci_build_job_processor
+  - apps/openci_build_job_processor_linux
   - apps/openci_server
   - apps/openci_worker_cli
   - packages/app_minimizer_plus


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - Incusを利用してOpenCIのLinuxビルドジョブを処理するジョブプロセッサを追加しました。
  - Linux向けジョブ処理サービスをDocker Composeから起動できるようになりました。
  - サーバーURL、実行条件、Incus接続情報、同時実行数などを環境変数で設定できます。
  - 必須設定が不足している場合に、起動時に明確なエラーを表示します。
  - ジョブ処理用コンテナを軽量な構成でビルド・実行できるようにしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->