### PR TITLE
refactor: rename teamStateProvider to selectedTeamProvider and delegate team management actions to teamServiceProvider

### DIFF
--- a/apps/dashboard/lib/build_logs/build_logs_detail_page.dart
+++ b/apps/dashboard/lib/build_logs/build_logs_detail_page.dart
@@ -323,7 +323,7 @@ class BuildLogsDetailPage extends HookConsumerWidget {
             Consumer(
               builder: (context, ref, _) {
                 final aiEnabled =
-                    ref.watch(teamStateProvider).value?.aiEnabled ?? true;
+                    ref.watch(selectedTeamProvider).value?.aiEnabled ?? true;
                 if (!aiEnabled) return const SizedBox.shrink();
                 if (buildJob.status != BuildJobStatus.FAILURE ||
                     buildJob.failureSummaryStatus == null) {

--- a/apps/dashboard/lib/root/dashboard_root.dart
+++ b/apps/dashboard/lib/root/dashboard_root.dart
@@ -34,7 +34,7 @@ class DashboardRouteGateway extends ConsumerWidget {
 
         final configAsync = ref.watch(selfHostedConfigProvider);
         final selectedTeamIdAsync = ref.watch(selectedTeamIdProvider);
-        final teamAsync = ref.watch(teamStateProvider);
+        final teamAsync = ref.watch(selectedTeamProvider);
 
         return (configAsync, selectedTeamIdAsync, teamAsync).when(
           loading: () =>

--- a/apps/dashboard/lib/secret_manager/secret_manager_provider.dart
+++ b/apps/dashboard/lib/secret_manager/secret_manager_provider.dart
@@ -18,7 +18,7 @@ class SecretManager extends _$SecretManager {
   Stream<List<Secret>> build() async* {
     final serverUrl = ref.watch(openciServerUrlProvider);
 
-    final teamId = ref.watch(teamStateProvider).value?.id;
+    final teamId = ref.watch(selectedTeamProvider).value?.id;
     if (teamId == null) {
       yield const [];
       return;
@@ -74,7 +74,7 @@ class SecretManager extends _$SecretManager {
   Future<void> addSecret(String name, String value) async {
     final serverUrl = ref.read(openciServerUrlProvider);
 
-    final teamId = ref.read(teamStateProvider).value?.id;
+    final teamId = ref.read(selectedTeamProvider).value?.id;
     if (teamId == null) throw StateError('team is not loaded yet');
 
     final url = Uri.parse('$serverUrl/teams/$teamId/secrets');
@@ -128,7 +128,7 @@ class SecretManager extends _$SecretManager {
   Future<String> readSecret({required String documentId}) async {
     final serverUrl = ref.read(openciServerUrlProvider);
 
-    final teamId = ref.read(teamStateProvider).value?.id;
+    final teamId = ref.read(selectedTeamProvider).value?.id;
     if (teamId == null) throw StateError('team is not loaded yet');
 
     final url = Uri.parse('$serverUrl/teams/$teamId/secrets/$documentId');
@@ -156,7 +156,7 @@ class SecretManager extends _$SecretManager {
   Future<void> deleteSecret({required String documentId}) async {
     final serverUrl = ref.read(openciServerUrlProvider);
 
-    final teamId = ref.read(teamStateProvider).value?.id;
+    final teamId = ref.read(selectedTeamProvider).value?.id;
     if (teamId == null) throw StateError('team is not loaded yet');
 
     final url = Uri.parse('$serverUrl/teams/$teamId/secrets/$documentId');
@@ -180,7 +180,7 @@ class SecretManager extends _$SecretManager {
 
   Future<void> generateCertificateKey() async {
     final serverUrl = ref.read(openciServerUrlProvider);
-    final teamId = ref.read(teamStateProvider).value?.id;
+    final teamId = ref.read(selectedTeamProvider).value?.id;
     if (teamId == null) throw StateError('team is not loaded yet');
 
     final url = Uri.parse('$serverUrl/teams/$teamId/ios-signing/generate-key');
@@ -209,7 +209,7 @@ class SecretManager extends _$SecretManager {
     required String privateKey,
   }) async {
     final serverUrl = ref.read(openciServerUrlProvider);
-    final teamId = ref.read(teamStateProvider).value?.id;
+    final teamId = ref.read(selectedTeamProvider).value?.id;
     if (teamId == null) throw StateError('team is not loaded yet');
 
     final url = Uri.parse('$serverUrl/teams/$teamId/ios-signing/setup-asc-key');

--- a/apps/dashboard/lib/secret_manager/secret_manager_provider.g.dart
+++ b/apps/dashboard/lib/secret_manager/secret_manager_provider.g.dart
@@ -53,7 +53,7 @@ final class SecretManagerProvider
   SecretManager create() => SecretManager();
 }
 
-String _$secretManagerHash() => r'87724c4ad6f17913d332f5d196937bd97b249967';
+String _$secretManagerHash() => r'ec0faadc004900f079c8f0e4fd77df2be0a45a6b';
 
 abstract class _$SecretManager extends $StreamNotifier<List<Secret>> {
   Stream<List<Secret>> build();

--- a/apps/dashboard/lib/settings/settings_page.dart
+++ b/apps/dashboard/lib/settings/settings_page.dart
@@ -373,7 +373,7 @@ class _TeamSettingsTile extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final teamAsync = ref.watch(teamStateProvider);
+    final teamAsync = ref.watch(selectedTeamProvider);
 
     return teamAsync.when(
       data: (team) {

--- a/apps/dashboard/lib/store_release/store_release_provider.dart
+++ b/apps/dashboard/lib/store_release/store_release_provider.dart
@@ -79,8 +79,8 @@ class AscBuild {
   );
 }
 
-String _requireTeamId(dynamic ref) {
-  final teamId = ref.read(teamStateProvider).value?.id as String?;
+String _requireTeamId(Ref ref) {
+  final teamId = ref.read(selectedTeamProvider).value?.id;
   if (teamId == null) throw StateError('team is not loaded yet');
   return teamId;
 }

--- a/apps/dashboard/lib/team/create_team_bottom_sheet.dart
+++ b/apps/dashboard/lib/team/create_team_bottom_sheet.dart
@@ -90,7 +90,7 @@ class CreateTeamBottomSheet extends HookConsumerWidget {
                       isLoading.value = true;
                       try {
                         await ref
-                            .read(teamListProvider.notifier)
+                            .read(teamServiceProvider)
                             .createTeam(teamNameController.text);
                         if (!context.mounted) return;
                         context.showSnackBarMessage(teamT.createdSuccess);

--- a/apps/dashboard/lib/team/delete_team_bottom_sheet.dart
+++ b/apps/dashboard/lib/team/delete_team_bottom_sheet.dart
@@ -197,7 +197,7 @@ class DeleteTeamBottomSheet extends HookConsumerWidget {
                                   .saveSelectedTeamId(otherTeam.id);
 
                               await ref
-                                  .read(teamListProvider.notifier)
+                                  .read(teamServiceProvider)
                                   .deleteTeam(teamIdToDelete);
 
                               if (!context.mounted) return;

--- a/apps/dashboard/lib/team/edit_team_bottom_sheet.dart
+++ b/apps/dashboard/lib/team/edit_team_bottom_sheet.dart
@@ -226,13 +226,13 @@ class EditTeamBottomSheet extends HookConsumerWidget {
                             isLoading.value = true;
                             try {
                               await ref
-                                  .read(teamListProvider.notifier)
+                                  .read(teamServiceProvider)
                                   .updateTeamName(
                                     selectedTeamId.value!,
                                     teamNameController.text,
                                   );
                               await ref
-                                  .read(teamListProvider.notifier)
+                                  .read(teamServiceProvider)
                                   .updateGitHubSettings(
                                     teamId: selectedTeamId.value!,
                                     githubBaseUrl: githubBaseUrlController.text,

--- a/apps/dashboard/lib/team/invite_team_member_bottom_sheet.dart
+++ b/apps/dashboard/lib/team/invite_team_member_bottom_sheet.dart
@@ -243,7 +243,7 @@ class InviteTeamMemberBottomSheet extends HookConsumerWidget {
                         isLoading.value = true;
                         try {
                           await ref
-                              .read(teamListProvider.notifier)
+                              .read(teamServiceProvider)
                               .inviteMember(
                                 selectedTeamId.value!,
                                 emailController.text.trim(),

--- a/apps/dashboard/lib/team/switch_team_bottom_sheet.dart
+++ b/apps/dashboard/lib/team/switch_team_bottom_sheet.dart
@@ -33,7 +33,7 @@ class SwitchTeamBottomSheet extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final teamListStream = ref.watch(teamListProvider);
-    final currentTeam = ref.watch(teamStateProvider).value;
+    final currentTeam = ref.watch(selectedTeamProvider).value;
     final teamT = t.team;
     final isMembersLoading = useState(false);
     final colorScheme = Theme.of(context).colorScheme;

--- a/apps/dashboard/lib/team/team_members_bottom_sheet.dart
+++ b/apps/dashboard/lib/team/team_members_bottom_sheet.dart
@@ -38,7 +38,7 @@ class TeamMember {
 @riverpod
 Future<List<TeamMember>> teamMembers(Ref ref) async {
   ref.keepAlive();
-  final team = ref.watch(teamStateProvider).value;
+  final team = ref.watch(selectedTeamProvider).value;
   if (team == null) return [];
 
   final serverUrl = ref.watch(openciServerUrlProvider);

--- a/apps/dashboard/lib/team/team_members_bottom_sheet.g.dart
+++ b/apps/dashboard/lib/team/team_members_bottom_sheet.g.dart
@@ -46,4 +46,4 @@ final class TeamMembersProvider
   }
 }
 
-String _$teamMembersHash() => r'25ba9678d61ba8933ca4b5de88e4a68dfb10c66d';
+String _$teamMembersHash() => r'091ba220b653ff780a4965844844ab9fb7aea51f';

--- a/apps/dashboard/lib/team/team_provider.dart
+++ b/apps/dashboard/lib/team/team_provider.dart
@@ -3,7 +3,6 @@ import 'dart:convert';
 
 import 'package:dashboard/api/openci_api_client.dart';
 import 'package:dashboard/team/selected_team_provider.dart';
-import 'package:flutter/foundation.dart';
 import 'package:openci_shared/openci_shared.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -11,75 +10,42 @@ export 'package:openci_shared/openci_shared.dart' show Team;
 
 part 'team_provider.g.dart';
 
-final teamList = [
-  Team(
-    id: '1',
-    name: 'Team A',
-    members: ['1'],
-    createdAt: DateTime.now(),
-    updatedAt: DateTime.now(),
-  ),
-  Team(
-    id: '2',
-    name: 'Team B',
-    members: ['2'],
-    createdAt: DateTime.now(),
-    updatedAt: DateTime.now(),
-  ),
-];
-
 @riverpod
-class TeamState extends _$TeamState {
-  @override
-  FutureOr<Team> build() async {
-    final teamList = await ref.watch(teamListProvider.future);
-    if (teamList.isEmpty) {
-      throw StateError('No teams available');
-    }
-    final selectedTeamId = await ref.watch(selectedTeamIdProvider.future);
-    return teamList.firstWhere(
-      (team) => team.id == selectedTeamId,
-      orElse: () => teamList.first,
-    );
+Future<Team> selectedTeam(Ref ref) async {
+  final teamList = await ref.watch(teamListProvider.future);
+  if (teamList.isEmpty) {
+    throw StateError('No teams available');
   }
+  final selectedTeamId = await ref.watch(selectedTeamIdProvider.future);
+  return teamList.firstWhere(
+    (team) => team.id == selectedTeamId,
+    orElse: () => teamList.first,
+  );
 }
 
 @riverpod
-class TeamList extends _$TeamList {
-  @override
-  Stream<List<Team>> build() async* {
-    yield await fetchTeamList().timeout(
-      const Duration(seconds: 8),
-      onTimeout: () => throw TimeoutException(
-        'Timed out while loading teams from openci_server',
-      ),
+Future<List<Team>> teamList(Ref ref) async {
+  final apiService = ref.watch(openciApiServiceProvider);
+  final response = await apiService.getTeams();
+
+  if (!response.isSuccessful) {
+    throw StateError(
+      'Failed to fetch teams: ${response.statusCode} ${response.error}',
     );
-
-    yield* Stream.periodic(const Duration(seconds: 15)).asyncMap((_) async {
-      try {
-        return await fetchTeamList();
-      } catch (e) {
-        debugPrint('Failed to poll teams: $e');
-        return state.value ?? const [];
-      }
-    });
   }
 
-  Future<List<Team>> fetchTeamList() async {
-    final apiService = ref.watch(openciApiServiceProvider);
-    final response = await apiService.getTeams();
+  return response.body ?? const [];
+}
 
-    if (!response.isSuccessful) {
-      throw StateError(
-        'Failed to fetch teams: ${response.statusCode} ${response.error}',
-      );
-    }
+@riverpod
+TeamService teamService(Ref ref) => TeamService(ref);
 
-    return response.body ?? const [];
-  }
+class TeamService {
+  final Ref _ref;
+  TeamService(this._ref);
 
   Future<void> createTeam(String teamName) async {
-    final apiService = ref.read(openciApiServiceProvider);
+    final apiService = _ref.read(openciApiServiceProvider);
     final response = await apiService.createTeam({
       'name': teamName,
     });
@@ -93,12 +59,12 @@ class TeamList extends _$TeamList {
     final data = response.body ?? <String, dynamic>{};
     final teamId = data['id'] as String;
 
-    ref.invalidateSelf();
-    await ref.read(selectedTeamIdProvider.notifier).saveSelectedTeamId(teamId);
+    _ref.invalidate(teamListProvider);
+    await _ref.read(selectedTeamIdProvider.notifier).saveSelectedTeamId(teamId);
   }
 
   Future<void> updateTeamName(String teamId, String newName) async {
-    final apiService = ref.read(openciApiServiceProvider);
+    final apiService = _ref.read(openciApiServiceProvider);
     final response = await apiService.updateTeam(teamId, {
       'name': newName,
     });
@@ -109,7 +75,7 @@ class TeamList extends _$TeamList {
       );
     }
 
-    ref.invalidateSelf();
+    _ref.invalidate(teamListProvider);
   }
 
   Future<void> updateGitHubSettings({
@@ -117,7 +83,7 @@ class TeamList extends _$TeamList {
     String? githubBaseUrl,
     required List<int> installationIds,
   }) async {
-    final apiService = ref.read(openciApiServiceProvider);
+    final apiService = _ref.read(openciApiServiceProvider);
     final response = await apiService.updateTeam(teamId, {
       'githubBaseUrl': _emptyToNull(githubBaseUrl),
       'installationIds': installationIds,
@@ -129,11 +95,11 @@ class TeamList extends _$TeamList {
       );
     }
 
-    ref.invalidateSelf();
+    _ref.invalidate(teamListProvider);
   }
 
   Future<void> deleteTeam(String teamId) async {
-    final apiService = ref.read(openciApiServiceProvider);
+    final apiService = _ref.read(openciApiServiceProvider);
     final response = await apiService.deleteTeam(teamId);
 
     if (!response.isSuccessful) {
@@ -142,11 +108,11 @@ class TeamList extends _$TeamList {
       );
     }
 
-    ref.invalidateSelf();
+    _ref.invalidate(teamListProvider);
   }
 
   Future<void> inviteMember(String teamId, String email) async {
-    final apiService = ref.read(openciApiServiceProvider);
+    final apiService = _ref.read(openciApiServiceProvider);
     final response = await apiService.inviteMember(teamId, {
       'email': email,
     });

--- a/apps/dashboard/lib/team/team_provider.g.dart
+++ b/apps/dashboard/lib/team/team_provider.g.dart
@@ -9,54 +9,50 @@ part of 'team_provider.dart';
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint, type=warning
 
-@ProviderFor(TeamState)
-final teamStateProvider = TeamStateProvider._();
+@ProviderFor(selectedTeam)
+final selectedTeamProvider = SelectedTeamProvider._();
 
-final class TeamStateProvider extends $AsyncNotifierProvider<TeamState, Team> {
-  TeamStateProvider._()
+final class SelectedTeamProvider
+    extends $FunctionalProvider<AsyncValue<Team>, Team, FutureOr<Team>>
+    with $FutureModifier<Team>, $FutureProvider<Team> {
+  SelectedTeamProvider._()
     : super(
         from: null,
         argument: null,
         retry: null,
-        name: r'teamStateProvider',
+        name: r'selectedTeamProvider',
         isAutoDispose: true,
         dependencies: null,
         $allTransitiveDependencies: null,
       );
 
   @override
-  String debugGetCreateSourceHash() => _$teamStateHash();
+  String debugGetCreateSourceHash() => _$selectedTeamHash();
 
   @$internal
   @override
-  TeamState create() => TeamState();
-}
+  $FutureProviderElement<Team> $createElement($ProviderPointer pointer) =>
+      $FutureProviderElement(pointer);
 
-String _$teamStateHash() => r'5539f6264c66208af7662c236106b915cd84ecce';
-
-abstract class _$TeamState extends $AsyncNotifier<Team> {
-  FutureOr<Team> build();
-  @$mustCallSuper
   @override
-  void runBuild() {
-    final ref = this.ref as $Ref<AsyncValue<Team>, Team>;
-    final element =
-        ref.element
-            as $ClassProviderElement<
-              AnyNotifier<AsyncValue<Team>, Team>,
-              AsyncValue<Team>,
-              Object?,
-              Object?
-            >;
-    element.handleCreate(ref, build);
+  FutureOr<Team> create(Ref ref) {
+    return selectedTeam(ref);
   }
 }
 
-@ProviderFor(TeamList)
+String _$selectedTeamHash() => r'd4dac19c287248adf4836bc1ff536af33c1f5849';
+
+@ProviderFor(teamList)
 final teamListProvider = TeamListProvider._();
 
 final class TeamListProvider
-    extends $StreamNotifierProvider<TeamList, List<Team>> {
+    extends
+        $FunctionalProvider<
+          AsyncValue<List<Team>>,
+          List<Team>,
+          FutureOr<List<Team>>
+        >
+    with $FutureModifier<List<Team>>, $FutureProvider<List<Team>> {
   TeamListProvider._()
     : super(
         from: null,
@@ -73,25 +69,54 @@ final class TeamListProvider
 
   @$internal
   @override
-  TeamList create() => TeamList();
-}
+  $FutureProviderElement<List<Team>> $createElement($ProviderPointer pointer) =>
+      $FutureProviderElement(pointer);
 
-String _$teamListHash() => r'f8cd3c24137e564cd232e0d0e2009614a360422d';
-
-abstract class _$TeamList extends $StreamNotifier<List<Team>> {
-  Stream<List<Team>> build();
-  @$mustCallSuper
   @override
-  void runBuild() {
-    final ref = this.ref as $Ref<AsyncValue<List<Team>>, List<Team>>;
-    final element =
-        ref.element
-            as $ClassProviderElement<
-              AnyNotifier<AsyncValue<List<Team>>, List<Team>>,
-              AsyncValue<List<Team>>,
-              Object?,
-              Object?
-            >;
-    element.handleCreate(ref, build);
+  FutureOr<List<Team>> create(Ref ref) {
+    return teamList(ref);
   }
 }
+
+String _$teamListHash() => r'0cce5ff0dd3b0b799e2d4ad521a1b55fbd2691af';
+
+@ProviderFor(teamService)
+final teamServiceProvider = TeamServiceProvider._();
+
+final class TeamServiceProvider
+    extends $FunctionalProvider<TeamService, TeamService, TeamService>
+    with $Provider<TeamService> {
+  TeamServiceProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'teamServiceProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$teamServiceHash();
+
+  @$internal
+  @override
+  $ProviderElement<TeamService> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  TeamService create(Ref ref) {
+    return teamService(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(TeamService value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<TeamService>(value),
+    );
+  }
+}
+
+String _$teamServiceHash() => r'c7af76967284024376f59e5774e81dcb21801bf8';


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 選択中のチーム情報に基づいて、ダッシュボード各画面の表示やデータ取得が一貫するようになりました。
  * チームの作成、編集、削除、メンバー招待などの操作が安定して利用できます。
  * チーム一覧を最新の情報から取得し、チーム選択後の内容が正しく反映されます。
  * シークレット管理やストアリリース設定が、選択中のチームに対して実行されます。
  * AI Failure Summary の表示が、選択中チームのAI設定に応じて切り替わります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->